### PR TITLE
Use concurrent workers env var

### DIFF
--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -10,6 +10,7 @@ const app = require('./app')
 const getJiraClient = require('../jira/client')
 
 const REDIS_URL = process.env.REDIS_URL || 'redis://127.0.0.1:6379'
+const { CONCURRENT_WORKERS = 1 } = process.env
 
 // Setup queues
 const queues = {
@@ -46,12 +47,12 @@ module.exports = {
   queues,
 
   start () {
-    queues.pullRequests.process(30, limterPerInstallation(processPullRequests(app)))
-    queues.commits.process(30, limterPerInstallation(processCommits(app)))
-    queues.branches.process(30, limterPerInstallation(processBranches(app)))
+    queues.pullRequests.process(Number(CONCURRENT_WORKERS), limterPerInstallation(processPullRequests(app)))
+    queues.commits.process(Number(CONCURRENT_WORKERS), limterPerInstallation(processCommits(app)))
+    queues.branches.process(Number(CONCURRENT_WORKERS), limterPerInstallation(processBranches(app)))
     queues.discovery.process(5, limterPerInstallation(discovery(app, queues)))
 
-    app.log('Worker process started')
+    app.log(`Worker process started with ${CONCURRENT_WORKERS} CONCURRENT WORKERS`)
   },
 
   async clean () {


### PR DESCRIPTION
Right now we've got a big backlog, so using an environment variable for concurrency so we don't have to redeploy every time we need to bump the workers up or down to address it.