### PR TITLE
ARC-430 update new org link

### DIFF
--- a/static/css/github-configuration.css
+++ b/static/css/github-configuration.css
@@ -1,4 +1,8 @@
-
+.getConfiguration {
+  margin: auto;
+  max-width: 570px;
+  height: 100vh;
+}
 
 .getConfiguration__header {
   font-weight: 500 !important;
@@ -126,6 +130,26 @@
   border-top: 2px solid #42526e;
   height: 1.8em;
   width: 1.8em;
+}
+
+.getConfiguration__newJiraOrg__container {
+  bottom: 6em;
+  padding: 0 1em;
+  position: absolute;
+  text-align: center;
+  max-width: 570px;
+}
+
+.getConfiguration__newJiraOrg__message {
+  margin: auto auto 1em;
+}
+
+.getConfiguration__newJiraOrg__link {
+  color: #42526e;
+}
+
+.getConfiguration__newJiraOrg__link:hover {
+  text-decoration: none;
 }
 
 @keyframes spin {

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -1,3 +1,7 @@
+body {
+   overflow: hidden;
+}
+
 .headerImage {
     margin: 2em auto 1em;
     text-align: center;

--- a/views/github-configuration.hbs
+++ b/views/github-configuration.hbs
@@ -28,7 +28,7 @@
       name='clientKey'
       value='{{clientKey}}'
     />
-    <section class='mx-auto' style='max-width: 570px'>
+    <section class='getConfiguration'>
       <div class="headerImage">
         <img src='/public/assets/jira-and-github.png' alt="Jira and GitHub logos" />
       </div>
@@ -110,18 +110,15 @@
         </div>
       </div>
 
-      <p class='text-gray text-center my-4 getConfiguration__accountLink'>
-        Don't see your account?
-        <a href='{{info.html_url}}/installations/new'>Install {{info.name}}</a>
-        on your user account or an Organization you own.
-      </p>
-
-      <p class='text-gray text-left my-4 getConfiguration__disclaimer'>
-        <strong> Please note</strong>: We currently sync data from all
-        repositories you've selected in the installation's settings. If there a
-        large number of repositories in the installation, initial data sync will
-        take some time to complete.
-      </p>
+      <section class="getConfiguration__newJiraOrg__container">
+        <p class='getConfiguration__newJiraOrg__message'>
+          Don't see your GitHub account? Install Jira on your GitHub organizations
+          to connect them to your Atlassian site.
+        </p>
+        <button class="actionBtn">
+          <a class="getConfiguration__newJiraOrg__link" href='{{info.html_url}}/installations/new'>Install Jira on a new organization</a>
+        </button>
+      </section>
 
       </div>
 


### PR DESCRIPTION
Updated the connect an org page to match the new design spec. Initially, we wanted to render all orgs where the user was an admin, regardless of whether Jira was installed or not. This would have allowed us to completely remove the need to have a link to `/installations/new`. Unfortunately, as we can't access the full list of orgs with user to server tokens, we need to keep the current implementation. Tidying up the UI so it at least looks a little nicer.

<img width="695" alt="Screen Shot 2021-08-04 at 9 23 24 am" src="https://user-images.githubusercontent.com/37155488/128098946-e543426d-37ab-4a63-9a91-18c3c02e88f0.png">
