### PR TITLE
ARC-429 Fixing connect.json to use APP_URL

### DIFF
--- a/lib/frontend/get-maintenance.js
+++ b/lib/frontend/get-maintenance.js
@@ -1,7 +1,7 @@
 module.exports = (req, res) => {
   // if getting showing page in Atlassian Marketplace, need to return 200
   // for the interceptor not to prevent the maintenance mode from showing.
-  if (req.path === '/jira/configuration' && req.req.query.xdm_e && req.query.jwt) {
+  if (req.path === '/jira/configuration' && req.query.xdm_e && req.query.jwt) {
     res.status(200);
   } else {
     // Best HTTP status code for maintenance mode: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#5xx_server_errors

--- a/lib/frontend/get-maintenance.js
+++ b/lib/frontend/get-maintenance.js
@@ -1,6 +1,12 @@
 module.exports = (req, res) => {
-  // Best HTTP status code for maintenance mode: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#5xx_server_errors
-  res.status(503);
+  // if getting showing page in Atlassian Marketplace, need to return 200
+  // for the interceptor not to prevent the maintenance mode from showing.
+  if (req.path === '/jira/configuration' && req.req.query.xdm_e && req.query.jwt) {
+    res.status(200);
+  } else {
+    // Best HTTP status code for maintenance mode: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#5xx_server_errors
+    res.status(503);
+  }
   return res.render('maintenance.hbs', {
     title: 'Github for Jira - Under Maintenance',
     APP_URL: process.env.APP_URL,

--- a/lib/jira/connect.js
+++ b/lib/jira/connect.js
@@ -14,7 +14,7 @@ module.exports = async (req, res) => {
       name: `GitHub${isProd ? '' : (instance ? (` (${instance})`) : '')}`,
       description: 'Application for integrating with GitHub',
       key: `com.github.integration${instance ? `.${instance}` : ''}`,
-      baseUrl: `${isHttps ? 'https' : 'http'}://${req.get('host')}`,
+      baseUrl: process.env.APP_URL,
       lifecycle: {
         installed: '/jira/events/installed',
         uninstalled: '/jira/events/uninstalled',


### PR DESCRIPTION
`atlassian-connect.json` needs to return the `APP_URL` for the `baseUrl` key or else it will make the marketplace app migration useless because it'll still point to the old heroku app url.

Also needed to fix maintenance mode to return a 200 status for `/jira/configure` when being called from Marketplace because it tries to intercept the status and doesn't show the page if not a 200.