### PR TITLE
Require installation ids when linking GitHub + Jira.

### DIFF
--- a/db/migrations/20180706184633-update-subscriptions-column.js
+++ b/db/migrations/20180706184633-update-subscriptions-column.js
@@ -1,0 +1,36 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Subscriptions', {
+      [Sequelize.Op.or]: [
+        {
+          jiraHost: null
+        },
+        {
+          gitHubInstallationId: null
+        }
+      ]
+    })
+
+    await queryInterface.changeColumn('Subscriptions', 'gitHubInstallationId', {
+      allowNull: false,
+      type: Sequelize.INTEGER,
+    })
+
+    await queryInterface.changeColumn('Subscriptions', 'jiraHost', {
+      allowNull: false,
+      type: Sequelize.STRING
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('Subscriptions', 'gitHubInstallationId', {
+      type: Sequelize.INTEGER,
+    })
+
+    await queryInterface.changeColumn('Subscriptions', 'jiraHost', {
+      type: Sequelize.STRING
+    })
+  }
+};

--- a/lib/frontend/index.js
+++ b/lib/frontend/index.js
@@ -73,7 +73,7 @@ function getFrontendApp (appTokenGenerator) {
       'Not Found': 404
     }
 
-    return res.status(errorCodes[err.message])
+    return res.status(errorCodes[err.message] || 400)
       .render('github-error.hbs', {
         info,
         title: `${err.message} - GitHub + Jira integration`

--- a/lib/frontend/post-github-configuration.js
+++ b/lib/frontend/post-github-configuration.js
@@ -5,6 +5,13 @@ module.exports = async (req, res) => {
     return res.sendStatus(401)
   }
 
+  if (!req.body.installationId) {
+    return res.status(400)
+      .json({
+        error: 'An Installation ID must be provided to link an installation and a Jira host.'
+      })
+  }
+
   await Subscription.install({
     installationId: req.body.installationId,
     host: req.session.jiraHost


### PR DESCRIPTION
Added a database constraint and an error check for null or missing installation ids when linking a GitHub installation and a Jira host.