### PR TITLE
ARC-385 Maintenance status fix

### DIFF
--- a/src/frontend/get-maintenance.ts
+++ b/src/frontend/get-maintenance.ts
@@ -1,13 +1,8 @@
 import { Request, Response } from "express";
 
-export default (req: Request, res: Response) => {
-	// if showing page in Atlassian Marketplace, need to return 200 (default)
-	// for the interceptor not to prevent the maintenance mode from showing.
-	if (req.path !== "/jira/configuration" || !req.query.xdm_e || !req.query.jwt) {
-		// Best HTTP status code for maintenance mode: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#5xx_server_errors
-		res.status(503);
-	}
-	return res.render("maintenance.hbs", {
+export default (_: Request, res: Response) => {
+	// Best HTTP status code for maintenance mode: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#5xx_server_errors
+	return res.status(503).render("maintenance.hbs", {
 		title: "Github for Jira - Under Maintenance",
 		APP_URL: process.env.APP_URL,
 		nonce: res.locals.nonce

--- a/views/jira-configuration.hbs
+++ b/views/jira-configuration.hbs
@@ -166,7 +166,9 @@
       </div>
       <script src="/public/js/jira-configuration.js" nonce="{{nonce}}"></script>
     </div>
+
     <!-- Per https://blog.developer.atlassian.com/announcement-reminder-about-deprecation-of-xdm_e-usage-and-needing-to-load-all-js-from-the-cdn/ we are required to load this from this specific CDN -->
+    <!-- DO NOT TOUCH!!! THIS IS NEEDED FOR CONNECT OR ELSE IT WILL CAUSE AN ERROR -->
     <script src="https://connect-cdn.atl-paas.net/all.js" nonce="{{nonce}}"></script>
   </body>
 </html>

--- a/views/maintenance.hbs
+++ b/views/maintenance.hbs
@@ -43,6 +43,7 @@
 </div>
 
 <!-- Per https://blog.developer.atlassian.com/announcement-reminder-about-deprecation-of-xdm_e-usage-and-needing-to-load-all-js-from-the-cdn/ we are required to load this from this specific CDN -->
+<!-- DO NOT TOUCH!!! THIS IS NEEDED FOR CONNECT OR ELSE IT WILL CAUSE AN ERROR -->
 <script src="https://connect-cdn.atl-paas.net/all.js" nonce="{{nonce}}"></script>
 </body>
 </html>


### PR DESCRIPTION
Apparently, we don't need to send a 200 http status for it to work in connect, it just needs the connect SDK to be included in the HTML.