### PR TITLE
Register Jira app as DevInfo tool.

### DIFF
--- a/lib/jira/connect.js
+++ b/lib/jira/connect.js
@@ -13,7 +13,7 @@ module.exports = async (req, res) => {
       },
       vendor: {
         name: 'GitHub',
-        url: 'http://www.github.com'
+        url: 'http://github.com'
       },
       authentication: {
         type: 'jwt'
@@ -23,6 +23,22 @@ module.exports = async (req, res) => {
         'WRITE',
         'ADMIN'
       ],
-      apiVersion: 1
+      apiVersion: 1,
+      modules: {
+        jiraDevelopmentTool: {
+          application: {
+            value: 'GitHub'
+          },
+          capabilities: [
+            'commit'
+          ],
+          key: 'github-development-tool',
+          logoUrl: 'https://assets-cdn.github.com/images/modules/logos_page/GitHub-Mark.png',
+          name: {
+            value: 'GitHub'
+          },
+          url: 'https://github.com'
+        }
+      }
     })
 }


### PR DESCRIPTION
This PR adds the devInfo module to our Jira app, thereby allowing us to display the data we sync with Jira.

This will resolve the first component of Issue #6.