### PR TITLE
Rename deprecated `id` param to `comment_id`

### DIFF
--- a/lib/github/issue-comment.js
+++ b/lib/github/issue-comment.js
@@ -18,7 +18,7 @@ module.exports = async (context, jiraClient, util) => {
 
   const editedComment = context.issue({
     body: linkifiedBody,
-    id: comment.id
+    comment_id: comment.id
   })
 
   await context.github.issues.editComment(editedComment)

--- a/test/safe/issue-comment.test.js
+++ b/test/safe/issue-comment.test.js
@@ -1,30 +1,3 @@
-const payload = {
-  event: 'issue_comment',
-  payload: {
-    action: 'created',
-    issue: {
-      number: 'test-issue-number'
-    },
-    comment: {
-      body: 'Test example comment with linked Jira issue: [TEST-123]',
-      id: 'test-comment-id'
-    },
-    repository: {
-      name: 'test-repo-name',
-      owner: {
-        login: 'test-repo-owner'
-      }
-    },
-    sender: {
-      type: 'User',
-      login: 'TestUser'
-    },
-    installation: {
-      id: 'test-installation-id'
-    }
-  }
-}
-
 describe('GitHub Actions', () => {
   describe('issue_comment', () => {
     describe('created', () => {


### PR DESCRIPTION
Fixes this warning when the tests run:

```
    console.warn node_modules/@octokit/rest/lib/deprecate.js:10
      DEPRECATED (@octokit/rest): "id" parameter has been renamed to "comment_id"
```

And removes an unused constant in the related test.