### PR TITLE
Add admin add-on navigation item

### DIFF
--- a/lib/jira/connect.js
+++ b/lib/jira/connect.js
@@ -64,26 +64,26 @@ module.exports = async (req, res) => {
               condition: 'user_is_admin'
             }
           ]
-      },
-      webSections: [
-        {
-          key: 'github-addon-menu',
-          location: 'admin_plugins_menu',
-          name: {
-            value: 'GitHub'
+        },
+        webSections: [
+          {
+            key: 'github-addon-menu',
+            location: 'admin_plugins_menu',
+            name: {
+              value: 'GitHub'
+            }
           }
-        }
-      ],
-      webItems: [
-        {
-          key: 'GitHub-addon-link',
-          location: 'admin_plugins_menu/github-addon-menu',
-          name: {
-            value: 'Configuration'
-          },
-          url: '/jira/configuration'
-        }
-      ]
+        ],
+        webItems: [
+          {
+            key: 'GitHub-addon-link',
+            location: 'admin_plugins_menu/github-addon-menu',
+            name: {
+              value: 'Configuration'
+            },
+            url: '/jira/configuration'
+          }
+        ]
       }
     })
 }


### PR DESCRIPTION
This updates the connect descriptor to include a link to the `/jira/configuration` page from the add-on menu. This is the exact same page we send customers to in the iframe, but instead lets the customer open the configuration page in a new window/tab.

![image](https://user-images.githubusercontent.com/13207348/46373817-07ce0300-c65d-11e8-8562-1c75ba018e3c.png)
