### PR TITLE
ARC-418 Collapse STALLED sync state into FAILED

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,6 +1,6 @@
 # Questions? Need help? You've come to the right place
 
-This file will help you troubleshoot the common issues that can occur with the GitHub for Jira integration. 
+This file will help you troubleshoot the common issues that can occur with the GitHub for Jira integration.
 
 ## Table of Contents
 
@@ -22,7 +22,7 @@ Still having trouble? Look up your problem in [Issues](https://github.com/atlass
 
 ## Sync status not reaching complete
 
-After installing the integration, your sync status should move from `PENDING` to `IN PROGRESS` to `COMPLETE`. 
+After installing the integration, your sync status should move from `PENDING` to `IN PROGRESS` to `COMPLETE`.
 
 You can check your sync status in the integration settings:
 
@@ -35,7 +35,6 @@ You can check your sync status in the integration settings:
 | PENDING  | The sync has not started.  |
 | IN PROGRESS   | The sync has started and is still in progress. No information will be displayed in Jira. |
 | COMPLETE | The sync has finished. Information will be displayed in Jira. |
-| STALLED  | The sync has not finished but has stopped being updated. Partial information may appear in Jira. |
 | FAILED   | The sync hit an error and stopped without completing. Partial information may appear in Jira. |
 
 The time it takes to complete the sync will depend on the size of your installation. Since the sync scans commits for every repository in your installation, be mindful that selecting "All Repositories" will perform a scan of every repository in your account, including forks. If you have repositories with hundreds of thousands of forks (e.g. a fork of the Linux repo), the scan might take several hours to complete.

--- a/src/config/metric-names.ts
+++ b/src/config/metric-names.ts
@@ -22,7 +22,6 @@ export const metricHttpRequest = (metricName?: string) => {
 
 export const metricSyncStatus = {
 	complete: `${server}.sync-status.complete`,
-	stalled: `${server}.sync-status.stalled`,
 	failed: `${server}.sync-status.failed`
 };
 

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -178,9 +178,9 @@ export default class Subscription extends Sequelize.Model {
 		await this.destroy();
 	}
 
-	// A stalled in progress sync is one that is ACTIVE but has not seen any updates in the last 15 minutes
+	// A IN PROGRESS sync is one that is ACTIVE but has not seen any updates in the last 15 minutes.
 	// This may happen when an error causes a sync to die without setting the status to 'FAILED'
-	isInProgressSyncStalled(): boolean {
+	hasInProgressSyncFailed(): boolean {
 		if (this.syncStatus === "ACTIVE") {
 			const fifteenMinutesAgo = new Date(Date.now() - 15 * 60 * 1000);
 

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -178,7 +178,7 @@ export default class Subscription extends Sequelize.Model {
 		await this.destroy();
 	}
 
-	// A IN PROGRESS sync is one that is ACTIVE but has not seen any updates in the last 15 minutes.
+	// An IN PROGRESS sync is one that is ACTIVE but has not seen any updates in the last 15 minutes.
 	// This may happen when an error causes a sync to die without setting the status to 'FAILED'
 	hasInProgressSyncFailed(): boolean {
 		if (this.syncStatus === "ACTIVE") {

--- a/static/css/jira-configuration.css
+++ b/static/css/jira-configuration.css
@@ -23,11 +23,6 @@
     color: #0747A6;
 }
 
-.jiraConfigurationTable__stalled {
-    background-color: #FFF0B3;
-    color: #172B4D;
-}
-
 .jiraConfigurationTable__complete {
     background-color: #E3FCEF;
     color: #006644;

--- a/test/frontend/get-jira-configuration.test.ts
+++ b/test/frontend/get-jira-configuration.test.ts
@@ -25,7 +25,7 @@ describe("Jira Configuration Suite", () => {
 				gitHubInstallationId: 15,
 				jiraHost: "https://test-host.jira.com",
 				destroy: jest.fn().mockResolvedValue(undefined),
-				isInProgressSyncStalled: jest.fn().mockResolvedValue(undefined),
+				hasInProgressSyncFailed: jest.fn().mockResolvedValue(undefined),
 				syncWarning: "some warning",
 				updatedAt: "2018-04-18T15:42:13Z",
 				repoSyncState: {

--- a/views/jira-configuration.hbs
+++ b/views/jira-configuration.hbs
@@ -43,8 +43,6 @@
                     <div class="sync-retry-modal-content">
                       <span id="status-close" class="close">&times;</span>
                       <p><strong>IN PROGRESS</strong> - The sync has started and is still in progress for this account. New data may not immediately be displayed in Jira.</p>
-                      <p><strong>STALLED</strong> - The sync has not made any progress for at least 15 minutes. If there were temporary technical issues, a normal resync will pick up from where it left off and continue with the
-                      sync.</p>
                       <p><strong>FAILED</strong> - There was a problem syncing data from your account. If there were temporary technical issues, a normal resync will pick up from where it left off and continue with the sync.
                       If it continues to return to FAILED state after re-trying, a full resync may be necessary.</p>
                       <p><strong>PENDING</strong> - The sync has been queued, but is not actively syncing data from GitHub.</p>


### PR DESCRIPTION
According to Chris from GitHub, if a STALLED sync is the result of a 'temporary technical issue' our app will try and kick the sync off again from where it got stuck. Otherwise, the user needs to resubmit the sync. It's not clear to users whether their issue is temporary or not so, to minimise confusion, we have decided to remove the STALLED state and bucket it in with the FAILED state. 

If our app does pick up a STALLED sync and is able to continue the statuses will now go FAILED > IN PROGRESS > COMPLETE. If not, it will remain in the FAILED state. Right now, a user will need to manually retry the sync but, as we gather metrics, we will work on automating this process.
