### PR TITLE
Remove bottleneck

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -240,7 +240,7 @@ router.post(
 	async (request: Request, res: Response): Promise<void> => {
 
 		const queueName = request.body.queue;   // "installation", "push", "metrics", or "discovery"
-		const jobTypes = request.body.jobTypes || []; // any combination of ["active", "delayed", "waiting", "paused"]
+		const jobTypes = request.body.jobTypes || ["active", "delayed", "waiting", "paused"];
 
 		if(!jobTypes.length){
 			res.status(400);
@@ -250,7 +250,7 @@ router.post(
 
 		const queue: Queue = queues[queueName];
 
-		if (queue == undefined) {
+		if (!queue) {
 			res.status(400);
 			res.send(`queue ${queueName} does not exist (available queues: "installation", "push", "metrics", or "discovery"`);
 			return;

--- a/src/config/enhance-octokit.ts
+++ b/src/config/enhance-octokit.ts
@@ -23,7 +23,7 @@ export class RateLimitingError extends Error {
 const instrumentRequests = (octokit: GitHubAPI) => {
 
 	octokit.hook.error("request", async (error) => {
-		if (error.status === 403 && error.headers && error.headers["X-RateLimit-Remaining"] == "0") {
+		if (error.headers && error.headers["X-RateLimit-Remaining"] == "0") {
 			if(error.headers["X-RateLimit-Reset"]) {
 				logger.warn({error}, "rate limiting error");
 				const rateLimitReset: number = parseInt(error.headers["X-RateLimit-Reset"]);

--- a/src/config/enhance-octokit.ts
+++ b/src/config/enhance-octokit.ts
@@ -7,13 +7,38 @@ import { Octokit } from "@octokit/rest";
 
 const logger = getLogger("octokit");
 
+export class RateLimitingError extends Error {
+	/**
+	 * The value of the x-ratelimit-reset header, i.e. the epoch seconds when the rate limit is refreshed.
+	 */
+	rateLimitReset: number;
+
+	constructor(resetMillis: number) {
+		super("rate limiting error");
+		this.rateLimitReset = resetMillis;
+		Object.setPrototypeOf(this, RateLimitingError.prototype);
+	}
+}
+
 const instrumentRequests = (octokit: GitHubAPI) => {
+
+	octokit.hook.error("request", async (error) => {
+		if (error.status === 403 && error.headers && error.headers["X-RateLimit-Remaining"] == "0") {
+			if(error.headers["X-RateLimit-Reset"]) {
+				logger.warn({error}, "rate limiting error");
+				const rateLimitReset: number = parseInt(error.headers["X-RateLimit-Reset"]);
+				throw new RateLimitingError(rateLimitReset);
+			}
+			throw error;
+		}
+	});
+
 	octokit.hook.wrap("request", async (request, options) => {
 		const requestStart = Date.now();
 		let responseStatus = null;
 
-		let response:Octokit.Response<any>;
-		let error:any;
+		let response: Octokit.Response<any>;
+		let error: any;
 		try {
 			response = await request(options);
 			responseStatus = response.status;
@@ -21,10 +46,11 @@ const instrumentRequests = (octokit: GitHubAPI) => {
 		} catch (err) {
 			error = err;
 			responseStatus = error?.responseCode;
+
 			throw error;
 		} finally {
-			if(error || responseStatus < 200 || responseStatus >= 400) {
-				logger.warn({request, response, error}, `Octokit error: failed request '${options.method} ${options.url}'`);
+			if (error || responseStatus < 200 || responseStatus >= 400) {
+				logger.warn({ request, response, error }, `Octokit error: failed request '${options.method} ${options.url}'`);
 			}
 			const elapsed = Date.now() - requestStart;
 			const tags = {

--- a/src/config/enhance-octokit.ts
+++ b/src/config/enhance-octokit.ts
@@ -29,8 +29,8 @@ const instrumentRequests = (octokit: GitHubAPI) => {
 				const rateLimitReset: number = parseInt(error.headers["X-RateLimit-Reset"]);
 				throw new RateLimitingError(rateLimitReset);
 			}
-			throw error;
 		}
+		throw error;
 	});
 
 	octokit.hook.wrap("request", async (request, options) => {

--- a/src/config/enhance-octokit.ts
+++ b/src/config/enhance-octokit.ts
@@ -13,9 +13,9 @@ export class RateLimitingError extends Error {
 	 */
 	rateLimitReset: number;
 
-	constructor(resetMillis: number) {
+	constructor(resetEpochSeconds: number) {
 		super("rate limiting error");
-		this.rateLimitReset = resetMillis;
+		this.rateLimitReset = resetEpochSeconds;
 		Object.setPrototypeOf(this, RateLimitingError.prototype);
 	}
 }

--- a/src/config/github-api.ts
+++ b/src/config/github-api.ts
@@ -1,35 +1,9 @@
 import { GitHubAPI } from "probot";
 import { getLogger } from "./logger";
-import Redis from "ioredis";
-import Bottleneck from "bottleneck";
-import getRedisInfo from "./redis-info";
-import ehanceOctokit from "./enhance-octokit";
+import enhanceOctokit from "./enhance-octokit";
 import { Options } from "probot/lib/github";
-import { isNodeTest } from "../util/isNodeEnv";
 
-// Just create one connection and share it
-const redisOptions = getRedisInfo("octokit");
-const client = new Redis(redisOptions);
-const connection = new Bottleneck.IORedisConnection({ client });
-
-const logger = getLogger("github.api");
-
-export default (options: Partial<GithubAPIOptions> = {}): GitHubAPI => {
+export default (options: Partial<Options> = {}): GitHubAPI => {
 	options.logger = options.logger || getLogger("config.github-api");
-	options.throttle = {
-		enabled: !isNodeTest(),
-		onRateLimit: (_, options) => logger.warn({ options }, "Request quota exhausted for request"),
-		onAbuseLimit: (_, options) => logger.warn({ options }, "Abuse detected for request")
-	};
-
-	// Configure the Bottleneck Redis Client
-	options.bottleneck = options.bottleneck || Bottleneck;
-	options.connection = options.connection || connection;
-
-	return ehanceOctokit(GitHubAPI(options as Options));
-}
-
-interface GithubAPIOptions extends Options {
-	connection?: Bottleneck.IORedisConnection;
-	bottleneck?: typeof Bottleneck;
+	return enhanceOctokit(GitHubAPI(options as Options));
 }

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -144,9 +144,7 @@ const updateJobStatus = async (
 			}
 		});
 
-		const delay = Number(process.env.LIMITER_PER_INSTALLATION) || 1000;
-
-		queues.installation.add(job.data, { delay });
+		queues.installation.add(job.data);
 		// no more data (last page was processed of this job type)
 	} else if (!(await getNextTask(subscription))) {
 		await subscription.update({ syncStatus: SyncStatus.COMPLETE });

--- a/src/transforms/push.ts
+++ b/src/transforms/push.ts
@@ -73,13 +73,15 @@ export async function enqueuePush(payload: unknown, jiraHost: string, options?: 
 
 export function processPushJob(app: Application) {
 	return async (job: Job): Promise<void> => {
+		let github
 		try {
-			const github = await app.auth(job.data.installationId);
-			enhanceOctokit(github);
-			await processPush(github, job.data);
+			github = await app.auth(job.data.installationId);
 		} catch (err) {
 			logger.error({ err, job }, "Could not authenticate");
+			return
 		}
+		enhanceOctokit(github);
+		await processPush(github, job.data);
 	};
 }
 
@@ -175,5 +177,6 @@ export const processPush = async (github: GitHubAPI, payload) => {
 
 	} catch (error) {
 		log.error(error, "Failed to process push");
+		throw error
 	}
 };

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -140,7 +140,7 @@ const setDelayOnRateLimiting = (jobHandler) => async (job) => {
 				logger.warn({ job }, "Rate limiting detected but couldn't calculate delay, delaying exponentially");
 				job.opts.backoff = {
 					type: "exponential",
-					delay: 30 * 60 * 1000
+					delay: 10 * 60 * 1000
 				}
 			} else {
 				logger.warn({ job }, `Rate limiting detected, delaying job by ${delay} ms`);

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -17,6 +17,7 @@ import { initializeSentry } from "../config/sentry";
 import { getLogger } from "../config/logger";
 import "../config/proxy";
 import { booleanFlag, BooleanFlags } from "../config/feature-flags";
+import {RateLimitingError} from "../config/enhance-octokit";
 
 const CONCURRENT_WORKERS = process.env.CONCURRENT_WORKERS || 1;
 const client = new Redis(getRedisInfo("client"));
@@ -127,6 +128,32 @@ const sentryMiddleware = (jobHandler) => async (job) => {
 	}
 };
 
+
+const setDelayOnRateLimiting = (jobHandler) => async (job) => {
+
+
+	try {
+		await jobHandler(job);
+	} catch (err) {
+
+		if(err instanceof RateLimitingError) {
+
+			const delay = err.rateLimitReset*1000 - new Date().getTime();
+
+			logger.warn({job}, `Rate limiting detected, setting the exponential backoff base to ${delay}`)
+
+			job.opts.backoff = {
+				type: "fixed",
+				delay: delay
+			}
+
+		}
+
+		throw err;
+	}
+
+}
+
 const sendQueueMetrics = async () => {
 	if (await booleanFlag(BooleanFlags.EXPOSE_QUEUE_METRICS, false)) {
 
@@ -145,7 +172,7 @@ const sendQueueMetrics = async () => {
 	}
 }
 
-const commonMiddleware = (jobHandler) => sentryMiddleware(jobHandler);
+const commonMiddleware = (jobHandler) => sentryMiddleware(setDelayOnRateLimiting(jobHandler));
 
 export const start = (): void => {
 	initializeSentry();

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -17,7 +17,7 @@ import { initializeSentry } from "../config/sentry";
 import { getLogger } from "../config/logger";
 import "../config/proxy";
 import { booleanFlag, BooleanFlags } from "../config/feature-flags";
-import {RateLimitingError} from "../config/enhance-octokit";
+import { RateLimitingError } from "../config/enhance-octokit";
 
 const CONCURRENT_WORKERS = process.env.CONCURRENT_WORKERS || 1;
 const client = new Redis(getRedisInfo("client"));
@@ -136,11 +136,11 @@ const setDelayOnRateLimiting = (jobHandler) => async (job) => {
 		await jobHandler(job);
 	} catch (err) {
 
-		if(err instanceof RateLimitingError) {
+		if (err instanceof RateLimitingError) {
 
-			const delay = err.rateLimitReset*1000 - new Date().getTime();
+			const delay = err.rateLimitReset * 1000 - new Date().getTime();
 
-			logger.warn({job}, `Rate limiting detected, setting the exponential backoff base to ${delay}`)
+			logger.warn({ job }, `Rate limiting detected, setting the exponential backoff base to ${delay}`)
 
 			job.opts.backoff = {
 				type: "fixed",

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -140,7 +140,7 @@ const setDelayOnRateLimiting = (jobHandler) => async (job) => {
 
 			const delay = err.rateLimitReset * 1000 - new Date().getTime();
 
-			logger.warn({ job }, `Rate limiting detected, setting the exponential backoff base to ${delay}`)
+			logger.warn({ job }, `Rate limiting detected, delaying job by ${delay} ms`)
 
 			job.opts.backoff = {
 				type: "fixed",

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -133,7 +133,8 @@ const setDelayOnRateLimiting = (jobHandler) => async (job) => {
 		await jobHandler(job);
 	} catch (err) {
 		if (err instanceof RateLimitingError) {
-			const delay = err.rateLimitReset * 1000 - new Date().getTime();
+			// delaying until the rate limit is reset (plus a buffer of a couple seconds)
+			const delay = err.rateLimitReset * 1000 + 10000 - new Date().getTime();
 			logger.warn({ job }, `Rate limiting detected, delaying job by ${delay} ms`)
 			job.opts.backoff = {
 				type: "fixed",

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -128,30 +128,20 @@ const sentryMiddleware = (jobHandler) => async (job) => {
 	}
 };
 
-
 const setDelayOnRateLimiting = (jobHandler) => async (job) => {
-
-
 	try {
 		await jobHandler(job);
 	} catch (err) {
-
 		if (err instanceof RateLimitingError) {
-
 			const delay = err.rateLimitReset * 1000 - new Date().getTime();
-
 			logger.warn({ job }, `Rate limiting detected, delaying job by ${delay} ms`)
-
 			job.opts.backoff = {
 				type: "fixed",
 				delay: delay
 			}
-
 		}
-
 		throw err;
 	}
-
 }
 
 const sendQueueMetrics = async () => {


### PR DESCRIPTION
Removes the bottleneck configuration completely so that calls to GitHub will not wait and block the queue.

Instead, handle rate limiting errors ourselves by delaying a job until the rate limit is refreshed.