### PR TITLE
Remove redundant configuration page and correct conditions

### DIFF
--- a/lib/jira/connect.js
+++ b/lib/jira/connect.js
@@ -61,7 +61,7 @@ module.exports = async (req, res) => {
               }
             },
             {
-              condition: 'user_is_logged_in'
+              condition: 'user_is_admin'
             }
           ]
         }


### PR DESCRIPTION
Closes #58 and #55

Looking into these two issues, we can fix them in one PR. Basically both of the errors above are because the atlassian connect manifest was in an experimental state. The `github-configuration-page` was identical to the `github-post-install-page`, except that Jira treats these slightly differently in the install flow. Removing the configuration page and adding a conditional for `user-is-admin` removes the redundant configuration page and makes the post-install page not accessible without being an admin.
