### PR TITLE
ARC-679 transaction log alert

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -132,10 +132,10 @@ alarms:
       Namespace: AWS/RDS
       MetricName: TransactionLogsDiskUsage
       Description: "Master transaction logs disk usage is too high"
-      Threshold: 3.221225472E9
+      Threshold: 4000000000 # Approx 4GB
       Priority: Low
       EvaluationPeriods: 5
-      Period: 300
+      Period: 60
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Statistic: Average
 

--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -128,7 +128,16 @@ alarms:
       Period: 120
       ComparisonOperator: GreaterThanThreshold
       Statistic: Average
-
+    TransactionLogsDiskUsageAlarm:
+      Namespace: AWS/RDS
+      MetricName: TransactionLogsDiskUsage
+      Description: "Master transaction logs disk usage is too high"
+      Threshold: 3.221225472E9
+      Priority: Low
+      EvaluationPeriods: 5
+      Period: 300
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Statistic: Average
 
 config:
   environmentVariables:


### PR DESCRIPTION
Added TransactionLogsDiskUsageAlarm to our service descriptor to increase the threshold and evaluation period for the P4 that we keep seeing in #fusion-low-prio-alerts channel.