### PR TITLE
endpoint to deduplicate the installation queue

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -243,24 +243,24 @@ router.post(
 		// the whole queue will be drained and all jobs will be readded.
 		const jobs = await queues.installation.getJobs(["active", "delayed", "waiting", "paused"]);
 		const foundInstallationIds = new Set<number>();
-		const jobsToRemove = [];
+		const duplicateJobs = [];
 
 		// collecting duplicate jobs per installation
 		for (const job of jobs) {
 			if (foundInstallationIds.has(job.data.installationId)) {
-				jobsToRemove.push(job);
+				duplicateJobs.push(job);
 			} else {
 				foundInstallationIds.add(job.data.installationId);
 			}
 		}
 
 		// removing duplicate jobs
-		await Promise.all(jobsToRemove.map((job) => {
+		await Promise.all(duplicateJobs.map((job) => {
 			logger.info({ job }, "removing duplicate job");
 			job.remove();
 		}));
 
-		res.send(`${jobsToRemove.length} duplicate jobs removed.`);
+		res.send(`${duplicateJobs.length} duplicate jobs removed.`);
 	}
 );
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -234,6 +234,37 @@ router.post(
 );
 
 router.post(
+	"/dedupInstallationQueue",
+	bodyParser,
+	elapsedTimeMetrics,
+	async (_: Request, res: Response): Promise<void> => {
+
+		// This remove all jobs from the queue. This way,
+		// the whole queue will be drained and all jobs will be readded.
+		const jobs = await queues.installation.getJobs(["active", "delayed", "waiting", "paused"]);
+		const foundInstallationIds = new Set<number>();
+		const jobsToRemove = [];
+
+		// collecting duplicate jobs per installation
+		for (const job of jobs) {
+			if (foundInstallationIds.has(job.data.installationId)) {
+				jobsToRemove.push(job);
+			} else {
+				foundInstallationIds.add(job.data.installationId);
+			}
+		}
+
+		// removing duplicate jobs
+		await Promise.all(jobsToRemove.map((job) => {
+			logger.info({ job }, "removing duplicate job");
+			job.remove();
+		}));
+
+		res.send(`${jobsToRemove.length} duplicate jobs removed.`);
+	}
+);
+
+router.post(
 	"/requeue",
 	bodyParser,
 	elapsedTimeMetrics,
@@ -242,7 +273,7 @@ router.post(
 		const queueName = request.body.queue;   // "installation", "push", "metrics", or "discovery"
 		const jobTypes = request.body.jobTypes || ["active", "delayed", "waiting", "paused"];
 
-		if(!jobTypes.length){
+		if (!jobTypes.length) {
 			res.status(400);
 			res.send("please specify the jobTypes field (available job types: [\"active\", \"delayed\", \"waiting\", \"paused\"])");
 			return;


### PR DESCRIPTION
The installation queue seems to be polluted with multiple installation jobs per installation. However, there should be only **one** installation job per installation on the queue at any given time.

This explains high number of items on the installation queue and the rate limiting errors we're seeing. 

This PR adds an admin endpoint that allows us to deduplicate the installation queue so that only one job per installation id remains on the queue.

Running this endpoint may relieve the installation queue of its current pressure. 