### PR TITLE
Increase concurrency per queue

### DIFF
--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -47,7 +47,7 @@ module.exports = {
 
   start () {
     queues.pullRequests.process(10, limterPerInstallation(processPullRequests(app)))
-    queues.commits.process(10, limterPerInstallation(processCommits(app)))
+    queues.commits.process(30, limterPerInstallation(processCommits(app)))
     queues.branches.process(10, limterPerInstallation(processBranches(app)))
     queues.discovery.process(5, limterPerInstallation(discovery(app, queues)))
 


### PR DESCRIPTION
Adding concurrency to the job queues to ensure more than 1 active job at a time.