### PR TITLE
Map PR status with `merged_at` instead of `merged`

### DIFF
--- a/lib/transforms/pull-request.js
+++ b/lib/transforms/pull-request.js
@@ -2,14 +2,15 @@ const parseSmartCommit = require('./smart-commit');
 const { getJiraId } = require('../jira/util/id');
 const _ = require('lodash');
 
-function mapStatus({ state, merged }) {
+// Use `merged_at` since `merged` may not be present on review comments
+function mapStatus({ state, merged_at }) {
   if (state === 'merged') {
     return 'MERGED';
   } else if (state === 'open') {
     return 'OPEN';
-  } else if (state === 'closed' && merged) {
+  } else if (state === 'closed' && merged_at) {
     return 'MERGED';
-  } else if (state === 'closed' && !merged) {
+  } else if (state === 'closed' && !merged_at) {
     return 'DECLINED';
   } else {
     return 'UNKNOWN';


### PR DESCRIPTION
Effectively works around the surprising fact that webhook payloads
generated by PR review comments [omit a `merged` entry](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-example-34) on the included
`pull_request` object.

Closes atlassian/github-for-jira#372.