### PR TITLE
Adding AWS environment variables for SDK to work locally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ SQS_BACKFILL_QUEUE_REGION=us-west-1
 SQS_PUSH_QUEUE_URL=http://127.0.0.1:4566/000000000000/push
 SQS_PUSH_QUEUE_REGION=us-west-1
 MICROS_AWS_REGION=us-west-1
+AWS_ACCESS_KEY_ID=development
+AWS_SECRET_ACCESS_KEY=development
 # Optional but needed for feature flags
 LAUNCHDARKLY_KEY=
 

--- a/.env.test
+++ b/.env.test
@@ -11,6 +11,8 @@ SQS_BACKFILL_QUEUE_URL=http://127.0.0.1:4566/000000000000/test-backfill
 SQS_BACKFILL_QUEUE_REGION=us-west-1
 SQS_PUSH_QUEUE_URL=http://127.0.0.1:4566/000000000000/test-push
 SQS_PUSH_QUEUE_REGION=us-west-1
+AWS_ACCESS_KEY_ID=test
+AWS_SECRET_ACCESS_KEY=test
 MICROS_AWS_REGION=us-west-1
 
 # Unique name for the jira app, used in the Atlassian Connect manifest to

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -18,6 +18,8 @@ const requiredEnvVars = [
 	"SQS_PUSH_QUEUE_URL",
 	"SQS_PUSH_QUEUE_REGION",
 	"MICROS_AWS_REGION",
+	"AWS_ACCESS_KEY_ID",
+	"AWS_SECRET_ACCESS_KEY"
 ];
 
 const filename = isNodeTest() ? ".env.test" : ".env";


### PR DESCRIPTION
Can't poll local SQS queue from localstack if AWS SDK is missing these env vars.