### PR TITLE
ARC-608 adding more logs to solve customer issue where admin/owner cannot connect an org

### DIFF
--- a/src/frontend/github-oauth.ts
+++ b/src/frontend/github-oauth.ts
@@ -8,6 +8,7 @@ import crypto from "crypto";
 import url from "url";
 import express, { NextFunction, Request, RequestHandler, Response, Router } from "express";
 import axios from "axios";
+import { getJiraHostFromRedirectUrl } from "../util/getUrl";
 
 const host = process.env.GHE_HOST || "github.com";
 
@@ -74,6 +75,8 @@ export default (opts: OAuthOptions): GithubOAuth => {
 		// Check if state is available and matches a previous request
 		if (!state || !redirectUrl) return next("Missing matching Auth state parameter");
 		if (!code) return next("Missing OAuth Code");
+
+		req.log.info(`Jira Host attempting to auth with GitHub: ${getJiraHostFromRedirectUrl(redirectUrl)}`);
 
 		try {
 			const response = await axios.get(

--- a/src/frontend/github-oauth.ts
+++ b/src/frontend/github-oauth.ts
@@ -76,7 +76,7 @@ export default (opts: OAuthOptions): GithubOAuth => {
 		if (!state || !redirectUrl) return next("Missing matching Auth state parameter");
 		if (!code) return next("Missing OAuth Code");
 
-		req.log.info(`Jira Host attempting to auth with GitHub: ${getJiraHostFromRedirectUrl(redirectUrl)}`);
+		req.log.info({jiraHost: getJiraHostFromRedirectUrl(redirectUrl)}, "Jira Host attempting to auth with GitHub");
 
 		try {
 			const response = await axios.get(

--- a/src/github/middleware.ts
+++ b/src/github/middleware.ts
@@ -113,8 +113,8 @@ export default (
 		const jiraSubscriptionsCount = subscriptions.length;
 		if (!jiraSubscriptionsCount) {
 			context.log(
-				{ noop: "no_subscriptions" },
-				`Halting further execution since no subscriptions were found. \n orgName: ${orgName}`
+				{ noop: "no_subscriptions", orgName: orgName },
+				"Halting further execution since no subscriptions were found."
 			);
 			return;
 		}

--- a/src/github/middleware.ts
+++ b/src/github/middleware.ts
@@ -114,7 +114,7 @@ export default (
 		if (!jiraSubscriptionsCount) {
 			context.log(
 				{ noop: "no_subscriptions" },
-				"Halting further execution since no subscriptions were found"
+				`Halting further execution since no subscriptions were found. \n orgName: ${orgName}`
 			);
 			return;
 		}

--- a/src/util/getUrl.ts
+++ b/src/util/getUrl.ts
@@ -14,8 +14,9 @@ export const getJiraMarketplaceUrl = (jiraHost: string): string =>
 	`https://${jiraHost}/plugins/servlet/upm/marketplace/plugins/com.github.integration.production`;
 
 export const getJiraHostFromRedirectUrl = (url: string): string => {
-	const urlIndex = url.indexOf("https%");
-	return urlIndex
-		? url.substring(urlIndex, url.length)
-		: "unknown Jira instance";
+	try {
+		return new URL(url).host;
+	} catch (err) {
+		return "unknown";
+	}
 };

--- a/src/util/getUrl.ts
+++ b/src/util/getUrl.ts
@@ -12,3 +12,10 @@ export const getGitHubConfigurationUrl = (urlParams: IUrlParams): string => {
 
 export const getJiraMarketplaceUrl = (jiraHost: string): string =>
 	`https://${jiraHost}/plugins/servlet/upm/marketplace/plugins/com.github.integration.production`;
+
+export const getJiraHostFromRedirectUrl = (url: string): string => {
+	const urlIndex = url.indexOf("https%");
+	return urlIndex
+		? url.substring(urlIndex, url.length)
+		: "unknown Jira instance";
+};


### PR DESCRIPTION
Customer still can't see the connect button. They are:
- logged into the correct GH account
- are an admin on the org
- are an owner

Trying to add more logs to try and solve why:

- the 2 orgs connected that render to the GH config page don't show up on the connect an org pg
- why they can't see the connect button when they appear to have all the correct permissions (usually only hidden if the user is not an admin)

The only thing I can currently find in the logs for the org they are trying to connect (equinix-enps) is `Halting further execution since no subscriptions were found` which comes from github/middleware.