### PR TITLE
Allow project keys to be ALPHA numerical

### DIFF
--- a/lib/jira/util/index.js
+++ b/lib/jira/util/index.js
@@ -26,7 +26,7 @@ module.exports = function (jiraClient) {
   };
 
   function addJiraIssueLinks(text, issues) {
-    const referenceRegex = /\[([A-Z]+-[0-9]+)\](?!\()/g;
+    const referenceRegex = /\[([A-Z0-9]+-[0-9]+)\](?!\()/g;
     const issueMap = issues.reduce((issueMap, issue) => ({
       ...issueMap,
       [issue.key]: issue,


### PR DESCRIPTION
# TL;DR
Project keys can be alphanumerical, and I have some that aren't being picked up due to this regex!

So lets relax the project key regex to include ALPHA numerical project keys - i.e
- FOO-123
- F12-123

![image](https://user-images.githubusercontent.com/78974409/116485508-3c6bc080-a840-11eb-93f7-60f150a9f7a6.png)
https://confluence.atlassian.com/adminjiraserver073/changing-the-project-key-format-861253229.html