### PR TITLE
ARC-421: make the deduplication aware of the jiraHost. 

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -253,7 +253,7 @@ router.post(
 		// This remove all jobs from the queue. This way,
 		// the whole queue will be drained and all jobs will be readded.
 		const jobs = await queues.installation.getJobs(["active", "delayed", "waiting", "paused"]);
-		const foundInstallationIds = new Set<number>();
+		const foundJobIds = new Set<string>();
 		const duplicateJobs: Job[] = [];
 
 		// collecting duplicate jobs per installation
@@ -262,10 +262,10 @@ router.post(
 			if (!job) {
 				continue;
 			}
-			if (foundInstallationIds.has(job.data.installationId)) {
+			if (foundJobIds.has(`${job.data.installationId}${job.data.jiraHost}`)) {
 				duplicateJobs.push(job);
 			} else {
-				foundInstallationIds.add(job.data.installationId);
+				foundJobIds.add(`${job.data.installationId}${job.data.jiraHost}`);
 			}
 		}
 


### PR DESCRIPTION
The deduplication mechanism was a bit too aggressive. It identified duplicates only by the installation ID, but there may be multiple jobs with the same installation ID, but with different Jira hosts. That means jobs were being removed from the queue when they shouldn't. This would explain the behavior we're seeing that some syncs are just stopping to do anything.

With this fix, the deduplication now identifies a job by its installationId **and** jiraHost.