### PR TITLE
ARC-220 pull request merge status fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ WEBHOOK_SECRET=development
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 ATLASSIAN_SECRET=development-secret
+# Optional but needed for feature flags
+LAUNCHDARKLY_KEY=
 
 # Unique name for the jira app, used in the Atlassian Connect manifest to
 # differentiate this instance from other deployments (staging, dev instances, etc).

--- a/src/transforms/pull-request.ts
+++ b/src/transforms/pull-request.ts
@@ -3,11 +3,11 @@ import { isEmpty } from "../jira/util/isEmpty";
 import { getJiraId } from "../jira/util/id";
 import _ from "lodash";
 
-function mapStatus(status: string, merged: boolean) {
+function mapStatus(status: string, merged_at?: string) {
 	if (status === "merged") return "MERGED";
 	if (status === "open") return "OPEN";
-	if (status === "closed" && merged) return "MERGED";
-	if (status === "closed" && !merged) return "DECLINED";
+	if (status === "closed" && merged_at) return "MERGED";
+	if (status === "closed" && !merged_at) return "DECLINED";
 	return "UNKNOWN";
 }
 
@@ -52,7 +52,7 @@ export default (payload, author, reviews?: unknown[]) => {
 		return undefined;
 	}
 
-	const pullRequestStatus = mapStatus(pull_request.state, pull_request.merged);
+	const pullRequestStatus = mapStatus(pull_request.state, pull_request.merged_at);
 
 	return {
 		id: repository.id,


### PR DESCRIPTION
We were using the `merged` property of the pull_request payload, which is [apparently based on the data given by the REST API](https://docs.github.com/en/rest/reference/pulls) which shows that the `merged` property is _always_ sent.  However, for the `pull_request_review` payload, it's missing causing issues in the PR status.  @atrigueiro and I confirmed that the `merged_at` property is available on all pull request payloads and are using that instead; it's a ISO8601 string that we can easily use as a truthy conditional replacement for `merged`.

This should fix https://github.com/atlassian/github-for-jira/issues/372