### PR TITLE
ARC-671: retry loading commits on error "The changedFiles count for this commit is unavailable"

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -19,7 +19,8 @@ export enum BooleanFlags {
 	PRIORITIZE_PUSHES = "prioritize-pushes",
 	EXPOSE_QUEUE_METRICS = "expose-queue-metrics",
 	PROCESS_PUSHES_IMMEDIATELY = "process-pushes-immediately",
-	SIMPLER_PROCESSOR = "simpler-processor"
+	SIMPLER_PROCESSOR = "simpler-processor",
+	RETRY_WITHOUT_CHANGED_FILES = "retry-without-changed-files"
 }
 
 export enum StringFlags {

--- a/src/sync/commits.ts
+++ b/src/sync/commits.ts
@@ -1,6 +1,10 @@
 import transformCommit from "../transforms/commit";
 import { getCommits as getCommitsQuery, getDefaultRef } from "./queries";
 import { GitHubAPI } from "probot";
+import { booleanFlag, BooleanFlags } from "../config/feature-flags";
+import { getLogger } from "../config/logger";
+
+const logger = getLogger("sync.commits");
 
 // TODO: better typings
 export default async (github: GitHubAPI, repository, cursor, perPage: number) => {
@@ -13,15 +17,44 @@ export default async (github: GitHubAPI, repository, cursor, perPage: number) =>
 
 	const refName = (data.repository.defaultBranchRef) ? data.repository.defaultBranchRef.name : "master";
 
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let commitsData: any = {};
+
 	// TODO: fix typings for graphql
-	const commitsData = (await github.graphql(getCommitsQuery, {
-		owner: repository.owner.login,
-		repo: repository.name,
-		per_page: perPage,
-		cursor,
-		default_ref: refName
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	})) as any;
+	try {
+		commitsData = (await github.graphql(getCommitsQuery(true), {
+			owner: repository.owner.login,
+			repo: repository.name,
+			per_page: perPage,
+			cursor,
+			default_ref: refName
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		})) as any;
+	} catch (err) {
+
+		if (!await booleanFlag(BooleanFlags.RETRY_WITHOUT_CHANGED_FILES, false)) {
+			throw err;
+		}
+
+		// According to the logs, GraphQL queries sometimes fail because the "changedFiles" field is not available.
+		// In this case we just try again, but without asking for the changedFiles field.
+
+		logger.info("retrying without changedFiles");
+
+		const changedFilesErrors = err.errors?.filter(e => e.message?.includes("The changedFiles count for this commit is unavailable"));
+		if (changedFilesErrors.length) {
+			commitsData = (await github.graphql(getCommitsQuery(false), {
+				owner: repository.owner.login,
+				repo: repository.name,
+				per_page: perPage,
+				cursor,
+				default_ref: refName
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			})) as any;
+		}
+
+		logger.info("successfully retried without changedFiles");
+	}
 
 	// if the repository is empty, commitsData.repository.ref is null
 	const edges = commitsData.repository.ref?.target?.history?.edges;

--- a/src/sync/queries.ts
+++ b/src/sync/queries.ts
@@ -31,7 +31,7 @@ export const getPullRequests = `query ($owner: String!, $repo: String!, $per_pag
     }
   }`;
 
-export const getCommits = `query ($owner: String!, $repo: String!, $per_page: Int!, $cursor: String, $default_ref: String!) {
+export const getCommits = (includeChangedFiles?: boolean) => `query ($owner: String!, $repo: String!, $per_page: Int!, $cursor: String, $default_ref: String!) {
     repository(owner: $owner, name: $repo){
       ref(qualifiedName: $default_ref) {
         target {
@@ -52,7 +52,7 @@ export const getCommits = `query ($owner: String!, $repo: String!, $per_page: In
                   message
                   oid
                   url
-                  changedFiles
+                  ${includeChangedFiles ? "changedFiles" : ""}
                 }
               }
             }


### PR DESCRIPTION
We're seeing a bunch of these errors in the logs, causing backfills to fail. So, we'll catch this error and retry again without asking for the `changedFiles` field.

The `changedFiles` feels can be undefined, it's only used in 2 places and those have a null-check.