### PR TITLE
ARC-651 Increasing long query timeout to 5 seconds

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -52,6 +52,8 @@ resources:
         - PII/IndirectConfidential # name of GitHub org
       parameters:
         DBType: postgres125
+        CustomParameters:
+          log_min_duration_statement: 5000
 
   - name: database
     type: postgres-db
@@ -138,7 +140,7 @@ workers:
 
 environmentOverrides:
 #  Uncomment lines 140-149 if you want remote debugging in ddev
-#  ddev:
+  ddev:
 #    loadBalancer:
 #      type: ELB # needed for remote debugging, default is "ALB"
 #    compose:


### PR DESCRIPTION
To prevent logging large JSON blobs in the logs, taking over DB storage.