### PR TITLE
Add app.json with variables documented for Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,6 +25,12 @@
     "DISABLE_STATS": {
       "description": "Disable the probot stats plugin for scalability",
       "value": "true"
+    },
+    "STORAGE_SECRET": {
+      "description": "The secret used to encrypt secrets in the database"
+    },
+    "DATABASE_URL": {
+      "description": "The Postgres connection URL for the backing database"
     }
   },
   "addons": [


### PR DESCRIPTION
This adds the `app.json` file, which serves a few purposes:

1. It's needed to set up Heroku CI
2. It provides some docs for variables that are available/required.