### PR TITLE
ARC-429 Change back proxy

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -260,9 +260,12 @@ environmentOverrides:
           default_vanity_dns: false
           domain:
             - github.stg.atlassian.com
+#          upstream_address:
+#            - address: github-for-jira.stg.services.atlassian.com
+#          rewrite: github-for-jira.stg.services.atlassian.com
           upstream_address:
-            - address: github-for-jira.stg.services.atlassian.com
-          rewrite: github-for-jira.stg.services.atlassian.com
+            - address: jira-integration-staging.herokuapp.com
+          rewrite: jira-integration-staging.herokuapp.com
           ip_whitelist:
             - public
 
@@ -317,6 +320,9 @@ environmentOverrides:
           default_vanity_dns: false
           domain:
             - github.atlassian.com
+#          upstream_address:
+#            - address: github-for-jira.services.atlassian.com
+#          rewrite: github-for-jira.services.atlassian.com
           upstream_address:
             - address: jira-integration-production.herokuapp.com
           rewrite: jira-integration-production.herokuapp.com

--- a/test/middleware/webhook-timeout.test.ts
+++ b/test/middleware/webhook-timeout.test.ts
@@ -4,11 +4,13 @@ import webhookTimeout from "../../src/middleware/webhook-timeout";
 describe("Webhook Timeout", () => {
 
 	it("sets timedout context with milliseconds", async () => {
+		const timeoutMs = 100;
 		const context: any = {};
-		const timeout = webhookTimeout(() => sleep(300), 100);
+		const timeout = webhookTimeout(() => sleep(300), timeoutMs);
 		await timeout(context);
-		expect(context.timedout).toBeGreaterThanOrEqual(100);
-		expect(context.timedout).toBeLessThan(300);
+		// Adding 10% failure range for setTimeout because it's not that accurate
+		expect(context.timedout).toBeGreaterThanOrEqual(timeoutMs * 0.9);
+		expect(context.timedout).toBeLessThan(300 * 1.1);
 	});
 
 	it("clears timeout if successful", async () => {


### PR DESCRIPTION
Moving proxy back to github's heroku on staging to test out migration properly.