### PR TITLE
ARC-472 updating alpine to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17-alpine as build
+FROM node:14.17-alpine3.14 as build
 
 # adding python for node-gyp
 RUN apk add g++ make python

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:14.17-alpine as build
+FROM node:14.17-alpine3.14 as build
 
 # adding python for node-gyp
 RUN apk add g++ make python
@@ -12,7 +12,7 @@ RUN npm ci
 # Building TypeScript files
 RUN npm run build:release
 
-FROM node:14.17-alpine
+FROM node:14.17-alpine3.14
 USER node
 COPY --chown=node:node --from=build /app /app
 WORKDIR /app

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,4 +1,4 @@
-FROM node:14.17-alpine as build
+FROM node:14.17-alpine3.14 as build
 
 # adding python for node-gyp
 RUN apk add g++ make python
@@ -12,7 +12,7 @@ RUN npm ci --only=production
 # Building TypeScript files
 RUN npm run build:release
 
-FROM node:14.17-alpine
+FROM node:14.17-alpine3.14
 USER node
 COPY --chown=node:node --from=build /app /app
 WORKDIR /app

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM node:14.17-alpine as build
+FROM node:14.17-alpine3.14 as build
 
 # adding python for node-gyp
 RUN apk add g++ make python
@@ -12,7 +12,7 @@ RUN npm ci --only=production
 # Building TypeScript files
 RUN npm run build:release
 
-FROM node:14.17-alpine
+FROM node:14.17-alpine3.14
 USER node
 COPY --chown=node:node --from=build /app /app
 WORKDIR /app


### PR DESCRIPTION
Alpine has a security issue, so we're forcefully updating it to Alpine 3.14.  For some reason, `node:4.17-alpine` is still pointing to Alpine 3.11.