### PR TITLE
Create views for analytics

### DIFF
--- a/db/migrations/20180914203755-analytics-views.js
+++ b/db/migrations/20180914203755-analytics-views.js
@@ -1,0 +1,35 @@
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query('CREATE SCHEMA analytics;')
+
+    await queryInterface.sequelize.query(`
+      CREATE VIEW analytics.Subscriptions AS (
+        SELECT
+          id,
+          "gitHubInstallationId" AS github_installation_id,
+          "jiraHost" AS jira_host,
+          "createdAt" as created_at,
+          "updatedAt" as updated_at
+        FROM
+          "Subscriptions"
+      )
+    `)
+
+    await queryInterface.sequelize.query(`
+      CREATE VIEW analytics.Installations AS (
+        SELECT
+          id,
+          "jiraHost" AS jira_host,
+          "createdAt" as created_at,
+          "updatedAt" as updated_at,
+          enabled
+        FROM
+          "Installations"
+      )
+    `)
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query('DROP SCHEMA analytics CASCADE;')
+  }
+}

--- a/lib/jira/client/index.js
+++ b/lib/jira/client/index.js
@@ -79,8 +79,6 @@ module.exports = async (id, installationId, jiraHost) => {
       }
     },
     devinfo: {
-      completeMigration: () => instance.post('/rest/devinfo/0.10/github/migrationComplete'),
-      undoMigration: () => instance.post('/rest/devinfo/0.10/github/undoMigration'),
       updateRepository: (data) => instance.post('/rest/devinfo/0.10/bulk', {
         preventTransitions: false,
         repositories: [data]


### PR DESCRIPTION
This adds a migration to create views for an analytics table since our analytics pipeline doesn't work with CamelCase fields.

xref: https://github.com/integrations/slack/pull/267