### PR TITLE
Job prioritization

### DIFF
--- a/lib/sync/discovery.js
+++ b/lib/sync/discovery.js
@@ -4,27 +4,32 @@ module.exports.discovery = (robot, queues) => {
     const repositories = await github.paginate(github.apps.getInstallationRepositories({ per_page: 100 }), res => res.data.repositories)
     robot.log(`${repositories.length} Repositories for Installation: ${job.data.installationId}`)
 
-    return repositories.forEach(async repository => {
+    return repositories.forEach(async (repository, i) => {
+      // Add jobs for each content type to their respective queue for each repository.
+      // `priority: i` lowers the priority by 1 for every repository
+      // in the installation, allowing smaller installations to complete faster
+      // and distributing jobs across the queue instead of processing every repository
+      // for a single installation sequentially
       queues.pullRequests.add(
         {
           installationId: job.data.installationId,
           jiraHost: job.data.jiraHost,
           repository
         },
-        { removeOnComplete: true, removeOnFail: true }
+        { priority: i, removeOnComplete: true, removeOnFail: true }
       )
 
       queues.commits.add({
         installationId: job.data.installationId,
         jiraHost: job.data.jiraHost,
         repository
-      }, { removeOnComplete: true, removeOnFail: true })
+      }, { priority: i, removeOnComplete: true, removeOnFail: true })
 
       queues.branches.add({
         installationId: job.data.installationId,
         jiraHost: job.data.jiraHost,
         repository
-      }, { removeOnComplete: true, removeOnFail: true })
+      }, { priority: i, removeOnComplete: true, removeOnFail: true })
     })
   }
 }


### PR DESCRIPTION
Here's a quick fix to lower the priority of jobs that are added to the queue. It sets priority to a larger number (lower priority) for each repository in an installation, ensuring that installations start getting data as quickly as possible. This isn't the ideal end state, but should mean that in general smaller installations will complete quicker than larger installations.