### PR TITLE
ARC-436 Adding better webhook logs for maintenance mode

### DIFF
--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -46,12 +46,6 @@ const isStateChangeOrDeploymentAction = (action) => [
 
 module.exports = function middleware(callback) {
   return withSentry(async (context) => {
-    // Ignore all incoming webhooks if maintenance mode is enabled
-    if (isMaintenanceMode()) {
-      context.log('Maintenance mode ENABLED - Ignoring event');
-      return;
-    }
-
     enhanceOctokit(context.github, context.log);
 
     let webhookEvent = context.name;
@@ -74,6 +68,14 @@ module.exports = function middleware(callback) {
 
     const gitHubInstallationId = context.payload.installation.id;
     context.log = context.log.child({ gitHubInstallationId });
+
+    // Ignore all incoming webhooks if maintenance mode is enabled
+    if (isMaintenanceMode()) {
+      context.sentry.setTag('maintenanceMode', true);
+      Sentry.captureMessage('Maintenance mode ENABLED - Ignoring event');
+      context.log({ maintenanceMode: true }, 'Maintenance mode ENABLED - Ignoring event');
+      return;
+    }
 
     // Edit actions are not allowed because they trigger this Jira integration to write data in GitHub and can trigger events, causing an infinite loop.
     // State change actions are allowed because they're one-time actions, therefore they won’t cause a loop.


### PR DESCRIPTION
We need to do this to be able to get `installationId` for any webhooks that got triggered while we're doing the migration.  Afterwards, we can start a resync for those installations so no data is lost in the process.