### PR TITLE
ARC-448 webhook logs prod

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -157,7 +157,7 @@ environmentOverrides:
     config:
       environmentVariables:
         APP_URL: https://github-for-jira.dev.services.atlassian.com
-        WEBHOOK_PROXY_URL: https://github-for-jira.dev.services.atlassian.com/github/events
+        WEBHOOK_PROXY_URL: https://github-for-jira.dev.services.atlassian.com
         INSTANCE_NAME: development
         NODE_OPTIONS: "--no-deprecation"
         LOG_LEVEL: debug
@@ -181,7 +181,7 @@ environmentOverrides:
     config:
       environmentVariables:
         APP_URL: https://github.stg.atlassian.com
-        WEBHOOK_PROXY_URL: https://github.stg.atlassian.com/github/events
+        WEBHOOK_PROXY_URL: https://github.stg.atlassian.com
         INSTANCE_NAME: staging
         SENTRY_ENVIRONMENT: stg-west
         APP_ID: '12645'
@@ -272,8 +272,10 @@ environmentOverrides:
   prod:
     config:
       environmentVariables:
-        APP_URL:  https://github.atlassian.com
-        WEBHOOK_PROXY_URL:  https://github.atlassian.com/github/events
+#        APP_URL:  https://github.atlassian.com
+        APP_URL:  https://github-for-jira.services.atlassian.com
+        WEBHOOK_PROXY_URL:  https://github-for-jira.services.atlassian.com
+#        WEBHOOK_PROXY_URL:  https://github.atlassian.com
         INSTANCE_NAME: production
         SENTRY_ENVIRONMENT: production
         APP_ID: '14320'


### PR DESCRIPTION
Changing APP_URL to point to services domain to test out maintenance mode webhook logs to confirm it's logging installation id.