### PR TITLE
ARC-666: make lockDuration dependent on the timeout to avoid a job being triggered twice

### DIFF
--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -41,8 +41,8 @@ const getQueueOptions = (timeout: number): QueueOptions => {
 			removeOnFail: true
 		},
 		settings: {
-			// lockDuration must be smaller than the timeout, otherwise a job might be processed twice
-			lockDuration: timeout - 500
+			// lockDuration must be greater than the timeout, so that it doesn't get processed again prematurely
+			lockDuration: timeout + 500
 		},
 		redis: getRedisInfo("bull"),
 		createClient: (type, redisOpts = {}) => {

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -40,6 +40,10 @@ const getQueueOptions = (timeout: number): QueueOptions => {
 			removeOnComplete: true,
 			removeOnFail: true
 		},
+		settings: {
+			// lockDuration must be smaller than the timeout, otherwise a job might be processed twice
+			lockDuration: timeout - 500
+		},
 		redis: getRedisInfo("bull"),
 		createClient: (type, redisOpts = {}) => {
 			let redisInfo;


### PR DESCRIPTION
We increased the timeout of the queue jobs, but the `lockDuration` is still the default (30 seconds). That means that after 30 seconds, a message will be "unlocked" and picked up by another worker to be processed again. Since each job adds a follow-up job to the queue, a job that is processed twice will add two follow-up-jobs to the queue, which might again add new jobs and so on, building up the waiting queue.

This PR should hopefully fix this.