### PR TITLE
NONE: add log statement

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -108,6 +108,8 @@ const sendQueueMetrics = async () => {
 	if (await booleanFlag(BooleanFlags.EXPOSE_QUEUE_METRICS, false)) {
 
 		for (const [queueName, queue] of Object.entries(queues)) {
+			logger.info("fetching queue metrics");
+
 			const jobCounts = await queue.getJobCounts();
 
 			logger.info({ queue: queueName, queueMetrics: jobCounts }, "publishing queue metrics");


### PR DESCRIPTION
Metrics shows that at some point of time we stop executing the code. Just ruling out possibility that we are stuck at redis call, not on some higher level...