### PR TITLE
Add stafftools CLI

### DIFF
--- a/bin/stafftools
+++ b/bin/stafftools
@@ -37,7 +37,7 @@ class JiraStaffTools < Thor
   desc "sync <git_hub_installation_id>", "Trigger sync (defaults to 'normal')"
   option :reset, type: :boolean, desc: "Clear sync status and start from beginning ('full')"
   def sync(git_hub_installation_id)
-    sync_type = options[:reset] && "full"
+    sync_type = "full" if options[:reset]
     jira_host = get_jira_host(git_hub_installation_id)
 
     response = client.post(
@@ -69,7 +69,7 @@ class JiraStaffTools < Thor
         out, _err, _status = Open3.capture3('jq -C', stdin_data: json_string)
         puts out
       else
-        puts json_string
+        puts JSON.pretty_generate(JSON.parse(json_string))
       end
     end
   end


### PR DESCRIPTION
This makes accessing the stafftools API quick and easy.

```
$ bin/stafftools
Commands:
  stafftools help [COMMAND]                    # Describe available commands or one specific command
  stafftools info <git_hub_installation_id>    # Display summary of GitHub installation
  stafftools status <git_hub_installation_id>  # Display repo sync status
  stafftools sync <git_hub_installation_id>    # Trigger sync (defaults to 'normal')

Options:
  [--token=TOKEN]          # Personal access token (defaults to GITHUB_TOKEN)
  [--host=HOST]            # Jira integration host (useful to test against staging or development)
                           # Default: https://jira.github.com
  [--debug], [--no-debug]  # Output full request and response (hepful when an error occurs)
```

With a GitHub installation ID, found from dotcom stafftools, you can pull summary info, see sync status, and trigger a sync.

Here is how to set it up:

```bash
hub clone integrations/jira
cd jira
bin/stafftools # It may ask you to enter password to install gems
open https://github.com/settings/tokens # Create a personal access token and copy it to the clipboard
echo "GITHUB_TOKEN=$(pbpaste)" >> .bash_profile # Set GITHUB_TOKEN env var
bin/stafftools info 1234 # Test it out
```

_Note: for security reasons, this is only available to GitHub employees with the correct access._