### PR TITLE
ARC-385 Maintenance mode atlassian-connect.json

### DIFF
--- a/lib/frontend/app.js
+++ b/lib/frontend/app.js
@@ -105,6 +105,9 @@ module.exports = (appTokenGenerator) => {
   // Admin API
   app.use('/api', api);
 
+  // Atlassian Marketplace Connect
+  app.get('/jira/atlassian-connect.json', getJiraConnect);
+
   // Maintenance mode view
   app.use((req, res, next) => (isMaintenanceMode() ? getMaintenance(req, res) : next()));
   app.get('/maintenance', csrfProtection, getMaintenance);
@@ -125,7 +128,6 @@ module.exports = (appTokenGenerator) => {
 
 
   // Set up event handlers
-  app.get('/jira/atlassian-connect.json', getJiraConnect);
   app.post('/jira/events/disabled', jiraAuthenticate, postJiraDisable);
   app.post('/jira/events/enabled', jiraAuthenticate, postJiraEnable);
   app.post('/jira/events/installed', postJiraInstall); // we can't authenticate since we don't have the secret

--- a/test/unit/maintenance/__snapshots__/maintenance.test.js.snap
+++ b/test/unit/maintenance/__snapshots__/maintenance.test.js.snap
@@ -1,8 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Maintenance Frontend Maintenance should return 503 for any frontend routes 1`] = `Object {}`;
-
-exports[`Maintenance Frontend Maintenance should return expected page when maintenance mode is off 1`] = `
+exports[`Maintenance Frontend Atlassian Connect should return Atlassian Connect JSON in maintenance mode 1`] = `
 Object {
   "apiMigrations": Object {
     "gdpr": false,
@@ -83,6 +81,8 @@ Object {
   },
 }
 `;
+
+exports[`Maintenance Frontend Maintenance should return 503 for any frontend routes 1`] = `Object {}`;
 
 exports[`Maintenance Frontend Maintenance should return maintenance page on "/maintenance" even if maintenance mode is off 1`] = `Object {}`;
 

--- a/test/unit/maintenance/maintenance.test.js
+++ b/test/unit/maintenance/maintenance.test.js
@@ -32,24 +32,19 @@ describe('Maintenance', () => {
         .expect(200));
   });
 
-  describe('Github', () => {
-  });
-
   describe('Frontend', () => {
-    describe('Jira', () => {
-      it('should return a non 200 status code when in maintenance mode', () =>
+    describe('Atlassian Connect', () => {
+      it('should return Atlassian Connect JSON in maintenance mode', () =>
         supertest(app.router)
           .get('/jira/atlassian-connect.json')
+          .expect(200)
           .then(response => {
-            expect(response.status).not.toBe(200);
+            // removing keys that changes for every test run
+            delete response.body.baseUrl;
+            delete response.body.name;
+            delete response.body.key;
+            expect(response.body).toMatchSnapshot();
           }));
-
-      it('should return a 200 status code when not in maintenance mode', () => {
-        delete process.env.MAINTENANCE_MODE;
-        return supertest(app.router)
-          .get('/jira/atlassian-connect.json')
-          .expect(200);
-      });
     });
 
     describe('Admin API', () => {
@@ -89,7 +84,7 @@ describe('Maintenance', () => {
 
       it('should return 503 for any frontend routes', () =>
         supertest(app.router)
-          .get('/jira/atlassian-connect.json')
+          .get('/github/setup')
           .expect(503)
           .then(response => {
             expect(response.body).toMatchSnapshot();
@@ -98,13 +93,10 @@ describe('Maintenance', () => {
       it('should return expected page when maintenance mode is off', () => {
         delete process.env.MAINTENANCE_MODE;
         return supertest(app.router)
-          .get('/jira/atlassian-connect.json')
-          .expect(200).then(response => {
-            // removing keys that changes for every test run
-            delete response.body.baseUrl;
-            delete response.body.name;
-            delete response.body.key;
-            expect(response.body).toMatchSnapshot();
+          .get('/github/setup')
+          .then(response => {
+            expect(response.status).toBeGreaterThanOrEqual(200);
+            expect(response.status).toBeLessThan(400);
           });
       });
 


### PR DESCRIPTION
Maintenance mode was obscuring the ability for people to install the app using `/jira/atlassian-connect.json`.  This has now been fixed and the tests reflected as such.