### PR TITLE
Reuse probot's logger, silence logger in tests

### DIFF
--- a/lib/jira/client/axios.js
+++ b/lib/jira/client/axios.js
@@ -1,17 +1,10 @@
 const axios = require('axios')
-const bunyan = require('bunyan')
-const bformat = require('bunyan-format')
 const jwt = require('atlassian-jwt')
 const url = require('url')
+const { logger } = require('probot/lib/logger')
 
 const instance = process.env.INSTANCE_NAME
 const iss = 'com.github.integration' + (instance ? `.${instance}` : '')
-
-const logger = bunyan.createLogger({
-  name: 'jira',
-  level: 'debug',
-  stream: bformat({ outputMode: 'short' })
-})
 
 function getAuthMiddleware (secret) {
   return (config) => {

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -1,7 +1,7 @@
 const Sequelize = require('sequelize')
 const env = process.env.NODE_ENV || 'development'
 const config = require('../../db/config.json')[env]
-const logger = require('./logger')
+const { logger } = require('probot/lib/logger')
 
 const InstallationModel = require('./installation')
 const SubscriptionModel = require('./subscription')

--- a/lib/models/logger.js
+++ b/lib/models/logger.js
@@ -1,8 +1,0 @@
-const bunyan = require('bunyan')
-const bformat = require('bunyan-format')
-
-module.exports = bunyan.createLogger({
-  name: 'sequelize',
-  level: 'debug',
-  stream: bformat({ outputMode: 'short' })
-})

--- a/test/setup/env.js
+++ b/test/setup/env.js
@@ -6,7 +6,8 @@ const defaults = Object.assign({
   ATLASSIAN_URL: 'https://test-atlassian-instance.net',
   ATLASSIAN_SECRET: 'test-secret',
   PRIVATE_KEY_PATH: './test/setup/test-key.pem',
-  GITHUB_CLIENT_SECRET: 'test-github-secret'
+  GITHUB_CLIENT_SECRET: 'test-github-secret',
+  LOG_LEVEL: 'fatal'
 }, process.env)
 
 Object.assign(process.env, defaults)


### PR DESCRIPTION
There are 2 places in the code where a new `bunyan` instance is initialized, which leads to multiple loggers with different configurations being used (e.g. they don't respect the `LOG_LEVEL` env var).

This replaces both of them with Probot's internal logger and set's the default `LOG_LEVEL` in the tests to `fatal`.

Now the test output looks like this:

```
$ npm test

> jira@ test /Users/bkeepers/projects/jira
> jest && standard

 PASS  test/safe/pull-request.test.js
 PASS  test/safe/issue.test.js
 PASS  test/safe/issue-comment.test.js
 PASS  test/safe/push.test.js
 PASS  test/unit/frontend/github-configuration.test.js
(node:90462) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 token listeners added. Use emitter.setMaxListeners() to increase limit
 PASS  test/unit/smart-commit.test.js
 PASS  test/unit/frontend/verify-jira-middleware.test.js
 PASS  test/unit/jira/util.test.js

Test Suites: 8 passed, 8 total
Tests:       40 passed, 40 total
Snapshots:   0 total
Time:        6.845s
Ran all test suites.
```

Don't worry, `MaxListenersExceededWarning`, I'm coming back for you later!