### PR TITLE
ARC-448 log webhook maintenance installation ID

### DIFF
--- a/src/github/middleware.ts
+++ b/src/github/middleware.ts
@@ -109,11 +109,6 @@ export default (
 		for (const subscription of subscriptions) {
 			const { jiraHost } = subscription;
 
-			if (await booleanFlag(BooleanFlags.MAINTENANCE_MODE, false, jiraHost)) {
-				context.log(`Maintenance mode ENABLED for jira host ${jiraHost} - Ignoring event of type ${webhookEvent}`);
-				continue;
-			}
-
 			context.sentry.setTag("jiraHost", jiraHost);
 			context.sentry.setTag(
 				"gitHubInstallationId",
@@ -121,6 +116,12 @@ export default (
 			);
 			context.sentry.setUser({ jiraHost, gitHubInstallationId });
 			context.log = context.log.child({ jiraHost });
+
+			if (await booleanFlag(BooleanFlags.MAINTENANCE_MODE, false, jiraHost)) {
+				context.log(`Maintenance mode ENABLED for jira host ${jiraHost} - Ignoring event of type ${webhookEvent}`);
+				continue;
+			}
+
 			if (context.timedout) {
 				Sentry.captureMessage(
 					"Timed out jira middleware iterating subscriptions"

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -92,7 +92,7 @@ export default class Subscription extends Sequelize.Model {
 		if (installationIds?.length > 0) {
 			andFilter.push({
 				gitHubInstallationId: {
-					[Op.in]: installationIds
+					[Op.in]: _.uniq(installationIds)
 				}
 			});
 		}


### PR DESCRIPTION
While maintenance mode is one during the transition, we want to log installationIds from our end so we can resync them.