### PR TITLE
Use instance name in the issuer claim

### DIFF
--- a/lib/jira/client/axios.js
+++ b/lib/jira/client/axios.js
@@ -4,6 +4,9 @@ const bformat = require('bunyan-format')
 const jwt = require('atlassian-jwt')
 const url = require('url')
 
+const instance = process.env.INSTANCE_NAME
+const iss = 'com.github.integration' + (instance ? `.${instance}` : '')
+
 const logger = bunyan.createLogger({
   name: 'jira',
   level: 'debug',
@@ -16,7 +19,7 @@ function getAuthMiddleware (secret) {
 
     const jwtToken = jwt.encode({
       ...getExpirationInSeconds(),
-      iss: 'com.github.integration',
+      iss,
       qsh: jwt.createQueryStringHash({
         method: config.method,
         originalUrl: pathname,


### PR DESCRIPTION
#30 added a variable to differentiate deployments of this integration, but it also appears to have broken authentication. This fixes the JWT authentication to use the instance name if set.