### PR TITLE
Update organization permission

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,10 @@ Your new GitHub app will need the following repository permissions:
 + Metadata: Read-only
 + Pull requests: Read & write
 
+The app will also need the following organization permission:
+
++ Members: Read-only
+
 It will also need to subscribe to the following events:
 
 + Commit comment


### PR DESCRIPTION
This PR updates the organization permissions for the app mentioned in contributing guide.

To install organization accounts on Jira, the app needs Read-only permission to **Members** under **Organization permissions**. It is required to check if the user installing the app is an admin of the organization or not.

The app in marketplace already takes this permission while installation.
<img width="450" alt="Installing Jira on org account" src="https://user-images.githubusercontent.com/83457710/127351217-48b36ead-cb40-4283-b0ae-2f912568171a.png">