### PR TITLE
ARC-477 add more logs to diagnose jira 400 failures and fix it

### DIFF
--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -8,20 +8,16 @@ import push from "./push";
 import { createBranch, deleteBranch } from "./branch";
 import webhookTimeout from "../middleware/webhook-timeout";
 import statsd from "../config/statsd";
-import { getLogger } from "../config/logger";
 import { metricWebhooks } from "../config/metric-names";
 import { Application } from "probot";
 
 export default (robot: Application) => {
-	const logger = getLogger("github.webhooks");
 
 	// TODO: Need ability to remove these listeners, especially for testing...
 	robot.on("*", async (context) => {
 		const { name, payload } = context;
 
-		context.log = logger.child({ id: context.id });
-
-		context.log.info({ event: name, action: payload.action }, "Event received");
+		context.log.info({ event: name, action: payload.action, webhookId: context.id }, "Event received");
 
 		const tags = [
 			"name: webhooks",

--- a/src/github/middleware.ts
+++ b/src/github/middleware.ts
@@ -82,8 +82,9 @@ export default (
 		const gitHubInstallationId = Number(context.payload?.installation?.id);
 
 		//TODO Remove this line and uncomment the next one to get rid of payloads in logs
-		context.log = logger.child({ webhookId: context.id, repoName, orgName, gitHubInstallationId, event: webhookEvent, payload: context.payload });
-		//context.log = logger.child({ webhookId: context.id, repoName, orgName, gitHubInstallationId });
+		const loggerWithWebhookParams = logger.child({ webhookId: context.id, repoName, orgName, gitHubInstallationId, event: webhookEvent, payload: context.payload });
+		//const loggerWithWebhookParams = logger.child({ webhookId: context.id, repoName, orgName, gitHubInstallationId });
+		context.log = loggerWithWebhookParams;
 
 		// Edit actions are not allowed because they trigger this Jira integration to write data in GitHub and can trigger events, causing an infinite loop.
 		// State change actions are allowed because they're one-time actions, therefore they won’t cause a loop.
@@ -133,7 +134,7 @@ export default (
 				gitHubInstallationId.toString()
 			);
 			context.sentry.setUser({ jiraHost, gitHubInstallationId });
-			context.log = context.log.child({ jiraHost });
+			context.log = loggerWithWebhookParams.child({ jiraHost });
 			context.log("Processing event for Jira Host");
 
 			if (await booleanFlag(BooleanFlags.MAINTENANCE_MODE, false, jiraHost)) {

--- a/src/github/push.ts
+++ b/src/github/push.ts
@@ -8,6 +8,7 @@ export default async (context: Context, jiraClient): Promise<void> => {
 	// but filter out any commits that don't have issue keys
 	// so we don't have to process them.
 	const payload = {
+		webhookId: context.id,
 		repository: context.payload?.repository,
 		commits: context.payload?.commits?.map((commit) => {
 			const issueKeys = issueKeyParser().parse(commit.message);

--- a/src/transforms/push.ts
+++ b/src/transforms/push.ts
@@ -12,7 +12,7 @@ import { JobOptions } from "bull";
 
 const logger = getLogger("transforms.push");
 
-const mapFile = (repoName: string, repoOwner: string, commitHash: string) => (githubFile) => {
+const mapFile = (githubFile:any, repoName: string, repoOwner: string, commitHash: string) => {
 	// changeType enum: [ "ADDED", "COPIED", "DELETED", "MODIFIED", "MOVED", "UNKNOWN" ]
 	// on github when a file is renamed we get two "files": one added, one removed
 	const mapStatus = {
@@ -149,7 +149,7 @@ export function processPush(app: Application) {
 						authorTimestamp: githubCommitAuthor.date,
 						displayId: commitSha.substring(0, 6),
 						fileCount: files.length, // Send the total count for all files
-						files: filesToSend.map(mapFile(repo, owner.name, sha.id)),
+						files: filesToSend.map(file => mapFile(file, repo, owner.name, sha.id)),
 						id: commitSha,
 						issueKeys: sha.issueKeys,
 						url: html_url,

--- a/test/safe/push.test.ts
+++ b/test/safe/push.test.ts
@@ -3,11 +3,11 @@ import nock from "nock";
 import { createJobData, processPush } from "../../src/transforms/push";
 import { createWebhookApp } from "../utils/probot";
 
-describe.skip("GitHub Actions", () => {
+describe("GitHub Actions", () => {
 	let app;
 	beforeEach(async () => app = await createWebhookApp());
 
-	describe("add to push queue", () => {
+	describe.skip("add to push queue", () => {
 		beforeEach(() => {
 			process.env.REDIS_URL = "redis://test";
 		});
@@ -66,11 +66,11 @@ describe.skip("GitHub Actions", () => {
 
 			githubNock
 				.get("/repos/test-repo-owner/test-repo-name/commits/commit-no-username")
-				.replyWithFile(200, "../fixtures/api/commit-no-username.json");
+				.reply(200, require("../fixtures/api/commit-no-username.json"));
 
 			githubNock
 				.get("/repos/test-repo-owner/test-repo-name/commits/commit-no-username")
-				.replyWithFile(200, "../fixtures/api/commit-no-username.json");
+				.reply(200, require("../fixtures/api/commit-no-username.json"));
 
 			await expect(processPush(app)(job)).toResolve();
 
@@ -138,7 +138,7 @@ describe.skip("GitHub Actions", () => {
 
 			githubNock
 				.get("/repos/test-repo-owner/test-repo-name/commits/test-commit-id")
-				.replyWithFile(200, "../fixtures/more-than-10-files.json");
+				.reply(200, require("../fixtures/more-than-10-files.json"));
 
 			jiraNock.post("/rest/devinfo/0.10/bulk", {
 				preventTransitions: false,
@@ -245,92 +245,6 @@ describe.skip("GitHub Actions", () => {
 			await expect(processPush(app)(job)).toResolve();
 		});
 
-		// Commenting these out for the moment. DevInfo API runs these
-		// transitions automatially based on the commit message, but we may
-		// use them elsewhere for manual transitions
-		// it('should run a #comment command in the commit message', async () => {
-		//   const fixture = require('../fixtures/push-comment.json')
-
-		//   await expect(app.receive(fixture)).toResolve()
-
-		//   jiraNock.post('/rest/api/latest/issue/TEST-123/comment', {
-		//     body: 'This is a comment'
-		//   }))
-		// })
-
-		// it('should run a #time command in the commit message', async () => {
-		//   const fixture = require('../fixtures/push-worklog.json')
-
-		//   await expect(app.receive(fixture)).toResolve()
-
-		//   jiraNock.post('/rest/api/latest/issue/TEST-123/worklog', {
-		//     timeSpentSeconds: td.matchers.isA(Number),
-		//     comment: 'This is a worklog'
-		//   }))
-		// })
-
-		// it('should run a transition command in the commit message', async () => {
-		//   const fixture = require('../fixtures/push-transition.json')
-
-		//   td.when(jiraApi.get(`/rest/api/latest/issue/TEST-123/transitions`))
-		//     .thenReturn({
-		//       transitions: [
-		//         {
-		//           id: 'test-transition-id',
-		//           name: 'Resolve'
-		//         }
-		//       ]
-		//     })
-
-		//   await expect(app.receive(fixture)).toResolve()
-
-		//   jiraNock.post('/rest/api/latest/issue/TEST-123/transitions', {
-		//     transition: {
-		//       id: 'test-transition-id'
-		//     }
-		//   }))
-		// })
-
-		// it('should run a transition command in the commit message', async () => {
-		//   const fixture = require('../fixtures/push-transition-comment.json')
-
-		//   td.when(jiraApi.get(`/rest/api/latest/issue/TEST-123/transitions`))
-		//     .thenReturn({
-		//       transitions: [
-		//         {
-		//           id: 'test-transition-id',
-		//           name: 'Resolve'
-		//         }
-		//       ]
-		//     })
-
-		//   await expect(app.receive(fixture)).toResolve()
-
-		//   jiraNock.post('/rest/api/latest/issue/TEST-123/transitions', {
-		//     transition: {
-		//       id: 'test-transition-id'
-		//     }
-		//   }))
-
-		//   jiraNock.post('/rest/api/latest/issue/TEST-123/comment', {
-		//     body: 'This is a transition'
-		//   }))
-		// })
-
-		// it('should run commands on all issues in the commit message', async () => {
-		//   const fixture = require('../fixtures/push-multiple.json')
-
-		//   await expect(app.receive(fixture)).toResolve()
-
-		//   jiraNock.post('/rest/api/latest/issue/TEST-123/comment', {
-		//     body: 'This is a comment'
-		//   }))
-
-		//   jiraNock.post('/rest/api/latest/issue/TEST-246/comment', {
-		//     body: 'This is a comment'
-		//   }))
-		// })
-
 		it("should not run a command without a Jira issue", async () => {
 			const fixture = require("../fixtures/push-no-issues.json");
 			const interceptor = jiraNock.post(/.*/);
@@ -362,7 +276,7 @@ describe.skip("GitHub Actions", () => {
 			};
 
 			githubNock.get("/repos/test-repo-owner/test-repo-name/commits/commit-no-username")
-				.replyWithFile(200, "../fixtures/push-merge-commit.json");
+				.reply(200, require("../fixtures/push-merge-commit.json"));
 
 			jiraNock.post("/rest/devinfo/0.10/bulk", {
 				preventTransitions: false,
@@ -425,7 +339,7 @@ describe.skip("GitHub Actions", () => {
 			};
 
 			githubNock.get("/repos/test-repo-owner/test-repo-name/commits/commit-no-username")
-				.replyWithFile(200, "../fixtures/push-non-merge-commit");
+				.reply(200, require("../fixtures/push-non-merge-commit"));
 
 			// flag property should not be present
 			jiraNock.post("/rest/devinfo/0.10/bulk", {


### PR DESCRIPTION
A few changes here:

* Fixed request failing with 400 when trying to push commits to Jira
* For push webhook path,  carrying webhookId through the queue and adding to logs as a parameter
* Renamed id to webhookId in logs, where we use webhook id to reduce confusion


