### PR TITLE
ARC-278 Add SQS for the push queue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,7 @@ The first time you run the app, simply run:
 npm install # installs node modules
 docker-compose up # Spin up docker containers
 npm run db # Creates DBs and initializes tables
+npm run sqs:init #initialises localstack sqs queues
 ```
 
 That's it.  Everything is ran in docker-compose, including redis, postgres, ngrok and the app (main and worker thread).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,19 @@ services:
     ports: [ "4040:4040" ]
     command: ngrok http app:8080
 
+  localstack:
+    container_name: localstack
+    image: localstack/localstack:0.8.7
+    environment:
+      - SERVICES=sqs:9602
+    ports:
+      - 9602:9602
+
   app:
     depends_on:
       - redis
       - postgres
+      - localstack
     volumes:
       - .:/app
     build:

--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -44,6 +44,16 @@ resources:
         - PII/IndirectConfidential # name of GitHub org
         - UGC/PrimaryIdentifier    # references to GitHub entities (commits, pull requests, etc.) and Jira issues
 
+  - type: sqs
+    name: webhooksqs
+    attributes:
+      MaxReceiveCount: 3 # If changing this attribute value, then also change the constant value in MessageRouter
+      MessageRetentionPeriod: 1209600
+      dataType:
+        - UGC/Label                # name of GitHub org / Jira site
+        - PII/IndirectConfidential # name of GitHub org
+        - UGC/PrimaryIdentifier    # references to GitHub entities (commits, pull requests, etc.) and Jira issues
+
   - name: rds
     type: dedicated-rds
     attributes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2130,6 +2130,29 @@
       "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
       "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
     },
+    "aws-sdk": {
+      "version": "2.989.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/aws-sdk/-/aws-sdk-2.989.0.tgz",
+      "integrity": "sha1-7TzOa5SFa0aXhLwzEqC2RDi5/mc=",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://packages.atlassian.com/api/npm/npm-remote/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
+        }
+      }
+    },
     "axios": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
@@ -2289,6 +2312,11 @@
           }
         }
       }
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo="
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -2460,6 +2488,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -4357,6 +4395,11 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
     "eventsource": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
@@ -5338,6 +5381,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q="
     },
     "ignore": {
       "version": "5.1.8",
@@ -7261,6 +7309,11 @@
       "requires": {
         "winston": "^3.3.3"
       }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-beautify": {
       "version": "1.13.13",
@@ -9591,6 +9644,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -10223,6 +10281,11 @@
           }
         }
       }
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "saxes": {
       "version": "5.0.1",
@@ -11772,6 +11835,22 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://packages.atlassian.com/api/npm/npm-remote/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
     "url-parse": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
@@ -12138,6 +12217,20 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "db:migrate:prod": "sequelize db:migrate --env production",
     "db:dev": "run-s db:create:dev db:migrate:dev",
     "db:test": "run-s db:create:test db:migrate:test",
+		"sqs:init": "aws --endpoint-url=http://localhost:9602 sqs create-queue --queue-name webhooksqs",
     "prepare": "husky install",
     "precommit": "run-p lint build"
   },
@@ -63,6 +64,7 @@
     "@types/rate-limit-redis": "^1.7.1",
     "@types/supertest": "^2.0.11",
     "atlassian-jwt": "^2.0.0",
+    "aws-sdk": "^2.989.0",
     "axios": "^0.21.1",
     "body-parser": "^1.18.3",
     "bottleneck": "^2.19.5",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -49,6 +49,8 @@ export interface EnvVars {
 	NODE_ENV: EnvironmentEnum,
 	MICROS_ENV: EnvironmentEnum;
 	MICROS_SERVICE_VERSION?: string,
+	SQS_WEBHOOKSQS_QUEUE_REGION: string,
+	SQS_WEBHOOKSQS_QUEUE_URL: string,
 
 	APP_ID: string;
 	APP_URL: string;

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -12,6 +12,8 @@ const launchdarklyClient = LaunchDarkly.init(envVars.LAUNCHDARKLY_KEY, {
 
 export enum BooleanFlags {
 	MAINTENANCE_MODE = "maintenance-mode",
+	SEND_PUSH_TO_SQS = "send-push-events-to-sqs",
+	STOP_SENDING_PUSH_TO_REDIS = "stop-sending-push-to-redis",
 	//Controls if we should check the token properly for APIs which are called from Jira Frontend. (Fixes the current state)
 	FIX_IFRAME_ENDPOINTS_JWT = "fix-jwt-authentication-for-iframe-endpoints",
 	//If enabled, we'll use asymmetrically signed jwt tokens for /install and /uninstall endpoints callbacks.

--- a/src/config/sqs.ts
+++ b/src/config/sqs.ts
@@ -1,0 +1,94 @@
+import AWS from "aws-sdk";
+import Logger from "bunyan"
+import {getLogger} from "./logger"
+import {Message} from "aws-sdk/clients/sqs";
+import envVars from "./env";
+
+// All our queues must be in the same region so we can set a global parameter here
+AWS.config.update({region: envVars.SQS_WEBHOOKSQS_QUEUE_REGION || "us-west-1"});
+
+// Create SQS service client
+const sqs = new AWS.SQS({apiVersion: "2012-11-05"});
+const logger = getLogger("config.sqs")
+
+// Replace with your account id and the queue name you setup
+
+export class SqsQueue {
+	queueUrl: string;
+	queueName: string;
+
+	constructor(queueName: string, queueUrl: string) {
+		this.queueUrl = queueUrl;
+		this.queueName = queueName;
+	}
+
+	sendMessage(payload: any, log?: Logger) {
+		log = log || logger
+		const params = {
+			MessageBody: JSON.stringify(payload),
+			QueueUrl: this.queueUrl
+		};
+		sqs.sendMessage(params, (err, data) => {
+			if (err) {
+				log.error(err, "Error sending SQS message");
+			} else {
+				log.info(`Successfully added message to sqs queue messageId: ${data.MessageId}`);
+			}
+		});
+	}
+
+	deleteMessage(message: Message) {
+		const deleteParams = {
+			QueueUrl: this.queueUrl,
+			ReceiptHandle: message.ReceiptHandle
+		};
+		sqs.deleteMessage(deleteParams, (err, data) => {
+			if (err) {
+				logger.error({err, data}, "Error deleting message from the queue");
+			} else {
+				logger.debug({data}, "Successfully deleted message from queue");
+			}
+		});
+	}
+
+	listen(messageHandler) {
+		// Setup the receiveMessage parameters
+		const params = {
+			QueueUrl: this.queueUrl,
+			MaxNumberOfMessages: 1,
+			VisibilityTimeout: 0,
+			WaitTimeSeconds: 0
+		};
+		sqs.receiveMessage(params, async (err, data) => {
+			if (err) {
+				logger.error({err}, `Error receiving message from SQS queue, queueName ${this.queueName}`);
+			} else {
+				if (!data.Messages) {
+					logger.debug("Nothing to process");
+					return;
+				}
+
+				await Promise.all(data.Messages.map(message => {
+
+					return new Promise<void>((resolve) => {
+						const messagePayload = JSON.parse(message.Body);
+						logger.info({messagePayload}, "Sqs message received");
+
+						try {
+							messageHandler({data: messagePayload})
+							this.deleteMessage(message)
+						} catch (err) {
+							logger.error(err, "error executing sqs message")
+						}
+						resolve()
+					})
+				})
+				)
+			}
+		});
+	}
+}
+
+export const sqsQueues: { [key: string]: SqsQueue } = {
+	push: new SqsQueue("push", envVars.SQS_WEBHOOKSQS_QUEUE_URL || "http://localhost:9602/queue/webhooksqs")
+};

--- a/src/github/push.ts
+++ b/src/github/push.ts
@@ -40,9 +40,9 @@ export default async (context: Context, jiraClient): Promise<void> => {
 
 	if (prioritize) {
 		context.log("Enqueueing push event (prioritized)");
-		await enqueuePush(payload, jiraClient.baseURL, { priority: 1 });
+		await enqueuePush(payload, jiraClient.baseURL,  context.log, { priority: 1 });
 	} else {
 		context.log("Enqueueing push event (not prioritized)");
-		await enqueuePush(payload, jiraClient.baseURL);
+		await enqueuePush(payload, jiraClient.baseURL, context.log, {});
 	}
 };

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -17,6 +17,7 @@ import { initializeSentry } from "../config/sentry";
 import { getLogger } from "../config/logger";
 import "../config/proxy";
 import { isNodeDev } from "../util/isNodeEnv";
+import {sqsQueues} from "../config/sqs";
 
 const CONCURRENT_WORKERS = process.env.CONCURRENT_WORKERS || 1;
 const client = new Redis(getRedisInfo("client"));
@@ -141,6 +142,9 @@ export const start = (): void => {
 		Number(CONCURRENT_WORKERS),
 		commonMiddleware(processPush(app))
 	);
+
+	sqsQueues.push.listen(commonMiddleware(processPush(app)))
+
 	queues.metrics.process(1, commonMiddleware(metricsJob));
 
 	probot.start();


### PR DESCRIPTION
In this PR I did the following:

* Added support for SQS queues
* added the queue for push events

* Added 2 feature flag:
* send-push-events-to-sqs - to control if we send events to sqs
* stop-sending-push-to-redis - to control if we send push events to redis

Both redis and sqs listeners will be enabled at all times


Some things which not there yet:
* Metrics for sqs queue processing/errors
* Timeouts for sqs queue processing