### PR TITLE
ARC-608 add log to check for user permission level

### DIFF
--- a/src/frontend/github-client-middleware.ts
+++ b/src/frontend/github-client-middleware.ts
@@ -37,6 +37,9 @@ export const isAdmin = (githubClient: GitHubAPI, logger: Logger) =>
 			const {
 				data: { role }
 			} = await githubClient.orgs.getMembership({ org, username });
+
+			logger.info(`isAdmin: User ${username} has ${role} role`);
+
 			return role === "admin";
 		} catch (err) {
 			logger.warn(err, `${org} has not accepted new permission for getOrgMembership`);


### PR DESCRIPTION
Added a log to make it easier for us to check user permissions and identify cause of 'issues' on the connect an org page.