### PR TITLE
run the deduplication job on an interval

### DIFF
--- a/src/worker/deduplicate-installations.ts
+++ b/src/worker/deduplicate-installations.ts
@@ -1,0 +1,32 @@
+import { queues } from "./main";
+import { getLogger } from "../config/logger";
+
+const logger = getLogger("deduplicate-installations");
+
+export const deduplicateInstallations = async() : Promise<number> => {
+	// This remove all jobs from the queue. This way,
+	// the whole queue will be drained and all jobs will be readded.
+	const jobs = await queues.installation.getJobs(["active", "delayed", "waiting", "paused"]);
+	const foundInstallationIds = new Set<number>();
+	const duplicateJobs = [];
+
+	// collecting duplicate jobs per installation
+	for (const job of jobs) {
+		if (!job) {
+			continue;
+		}
+		if (foundInstallationIds.has(job.data.installationId)) {
+			duplicateJobs.push(job);
+		} else {
+			foundInstallationIds.add(job.data.installationId);
+		}
+	}
+
+	// removing duplicate jobs
+	await Promise.all(duplicateJobs.map((job) => {
+		logger.info({ job }, "removing duplicate job");
+		job.remove();
+	}));
+
+	return duplicateJobs.length;
+}


### PR DESCRIPTION
Deduplicating the installation queue has removed the blockage in the queue. Syncs are working again 🥳 
![image](https://user-images.githubusercontent.com/1363578/133862411-a7194289-43fa-470c-be60-f4ddc44ebee2.png)

However, there must still be a bug / configuration issue somewhere that causes jobs to be processed twice, which would explain why the queue explodes like this (each job adds a new job to the queue and if it gets processed twice, it will add 2 new jobs, which will add more jobs and so on).

To mitigate this issue until we found the cause for it, this PR adds code to run the deduplication job every couple of minutes.