### PR TITLE
ARC-468: Use ref instead of sha for getCommit

### DIFF
--- a/src/transforms/branch.ts
+++ b/src/transforms/branch.ts
@@ -4,19 +4,14 @@ import issueKeyParser from "jira-issue-key-parser";
 import { isEmpty } from "../jira/util/isEmpty";
 
 async function getLastCommit(context: Context, issueKeys: string[]) {
-	const {
-		github,
-		payload: { ref }
-	} = context;
+	const { github, payload: { ref } } = context;
 
 	const {
-		data: {
-			object: { sha }
-		}
+		data: { object: { sha } }
 	} = await github.git.getRef(context.repo({ ref: `heads/${ref}` }));
 	const {
 		data: { commit, html_url: url }
-	} = await github.repos.getCommit(context.repo({ sha }));
+	} = await github.repos.getCommit(context.repo({ ref: sha }));
 
 	return {
 		author: {


### PR DESCRIPTION
We're seeing a bunch of `Deprecation: [@octokit/rest] "sha" parameter is deprecated for ".repos.getCommit()". Use "ref" instead` warning on our logs. 

`getCommit` now expects a parameter called `ref`.

![Screen Shot 2021-09-13 at 3 12 35 pm](https://user-images.githubusercontent.com/58801956/133027634-c5610191-fc1e-46f0-8864-43f26d9d6bb0.png)

All other places we're calling `getCommit` are already using `ref`.