### PR TITLE
Add jiraHost to sync failed log

### DIFF
--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -394,7 +394,8 @@ export const processInstallation =
 
 				await subscription.update({ syncStatus: "FAILED" });
 
-				logger.warn({ job, task: nextTask, err }, "Sync failed");
+				const host = subscription.jiraHost || "none";
+				logger.warn({ job, task: nextTask, err, jiraHost: host }, "Sync failed");
 
 				job.sentry.setExtra("Installation FAILED", JSON.stringify(err, null, 2));
 				job.sentry.captureException(err);


### PR DESCRIPTION
Realised while trying to look for failures for specific customers, that we currently have no way to search for a sync failed log and connect it to a specific jira instance.