### PR TITLE
ARC-421: allow filtering for "last updated" date in resync endpoint

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -222,8 +222,10 @@ router.post(
 		const limit = Number(req.body.limit) || undefined;
 		// Needed for 'pagination'
 		const offset = Number(req.body.offset) || 0;
+		// only resync installations whose "updatedAt" date is older than x seconds
+		const inactiveForSeconds = Number(req.body.inactiveForSeconds) || undefined;
 
-		const subscriptions = await Subscription.getAllFiltered(installationIds, statusTypes, offset, limit);
+		const subscriptions = await Subscription.getAllFiltered(installationIds, statusTypes, offset, limit, inactiveForSeconds);
 
 		await Promise.all(subscriptions.map((subscription) =>
 			Subscription.findOrStartSync(subscription, syncType)

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -84,6 +84,7 @@ export default class Subscription extends Sequelize.Model {
 		statusTypes: string[] = ["FAILED", "PENDING", "ACTIVE"],
 		offset = 0,
 		limit?: number,
+		inactiveForSeconds?: number
 	): Promise<Subscription[]> {
 
 		const andFilter = [];
@@ -100,6 +101,17 @@ export default class Subscription extends Sequelize.Model {
 			andFilter.push({
 				gitHubInstallationId: {
 					[Op.in]: _.uniq(installationIds)
+				}
+			});
+		}
+
+		if (inactiveForSeconds) {
+
+			const xSecondsAgo = new Date(new Date().getTime() - (inactiveForSeconds * 1000))
+
+			andFilter.push({
+				updatedAt: {
+					[Op.lt]: xSecondsAgo
 				}
 			});
 		}


### PR DESCRIPTION
Allows filtering for subscriptions with the `updatedAt` field older than a specified number of seconds. We can use this to restart syncs that have been inactive for a time.