### PR TITLE
Arc 676 continue sync on error

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -21,7 +21,8 @@ export enum BooleanFlags {
 	PROCESS_PUSHES_IMMEDIATELY = "process-pushes-immediately",
 	SIMPLER_PROCESSOR = "simpler-processor",
 	CUSTOM_QUERIES_FOR_REPO_SYNC_STATE = "use-custom-queries-for-repo-sync-state",
-	RETRY_WITHOUT_CHANGED_FILES = "retry-without-changed-files"
+	RETRY_WITHOUT_CHANGED_FILES = "retry-without-changed-files",
+	CONTINUE_SYNC_ON_ERROR = "continue-sync-on-error"
 }
 
 export enum StringFlags {

--- a/src/config/metric-names.ts
+++ b/src/config/metric-names.ts
@@ -36,6 +36,11 @@ export const metricSyncStatus = {
 	failed: `${server}.sync-status.failed`
 };
 
+export const metricTaskStatus = {
+	complete: `${server}.task-status.complete`,
+	failed: `${server}.task-status.failed`
+};
+
 export const metricWebhooks = {
 	webhookEvent: `${server}.webhooks.webhook-events`
 };

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -39,7 +39,7 @@ export interface RepositoryData {
 	[key: string]: unknown;
 }
 
-export type TaskStatus = "pending" | "complete";
+export type TaskStatus = "pending" | "complete" | "failed";
 
 export interface Repository {
 	id: string;

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -42,7 +42,7 @@ type TaskType = "pull" | "commit" | "branch";
 
 const taskTypes = Object.keys(tasks) as TaskType[];
 
-const completedTaskStatuses: TaskStatus[] = ["complete", "failed"];
+const completedTaskStatuses : TaskStatus[] = ["complete", "failed"];
 
 const updateNumberOfReposSynced = async (
 	repos: Repositories,
@@ -233,10 +233,10 @@ export const isNotFoundError = (
 	const isNotFoundError = isNotFoundErrorType?.length > 0 || err?.status === 404;
 
 	isNotFoundError &&
-	logger.info(
-		{ job, task: nextTask },
-		"Repository deleted after discovery, skipping initial sync"
-	);
+		logger.info(
+			{ job, task: nextTask },
+			"Repository deleted after discovery, skipping initial sync"
+		);
 
 	return isNotFoundError;
 };
@@ -425,7 +425,9 @@ export const processInstallation =
 
 				if (await booleanFlag(BooleanFlags.CONTINUE_SYNC_ON_ERROR, false, jiraHost)) {
 
-					logger.warn({ job, task: nextTask, err }, "Task failed, continuing with next task");
+					// TODO: add the jiraHost to the logger with logger.child()
+					const host = subscription.jiraHost || "none";
+					logger.warn({ job, task: nextTask, err, jiraHost: host }, "Task failed, continuing with next task");
 
 					// marking the current task as failed
 					await subscription.updateRepoSyncStateItem(nextTask.repositoryId, getStatusKey(nextTask.task as TaskType), "failed");
@@ -438,6 +440,7 @@ export const processInstallation =
 
 					await subscription.update({ syncStatus: "FAILED" });
 
+					// TODO: add the jiraHost to the logger with logger.child()
 					const host = subscription.jiraHost || "none";
 					logger.warn({ job, task: nextTask, err, jiraHost: host }, "Sync failed");
 

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -1,5 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import SubscriptionClass, { Repositories, Repository, RepositoryData, SyncStatus } from "../models/subscription";
+import SubscriptionClass, {
+	Repositories,
+	Repository,
+	RepositoryData,
+	SyncStatus,
+	TaskStatus
+} from "../models/subscription";
 import { Subscription } from "../models";
 import getJiraClient from "../jira/client";
 import { getRepositorySummary } from "./jobs";
@@ -36,6 +42,8 @@ type TaskType = "pull" | "commit" | "branch";
 
 const taskTypes = Object.keys(tasks) as TaskType[];
 
+const completedTaskStatuses: TaskStatus[] = ["complete", "failed"];
+
 const updateNumberOfReposSynced = async (
 	repos: Repositories,
 	subscription: SubscriptionClass
@@ -49,9 +57,9 @@ const updateNumberOfReposSynced = async (
 		// all 3 statuses need to be complete for a repo to be fully synced
 		const { pullStatus, branchStatus, commitStatus } = repos[id];
 		return (
-			pullStatus === "complete" &&
-			branchStatus === "complete" &&
-			commitStatus === "complete"
+			completedTaskStatuses.includes(pullStatus)
+			&& completedTaskStatuses.includes(branchStatus)
+			&& completedTaskStatuses.includes(commitStatus)
 		);
 	});
 
@@ -225,10 +233,10 @@ export const isNotFoundError = (
 	const isNotFoundError = isNotFoundErrorType?.length > 0 || err?.status === 404;
 
 	isNotFoundError &&
-		logger.info(
-			{ job, task: nextTask },
-			"Repository deleted after discovery, skipping initial sync"
-		);
+	logger.info(
+		{ job, task: nextTask },
+		"Repository deleted after discovery, skipping initial sync"
+	);
 
 	return isNotFoundError;
 };

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -178,6 +178,27 @@ const isBlocked = async (installationId: number): Promise<boolean> => {
 	}
 }
 
+/**
+ * Determines if an an error returned by the GitHub API means that we should retry it
+ * with a smaller request (i.e. with fewer pages).
+ * @param err the error thrown by Octokit.
+ */
+export const isRetryableWithSmallerRequest = (err): boolean => {
+	if (err.errors) {
+
+		const retryableErrors = err.errors.filter(
+			(error) => {
+				return "MAX_NODE_LIMIT_EXCEEDED" == error.type
+					|| error.message?.startsWith("Something went wrong while executing your query")
+			}
+		);
+
+		return retryableErrors.length;
+	} else {
+		return false;
+	}
+};
+
 // TODO: type queues
 export const processInstallation =
 	(app: Application, queues) =>
@@ -240,38 +261,37 @@ export const processInstallation =
 
 			const processor = tasks[task];
 
-			const handleGitHubError = (err) => {
-				if (err.errors) {
-					const ignoredErrorTypes = ["MAX_NODE_LIMIT_EXCEEDED"];
-					const notIgnoredError = err.errors.filter(
-						(error) => !ignoredErrorTypes.includes(error.type)
-					).length;
-
-					if (notIgnoredError) {
-						throw err;
-					}
-				} else {
-					throw err;
-				}
-			};
-
 			const execute = async () => {
 				if (await booleanFlag(BooleanFlags.SIMPLER_PROCESSOR, true)) {
-					try {
-						return await processor(github, repository, cursor, 20);
-					} catch (err) {
-						logger.error({ err, job, github, repository, cursor, task }, "Error Executing Task");
-						handleGitHubError(err);
-					}
+
+					// just try with one page size
+					return await processor(github, repository, cursor, 20);
+
 				} else {
+
 					for (const perPage of [20, 10, 5, 1]) {
+						// try for decreasing page sizes in case GitHub returns errors that should be retryable with smaller requests
 						try {
 							return await processor(github, repository, cursor, perPage);
 						} catch (err) {
-							logger.error({ err, job, github, repository, cursor, task }, "Error Executing Task");
-							handleGitHubError(err);
+							logger.error({
+								err,
+								job,
+								github,
+								repository,
+								cursor,
+								task
+							}, `Error processing job with page size ${perPage}, retrying with next smallest page size`);
+							if (isRetryableWithSmallerRequest(err)) {
+								// error is retryable, retrying with next smaller page size
+								continue;
+							} else {
+								// error is not retryable, re-throwing it
+								throw err;
+							}
 						}
 					}
+
 				}
 
 				throw new Error(`Error processing GraphQL query: installationId=${installationId}, repositoryId=${repositoryId}, task=${task}`);

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -80,7 +80,7 @@ const getNextTask = async (subscription: SubscriptionClass): Promise<Task> => {
 
 	for (const [repositoryId, repoData] of sortedRepos(repos)) {
 		const task = taskTypes.find(
-			(taskType) => repoData[getStatusKey(taskType)] === "pending"
+			(taskType) => repoData[getStatusKey(taskType)] === undefined || repoData[getStatusKey(taskType)] === "pending"
 		);
 		if (!task) continue;
 		const { repository, [getCursorKey(task)]: cursor } = repoData;
@@ -407,7 +407,7 @@ export const processInstallation =
 					logger.warn({ job, task: nextTask, err }, "Task failed, continuing with next task");
 
 					// marking the current task as failed
-					await subscription.updateRepoSyncStateItem(nextTask.repositoryId, nextTask.task, "failed");
+					await subscription.updateRepoSyncStateItem(nextTask.repositoryId, getStatusKey(nextTask.task as TaskType), "failed");
 					await subscription.update({ syncWarning: "Some commits, branches, and pull requests couldn't be loaded from GitHub." });
 
 					statsd.increment(metricTaskStatus.failed);

--- a/test/unit/sync/helpers/sync-helpers.test.ts
+++ b/test/unit/sync/helpers/sync-helpers.test.ts
@@ -10,7 +10,7 @@ import {
 /* eslint-disable @typescript-eslint/no-var-requires */
 import {
 	sortedRepos,
-	handleNotFoundErrors,
+	isNotFoundError,
 } from "../../../../src/sync/installation";
 
 describe("Sync helpers suite", () => {
@@ -25,7 +25,7 @@ describe("Sync helpers suite", () => {
 		it("should continue sync if 404 status is sent in response from octokit/request", (): void => {
 			// returns true if status is 404 so sync will continue
 			expect(
-				handleNotFoundErrors(
+				isNotFoundError(
 					mockNotFoundErrorOctokitRequest,
 					mockJob,
 					mockNextTask
@@ -36,7 +36,7 @@ describe("Sync helpers suite", () => {
 		it("should continue sync if NOT FOUND error is sent in response from octokit/graphql", (): void => {
 			// returns true if error object has type 'NOT_FOUND' so sync will continue
 			expect(
-				handleNotFoundErrors(
+				isNotFoundError(
 					mockNotFoundErrorOctokitGraphql,
 					mockJob,
 					mockNextTask
@@ -46,7 +46,7 @@ describe("Sync helpers suite", () => {
 
 		it("handleNotFoundErrors should not continue sync for any other error response type", () => {
 			expect(
-				handleNotFoundErrors(
+				isNotFoundError(
 					mockOtherOctokitRequestErrors,
 					mockJob,
 					mockNextTask
@@ -54,7 +54,7 @@ describe("Sync helpers suite", () => {
 			).toBeFalsy();
 
 			expect(
-				handleNotFoundErrors(
+				isNotFoundError(
 					mockOtherOctokitGraphqlErrors,
 					mockJob,
 					mockNextTask
@@ -62,7 +62,7 @@ describe("Sync helpers suite", () => {
 			).toBeFalsy();
 
 			expect(
-				handleNotFoundErrors(
+				isNotFoundError(
 					mockOtherError,
 					mockJob,
 					mockNextTask
@@ -70,7 +70,7 @@ describe("Sync helpers suite", () => {
 			).toBeFalsy();
 
 			expect(
-				handleNotFoundErrors(
+				isNotFoundError(
 					null,
 					mockJob,
 					mockNextTask
@@ -78,7 +78,7 @@ describe("Sync helpers suite", () => {
 			).toBeFalsy();
 
 			expect(
-				handleNotFoundErrors(
+				isNotFoundError(
 					"",
 					mockJob,
 					mockNextTask

--- a/test/unit/sync/installation.test.ts
+++ b/test/unit/sync/installation.test.ts
@@ -1,0 +1,43 @@
+import { isRetryableWithSmallerRequest } from "../../../src/sync/installation";
+
+describe("sync/installation", () => {
+
+	describe("isRetryableWithSmallerRequest()", () => {
+
+		it("should return true for max node limit exceeded", async () => {
+			const err = {
+				errors: [
+					{
+						type: "MAX_NODE_LIMIT_EXCEEDED"
+					}
+				]
+			};
+
+			expect(isRetryableWithSmallerRequest(err)).toBeTruthy();
+		});
+
+		it("should return true for 'something went wrong' error", async () => {
+			const err = {
+				errors: [
+					{
+						message: "Something went wrong while executing your query. some random text"
+					}
+				]
+			};
+
+			expect(isRetryableWithSmallerRequest(err)).toBeTruthy();
+		});
+
+		it("should return false for unknown error", async () => {
+			const err = {
+				errors: [
+					{
+						type: "FOO"
+					}
+				]
+			};
+
+			expect(isRetryableWithSmallerRequest(err)).toBeFalsy();
+		});
+	});
+});


### PR DESCRIPTION
Currently, a sync stops completely on a single error. For example, when the GitHub API times out (which it does for large requests), or if there is some other error that we don't have error handling for, the whole sync stops. All repos that have not been synced will stay unsynced.

This PR changes this behavior. If there is an unhandled error, the sync will now continue with the next task, a task being one of the following:

- syncing the commits of a repo
- syncing the PRs of a repo
- syncing the branches of a repo

I.e. if there is an error in the middle of syncing commits, the rest of the commits for this repo are skipped (and left "unsynced") and it continues with the branches and PRs.

In the future, we should add even better handling around this, so that we can continue with the next page of commits if a commit task fails, so that not all commits after the error will be left unsynced.

You can test this PR with this repository: https://github.com/thombergs/jira-test. It has some commits with a couple hundred thousand changed files, which will cause an error in the GitHub API.