### PR TITLE
ARC-684 Metrics for webhooks reliability SLO. Fixed path tag on HTTP metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,8 @@
     },
     "@atlassian/aui": {
       "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@atlassian/aui/-/aui-9.4.0.tgz",
-      "integrity": "sha512-JhJsMXZQDZUicmPwDrTEuBnFcpqe7+T+TfoBDpQcyQAr2Aq9GuwQ+2KUU0P/CWiqlcZMKaPh8zukCb9I7F1Ckw==",
+      "resolved": "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/aui/-/@atlassian/aui-9.4.0.tgz",
+      "integrity": "sha1-dsZMMmZ/xcLC6KKbFQei4IZk+OQ=",
       "requires": {
         "@atlassian/tipsy": "1.3.3",
         "@popperjs/core": "2.4.4",
@@ -47,8 +47,8 @@
     },
     "@atlassian/tipsy": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@atlassian/tipsy/-/tipsy-1.3.3.tgz",
-      "integrity": "sha512-6jd9wdoiPdCbwsNi1Xrn/oMdGz22dKPeCoZ/cCGKqjnh+UYkBKb5W3spW+WNqRSxGvVtfUEEg6TXotRK/FPDaw=="
+      "resolved": "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/tipsy/-/tipsy-1.3.3.tgz",
+      "integrity": "sha1-P3d1TExwMkxck45Bq6ospoLyIDY="
     },
     "@babel/code-frame": {
       "version": "7.12.13",
@@ -1143,8 +1143,8 @@
     },
     "@popperjs/core": {
       "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.4.tgz",
-      "integrity": "sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg=="
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@popperjs/core/-/core-2.4.4.tgz",
+      "integrity": "sha1-EdXbGb0XiTbsic2EUZxN5DlXQ5g="
     },
     "@sentry/core": {
       "version": "6.8.0",
@@ -2259,8 +2259,8 @@
     },
     "backbone": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
-      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/backbone/-/backbone-1.4.0.tgz",
+      "integrity": "sha1-VNtN6d98OBHD8DLzR0mkzSfzvRI=",
       "requires": {
         "underscore": ">=1.8.3"
       }
@@ -3190,7 +3190,7 @@
     },
     "css.escape": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.0.tgz",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/css.escape/-/css.escape-1.5.0.tgz",
       "integrity": "sha1-lZhNeIfOTKkGhOgTlm9C0e+H7Oo="
     },
     "cssom": {
@@ -4709,8 +4709,8 @@
     },
     "fancy-file-input": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/fancy-file-input/-/fancy-file-input-2.0.4.tgz",
-      "integrity": "sha512-l+J0WwDl4nM/zMJ/C8qleYnXMUJKsLng7c5uWH/miAiHoTvPDtEoLW1tmVO6Cy2O8i/1VfA+2YOwg/Q3+kgO6w=="
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/fancy-file-input/-/fancy-file-input-2.0.4.tgz",
+      "integrity": "sha1-aYwhZILgdkmoJ2gcTbMFT93Joys="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -7312,7 +7312,7 @@
     },
     "jquery-ui": {
       "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/jquery-ui/-/jquery-ui-1.12.1.tgz",
       "integrity": "sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE="
     },
     "js-beautify": {
@@ -10665,12 +10665,12 @@
     },
     "skatejs": {
       "version": "0.13.17",
-      "resolved": "https://registry.npmjs.org/skatejs/-/skatejs-0.13.17.tgz",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/skatejs/-/skatejs-0.13.17.tgz",
       "integrity": "sha1-eiH7s0NNpF5StHthZHFo7p53gHE="
     },
     "skatejs-template-html": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/skatejs-template-html/-/skatejs-template-html-0.0.0.tgz",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/skatejs-template-html/-/skatejs-template-html-0.0.0.tgz",
       "integrity": "sha1-6ZDBp9S1i3MF/8wzOJOb9AICPfc="
     },
     "slash": {
@@ -11430,7 +11430,7 @@
     },
     "trim-extra-html-whitespace": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/trim-extra-html-whitespace/-/trim-extra-html-whitespace-1.3.0.tgz",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/trim-extra-html-whitespace/-/trim-extra-html-whitespace-1.3.0.tgz",
       "integrity": "sha1-tH77DRpfKlaoXMRc6lJWUek0BM8="
     },
     "trim-newlines": {
@@ -11708,8 +11708,8 @@
     },
     "underscore": {
       "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha1-DBxr0t9UtrafIxQGbWW2zeb8+dE="
     },
     "union-value": {
       "version": "1.0.1",

--- a/src/config/metric-names.ts
+++ b/src/config/metric-names.ts
@@ -45,6 +45,8 @@ export const metricTaskStatus = {
 export const metricWebhooks = {
 	webhookEvent: `${server}.webhooks.webhook-events`,
 	webhookProcessingTimes: `${server}.webhooks.processing-time.duration-ms`,
+	webhookProcessed: `${server}.webhooks.processed`,
+	webhookFailure: `${server}.webhooks.failed`,
 	webhookLatency: `${server}.webhooks.processing-time.latency`,
 };
 

--- a/src/config/statsd.ts
+++ b/src/config/statsd.ts
@@ -57,7 +57,8 @@ export const elapsedTimeMetrics = (
 	const method = req.method;
 
 	res.once("finish", () => {
-		const pathTag = req.route?.path || ((req.baseUrl || "/") + "*" );
+
+		const pathTag = req.baseUrl ? req.baseUrl + (req.route?.path || "*") : (req.route?.path || "/*");
 		const elapsedTime = elapsedTimeInMs();
 		const statusCode  = `${res.statusCode}`;
 		const tags = { path: pathTag, method,  statusCode};

--- a/src/github/branch.ts
+++ b/src/github/branch.ts
@@ -1,6 +1,6 @@
 import transformBranch from "../transforms/branch";
 import issueKeyParser from "jira-issue-key-parser";
-import { emitWebhookProcessingTimeMetrics } from "../util/webhooks";
+import { emitWebhookProcessedMetrics } from "../util/webhooks";
 import { CustomContext } from "./middleware";
 import { booleanFlag, BooleanFlags } from "../config/feature-flags";
 import _ from "lodash";
@@ -30,7 +30,7 @@ export const createBranch = async (
 		(await booleanFlag(BooleanFlags.WEBHOOK_RECEIVED_METRICS, false)) &&
 		webhookReceived
 	) {
-		emitWebhookProcessingTimeMetrics(
+		emitWebhookProcessedMetrics(
 			webhookReceived,
 			name,
 			log,
@@ -64,7 +64,7 @@ export const deleteBranch = async (context, jiraClient): Promise<void> => {
 		(await booleanFlag(BooleanFlags.WEBHOOK_RECEIVED_METRICS, false)) &&
 		webhookReceived
 	) {
-		emitWebhookProcessingTimeMetrics(
+		emitWebhookProcessedMetrics(
 			webhookReceived,
 			name,
 			log,

--- a/src/github/deployment.ts
+++ b/src/github/deployment.ts
@@ -1,5 +1,5 @@
 import transformDeployment from "../transforms/deployment";
-import { emitWebhookProcessingTimeMetrics } from "../util/webhooks";
+import { emitWebhookProcessedMetrics } from "../util/webhooks";
 import { CustomContext } from "./middleware";
 import { booleanFlag, BooleanFlags } from "../config/feature-flags";
 
@@ -23,7 +23,7 @@ export default async (context: CustomContext, jiraClient): Promise<void> => {
 		(await booleanFlag(BooleanFlags.WEBHOOK_RECEIVED_METRICS, false)) &&
 		webhookReceived
 	) {
-		emitWebhookProcessingTimeMetrics(
+		emitWebhookProcessedMetrics(
 			webhookReceived,
 			name,
 			log,

--- a/src/github/issue-comment.ts
+++ b/src/github/issue-comment.ts
@@ -1,5 +1,5 @@
 import JiraClient from "../models/jira-client";
-import { emitWebhookProcessingTimeMetrics } from "../util/webhooks";
+import { emitWebhookProcessedMetrics } from "../util/webhooks";
 import { CustomContext } from "./middleware";
 import { booleanFlag, BooleanFlags } from "../config/feature-flags";
 
@@ -43,7 +43,7 @@ export default async (
 		(await booleanFlag(BooleanFlags.WEBHOOK_RECEIVED_METRICS, false)) &&
 		webhookReceived
 	) {
-		emitWebhookProcessingTimeMetrics(
+		emitWebhookProcessedMetrics(
 			webhookReceived,
 			name,
 			log,

--- a/src/github/issue.ts
+++ b/src/github/issue.ts
@@ -1,5 +1,5 @@
 import JiraClient from "../models/jira-client";
-import { emitWebhookProcessingTimeMetrics } from "../util/webhooks";
+import { emitWebhookProcessedMetrics } from "../util/webhooks";
 import { booleanFlag, BooleanFlags } from "../config/feature-flags";
 import { CustomContext } from "./middleware";
 
@@ -34,7 +34,7 @@ export default async (context: CustomContext, _: JiraClient, util): Promise<void
 		(await booleanFlag(BooleanFlags.WEBHOOK_RECEIVED_METRICS, false)) &&
 		webhookReceived
 	) {
-		emitWebhookProcessingTimeMetrics(
+		emitWebhookProcessedMetrics(
 			webhookReceived,
 			name,
 			log,

--- a/src/github/middleware.ts
+++ b/src/github/middleware.ts
@@ -9,7 +9,7 @@ import getJiraUtil from "../jira/util";
 import enhanceOctokit from "../config/enhance-octokit";
 import { Context } from "probot/lib/context";
 import { booleanFlag, BooleanFlags } from "../config/feature-flags";
-import { getCurrentTime } from "../util/webhooks";
+import {emitWebhookFailedMetrics, getCurrentTime} from "../util/webhooks";
 import JiraClient from "../models/jira-client";
 import { getLogger } from "../config/logger";
 import envVars from "../config/env";
@@ -34,6 +34,7 @@ const withSentry = function (callback) {
 			await callback(context);
 		} catch (err) {
 			context.log.error({ err, context }, "Error while processing webhook");
+			emitWebhookFailedMetrics(extractWebhookEventNameFromContext(context));
 			context.sentry?.captureException(err);
 			throw err;
 		}
@@ -69,16 +70,21 @@ export class CustomContext<E = any> extends Context<E> {
 	webhookReceived?: number;
 }
 
+function extractWebhookEventNameFromContext(context: CustomContext<any>): string {
+	let webhookEvent = context.name;
+	if (context.payload?.action) {
+		webhookEvent = `${webhookEvent}.${context.payload.action}`;
+	}
+	return webhookEvent;
+}
+
 // TODO: fix typings
 export default (
 	callback: (context: CustomContext, jiraClient: JiraClient, util: any) => Promise<void>
 ) => {
 	return withSentry(async (context: CustomContext) => {
 		enhanceOctokit(context.github);
-		let webhookEvent = context.name;
-		if (context.payload.action) {
-			webhookEvent = `${webhookEvent}.${context.payload.action}`;
-		}
+		const webhookEvent = extractWebhookEventNameFromContext(context);
 
 		const webhookReceived = getCurrentTime();
 		context.webhookReceived = webhookReceived;
@@ -229,7 +235,9 @@ export default (
 					err,
 					`Error processing the event for Jira hostname '${jiraHost}'`
 				);
+				emitWebhookFailedMetrics(webhookEvent);
 				context.sentry?.captureException(err);
+
 			}
 		}
 	});

--- a/src/github/pull-request.ts
+++ b/src/github/pull-request.ts
@@ -1,7 +1,7 @@
 import transformPullRequest from "../transforms/pull-request";
 import issueKeyParser from "jira-issue-key-parser";
 
-import { emitWebhookProcessingTimeMetrics } from "../util/webhooks";
+import { emitWebhookProcessedMetrics } from "../util/webhooks";
 import { CustomContext } from "./middleware";
 import { booleanFlag, BooleanFlags } from "../config/feature-flags";
 import _ from "lodash";
@@ -101,7 +101,7 @@ export default async (
 		(await booleanFlag(BooleanFlags.WEBHOOK_RECEIVED_METRICS, false)) &&
 		webhookReceived
 	) {
-		emitWebhookProcessingTimeMetrics(
+		emitWebhookProcessedMetrics(
 			webhookReceived,
 			name,
 			log,

--- a/src/github/repository.ts
+++ b/src/github/repository.ts
@@ -1,4 +1,4 @@
-import { emitWebhookProcessingTimeMetrics } from "../util/webhooks";
+import { emitWebhookProcessedMetrics } from "../util/webhooks";
 import { booleanFlag, BooleanFlags } from "../config/feature-flags";
 
 export const deleteRepository = async (context, jiraClient): Promise<void> => {
@@ -13,7 +13,7 @@ export const deleteRepository = async (context, jiraClient): Promise<void> => {
 		(await booleanFlag(BooleanFlags.WEBHOOK_RECEIVED_METRICS, false)) &&
 		webhookReceived
 	) {
-		emitWebhookProcessingTimeMetrics(
+		emitWebhookProcessedMetrics(
 			webhookReceived,
 			name,
 			log,

--- a/src/github/workflow.ts
+++ b/src/github/workflow.ts
@@ -1,6 +1,6 @@
 import transformWorkflow from "../transforms/workflow";
 import { CustomContext } from "./middleware";
-import { emitWebhookProcessingTimeMetrics } from "../util/webhooks";
+import { emitWebhookProcessedMetrics } from "../util/webhooks";
 import { booleanFlag, BooleanFlags } from "../config/feature-flags";
 
 export default async (context: CustomContext, jiraClient): Promise<void> => {
@@ -23,7 +23,7 @@ export default async (context: CustomContext, jiraClient): Promise<void> => {
 		(await booleanFlag(BooleanFlags.WEBHOOK_RECEIVED_METRICS, false)) &&
 		webhookReceived
 	) {
-		emitWebhookProcessingTimeMetrics(
+		emitWebhookProcessedMetrics(
 			webhookReceived,
 			name,
 			log,

--- a/src/transforms/push.ts
+++ b/src/transforms/push.ts
@@ -6,7 +6,7 @@ import { Application, GitHubAPI } from "probot";
 import { getLogger } from "../config/logger";
 import { Job, JobOptions } from "bull";
 import { getJiraAuthor } from "../util/jira";
-import { emitWebhookProcessingTimeMetrics } from "../util/webhooks";
+import {emitWebhookFailedMetrics, emitWebhookProcessedMetrics} from "../util/webhooks";
 import { booleanFlag, BooleanFlags } from "../config/feature-flags";
 import { JiraCommit } from "../interfaces/jira";
 import _ from "lodash";
@@ -194,15 +194,14 @@ export const processPush = async (github: GitHubAPI, payload) => {
 			const jiraResponse = await jiraClient.devinfo.repository.update(
 				jiraPayload
 			);
-			const webhookName = payload.name || "none";
 
 			if (
 				(await booleanFlag(BooleanFlags.WEBHOOK_RECEIVED_METRICS, false)) &&
 				webhookReceived
 			) {
-				emitWebhookProcessingTimeMetrics(
+				emitWebhookProcessedMetrics(
 					webhookReceived,
-					webhookName,
+					"push",
 					log,
 					jiraResponse?.status
 				);
@@ -210,6 +209,7 @@ export const processPush = async (github: GitHubAPI, payload) => {
 		}
 	} catch (error) {
 		log.error(error, "Failed to process push");
+		emitWebhookFailedMetrics("push");
 		throw error;
 	}
 };

--- a/src/util/webhooks.ts
+++ b/src/util/webhooks.ts
@@ -3,7 +3,17 @@ import { metricWebhooks } from "../config/metric-names";
 
 export const getCurrentTime = () => Date.now();
 
-export const emitWebhookProcessingTimeMetrics = (
+/**
+ * Emits metrics for successfully processed webhook. These metrics include:
+ *  - Webhook processing duration histogram
+ *  - Processed webhooks counter
+ *
+ * @param webhookReceivedTime time when GitHub for Jira app received a webhook from GitHub
+ * @param webhookName name of the webhook (type)
+ * @param contextLogger logger for the function logs
+ * @param status http response code if applicable to this webhook type
+ */
+export const emitWebhookProcessedMetrics = (
 	webhookReceivedTime: number,
 	webhookName: string,
 	contextLogger: any,
@@ -26,6 +36,8 @@ export const emitWebhookProcessingTimeMetrics = (
 				name: webhookName,
 				status: status?.toString() || "none",
 			};
+
+			statsd.increment(metricWebhooks.webhookProcessed, tags);
 
 			// send metrics without gsd_histogram tag so we still have .count, .p99, .median etc
 			statsd.histogram(
@@ -61,3 +73,17 @@ export const emitWebhookProcessingTimeMetrics = (
 		);
 	}
 };
+
+/**
+ * Emits metric for failed webhook
+ * @param webhookName
+ */
+export const emitWebhookFailedMetrics = (webhookName: string) => {
+
+	const tags = {
+		name: webhookName,
+	};
+
+	statsd.increment(metricWebhooks.webhookFailure, tags);
+
+}

--- a/test/unit/util/webhooks.test.ts
+++ b/test/unit/util/webhooks.test.ts
@@ -1,4 +1,4 @@
-import { emitWebhookProcessingTimeMetrics } from "../../../src/util/webhooks";
+import { emitWebhookProcessedMetrics } from "../../../src/util/webhooks";
 import statsd from "../../../src/config/statsd";
 
 let dateNowSpy;
@@ -32,7 +32,7 @@ describe("Webhooks suite", () => {
 			const addStatsdSpy = jest.spyOn(statsd, "histogram");
 
 			expect(
-				emitWebhookProcessingTimeMetrics(
+				emitWebhookProcessedMetrics(
 					webhookReceived,
 					webhookName,
 					mockContextLogger,
@@ -70,7 +70,7 @@ describe("Webhooks suite", () => {
 				const status = 400;
 
 				expect(
-					emitWebhookProcessingTimeMetrics(
+					emitWebhookProcessedMetrics(
 						webhookReceived,
 						webhookName,
 						mockContextLogger,
@@ -81,7 +81,7 @@ describe("Webhooks suite", () => {
 
 			it("if webhookReceived is undefined", () => {
 				expect(
-					emitWebhookProcessingTimeMetrics(
+					emitWebhookProcessedMetrics(
 						0,
 						"workflow_run",
 						mockContextLogger,
@@ -92,7 +92,7 @@ describe("Webhooks suite", () => {
 
 			it("if webhookReceived is null", () => {
 				expect(
-					emitWebhookProcessingTimeMetrics(
+					emitWebhookProcessedMetrics(
 						0,
 						"workflow_run",
 						mockContextLogger,


### PR DESCRIPTION
There are 2 changes
1. I've added failure/success metrics for webhooks processing so we'll be able to count the amount of failed webhooks
2. I've changed the way we calculate "path" for HTTP metrics hence there was a bug