### PR TITLE
Changing external proxy for whitelist proxy

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -26,10 +26,9 @@ if (env.error && nodeEnv !== EnvironmentEnum.production) {
 	throw env.error;
 }
 
-const getProxyFromEnvironment = (): string => {
-	const proxyHost = process.env.EXTERNAL_ONLY_PROXY_HOST;
-	const proxyPort = process.env.EXTERNAL_ONLY_PROXY_PORT;
-	return proxyHost && proxyPort ? `http://${proxyHost}:${proxyPort}` : undefined;
+const getProxyFromEnvironment = (): string | undefined => {
+	const proxy = process.env.WHITELIST_PROXY;
+	return proxy ? `http://${proxy}` : undefined;
 };
 
 // TODO: Make envvars dynamic


### PR DESCRIPTION
External proxy goes to the public internet before coming back to Jira.  By using the whitelist proxy, we can hit the jira API directly within our VPC which also means it's not blocked by atlassian's ip allowlist.