### PR TITLE
Add env variable for differentiating instances

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ LOG_LEVEL=debug
 # The Postgres URL used to connect to the database and secret for encrypting data
 DATABASE_URL=
 STORAGE_SECRET=
+
+# Unique identifier for this instance, used in the Atlassian Connect manifest to
+# differentiate this instance from other deployments (staging, dev instances, etc).
+# INSTANCE_NAME=<you-username>

--- a/lib/jira/connect.js
+++ b/lib/jira/connect.js
@@ -1,9 +1,11 @@
+const instance = process.env.INSTANCE_NAME
+
 module.exports = async (req, res) => {
   return res.status(200)
     .json({
-      name: 'GitHub Integration',
+      name: 'GitHub' + (instance ? ` (${instance})` : ''),
       description: 'Application for integrating with GitHub',
-      key: 'com.github.integration',
+      key: 'com.github.integration' + (instance ? `.${instance}` : ''),
       baseUrl: `${req.protocol}://${req.get('host')}`,
       lifecycle: {
         installed: '/jira/events/installed',


### PR DESCRIPTION
Atlassian expects that each Add-on uses a unique key. Since we'll have multiple dev instances, staging, and production, this PR adds an `INSTANCE_NAME` variable that, if set, changes the add-on name and key.

```json
{
  "name":"GitHub (bkeepers)",
  "key":"com.github.integration.bkeepers",
```

