### PR TITLE
ARC-460 Lower 5xx alarm priority

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -307,8 +307,8 @@ environmentOverrides:
         HighSeverityAlarmWhenTooManyBackend5xxErrors:
           MetricName: HTTPCode_Target_5XX_Count
           Namespace: AWS/ApplicationELB
-          Priority: High
-          Threshold: 200
+          Priority: Low
+          Threshold: 500
           EvaluationPeriods: 1
           Period: 300
           ComparisonOperator: GreaterThanOrEqualToThreshold

--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -245,7 +245,7 @@ environmentOverrides:
           EvaluationPeriods: 3
           Period: 60
           ComparisonOperator: GreaterThanThreshold
-          Statistic: Maximum
+          Statistic: Average
     workers:
       - name: Worker
         scaling:


### PR DESCRIPTION
There is no threshold for this alarm which will be high enough to not make it noisy. 

Until we replace this alert with error budget detector we need to lower the priority.