### PR TITLE
ARC-682: remove the "sync failed" error on the read path

### DIFF
--- a/src/frontend/get-jira-configuration.ts
+++ b/src/frontend/get-jira-configuration.ts
@@ -3,29 +3,16 @@ import moment from "moment";
 import { Subscription } from "../models";
 import { NextFunction, Request, Response } from "express";
 import statsd from "../config/statsd";
-import { metricSyncStatus, metricError } from "../config/metric-names";
-import * as Sentry from "@sentry/node";
+import { metricError } from "../config/metric-names";
 
-const syncStatus = (syncStatus) =>
-	syncStatus === "ACTIVE" ? "IN PROGRESS" : syncStatus;
-
-const sendFailedStatusMetrics = (installationId: string, reqLog: any): void => {
-	const syncError = "No updates in the last 15 minutes";
-	reqLog.warn({ installationId, error: syncError }, "Sync failed");
-
-	Sentry.setExtra("Installation FAILED", syncError);
-	Sentry.captureException(syncError);
-
-	statsd.increment(metricSyncStatus.failed);
-};
+const syncStatus = (status) =>
+	status === "ACTIVE" ? "IN PROGRESS" : status;
 
 export async function getInstallation(client, subscription, reqLog?) {
 	const id = subscription.gitHubInstallationId;
 	try {
 		const response = await client.apps.getInstallation({ installation_id: id });
-		response.data.syncStatus = subscription.hasInProgressSyncFailed()
-			? "FAILED"
-			: syncStatus(subscription.syncStatus);
+		response.data.syncStatus = syncStatus(subscription.syncStatus);
 		response.data.syncWarning = subscription.syncWarning;
 		response.data.subscriptionUpdatedAt = formatDate(subscription.updatedAt);
 		response.data.totalNumberOfRepos = Object.keys(
@@ -34,8 +21,6 @@ export async function getInstallation(client, subscription, reqLog?) {
 		response.data.numberOfSyncedRepos =
 			subscription.repoSyncState?.numberOfSyncedRepos || 0;
 		response.data.jiraHost = subscription.jiraHost;
-
-		response.data.syncStatus === "FAILED" && sendFailedStatusMetrics(id, reqLog);
 
 		return response.data;
 	} catch (err) {

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -227,7 +227,7 @@ export default class Subscription extends Sequelize.Model {
 
 		this.repoSyncState.numberOfSyncedRepos = cnt;
 		await this.sequelize.query(
-			`UPDATE "Subscriptions" SET "repoSyncState" = jsonb_set("repoSyncState", '{numberOfSyncedRepos}', ':cnt', true) WHERE id = :id`,
+			`UPDATE "Subscriptions" SET "updatedAt" = NOW(), "repoSyncState" = jsonb_set("repoSyncState", '{numberOfSyncedRepos}', ':cnt', true) WHERE id = :id`,
 			{
 				replacements: {
 					cnt: cnt,
@@ -235,6 +235,7 @@ export default class Subscription extends Sequelize.Model {
 				}
 			}
 		);
+
 		return this;
 	}
 
@@ -248,7 +249,7 @@ export default class Subscription extends Sequelize.Model {
 		});
 
 		await this.sequelize.query(
-			`UPDATE "Subscriptions" SET "repoSyncState" = jsonb_set("repoSyncState", :path, :value, true) WHERE id = :id`,
+			`UPDATE "Subscriptions" SET "updatedAt" = NOW(), "repoSyncState" = jsonb_set("repoSyncState", :path, :value, true) WHERE id = :id`,
 			{
 				replacements: {
 					path: `{repos,${repositoryId},${key}}`,
@@ -264,17 +265,6 @@ export default class Subscription extends Sequelize.Model {
 		await this.destroy();
 	}
 
-	// An IN PROGRESS sync is one that is ACTIVE but has not seen any updates in the last 15 minutes.
-	// This may happen when an error causes a sync to die without setting the status to 'FAILED'
-	hasInProgressSyncFailed(): boolean {
-		if (this.syncStatus === "ACTIVE") {
-			const fifteenMinutesAgo = new Date(Date.now() - 15 * 60 * 1000);
-
-			return this.updatedAt < fifteenMinutesAgo;
-		} else {
-			return false;
-		}
-	}
 }
 
 export interface SubscriptionPayload {

--- a/test/frontend/get-jira-configuration.test.ts
+++ b/test/frontend/get-jira-configuration.test.ts
@@ -25,7 +25,6 @@ describe("Jira Configuration Suite", () => {
 				gitHubInstallationId: 15,
 				jiraHost: "https://test-host.jira.com",
 				destroy: jest.fn().mockResolvedValue(undefined),
-				hasInProgressSyncFailed: jest.fn().mockResolvedValue(undefined),
 				syncWarning: "some warning",
 				updatedAt: "2018-04-18T15:42:13Z",
 				repoSyncState: {


### PR DESCRIPTION
When a subscription hasn't had its `updatedAt` field updated for the last 15 minutes, the UI would show a sync as FAILED, even if it was still running in the background.

This PR updates the `updatedAt` field more often but also removes the mapping to the FAILED state in the UI.