### PR TITLE
Fix crash when processing standard commits.

### DIFF
--- a/lib/transforms/push.js
+++ b/lib/transforms/push.js
@@ -33,7 +33,7 @@ module.exports = (payload, authorMap) => {
     .filter(commit => commit)
 
   if (commits.length === 0) {
-    return
+    return {}
   }
 
   return {

--- a/test/fixtures/push-empty.json
+++ b/test/fixtures/push-empty.json
@@ -1,0 +1,35 @@
+{
+  "event": "push",
+  "payload": {
+    "action": "created",
+    "commits": [
+      {
+        "id": "test-commit-id",
+        "hash": "test-commit-hash",
+        "author": {
+          "username": "test-commit-author-username"
+        },
+        "message": "Test commit.",
+        "added": ["test-added"],
+        "modified": ["test-modified"],
+        "removed": ["test-removal"]
+      }
+    ],
+    "repository": {
+      "id": "test-repo-id",
+      "name": "test-repo-name",
+      "full_name": "example/test-repo-name",
+      "url": "test-repo-url",
+      "owner": {
+        "login": "test-repo-owner"
+      }
+    },
+    "sender": {
+      "type": "User",
+      "login": "TestUser"
+    },
+    "installation": {
+      "id": "test-installation-id"
+    }
+  }
+}

--- a/test/fixtures/push-no-issues.json
+++ b/test/fixtures/push-no-issues.json
@@ -1,0 +1,35 @@
+{
+  "event": "push",
+  "payload": {
+    "action": "created",
+    "commits": [
+      {
+        "id": "test-commit-id",
+        "hash": "test-commit-hash",
+        "author": {
+          "username": "test-commit-author-username"
+        },
+        "message": "Example commit #comment This is a comment",
+        "added": ["test-added"],
+        "modified": ["test-modified"],
+        "removed": ["test-removal"]
+      }
+    ],
+    "repository": {
+      "id": "test-repo-id",
+      "name": "test-repo-name",
+      "full_name": "example/test-repo-name",
+      "url": "test-repo-url",
+      "owner": {
+        "login": "test-repo-owner"
+      }
+    },
+    "sender": {
+      "type": "User",
+      "login": "TestUser"
+    },
+    "installation": {
+      "id": "test-installation-id"
+    }
+  }
+}

--- a/test/safe/push.test.js
+++ b/test/safe/push.test.js
@@ -129,5 +129,23 @@ describe('GitHub Actions', () => {
         body: 'This is a comment'
       }))
     })
+
+    it('should not run a command without a Jira issue', async () => {
+      const payload = require('../fixtures/push-no-issues.json')
+
+      td.when(jiraApi.post(), { ignoreExtraArgs: true })
+        .thenThrow(new Error('Should not make any changes to Jira.'))
+
+      await app.receive(payload)
+    })
+
+    it('should support commits without smart commands', async () => {
+      const payload = require('../fixtures/push-empty.json')
+
+      td.when(jiraApi.post(), { ignoreExtraArgs: true })
+        .thenThrow(new Error('Should not make any changes to Jira.'))
+
+      await app.receive(payload)
+    })
   })
 })


### PR DESCRIPTION
This PR fixes a crash when processing standard commits without a Jira issue included in the commit message. When no commit was included, the undefined return caused a crash due to failed destructuring. This change was introduced when smart commit support was added.