### PR TITLE
ARC-764: split processInstallation

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -25,6 +25,7 @@ export enum BooleanFlags {
 	NEW_SETUP_PAGE = "new-setup-page",
 	PROPAGATE_REQUEST_ID = "propagate-request-id",
 	NEW_BACKFILL_PROCESS_ENABLED = "new-backfill-process-enabled",
+	SPLIT_PROCESS_INSTALLATION_FUNCTION = "split-process-installation-function"
 }
 
 export enum StringFlags {

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -416,7 +416,9 @@ export const processInstallation =
 			const {installationId, jiraHost} = job.data;
 
 			let logger: LoggerWithTarget;
-			if (await booleanFlag(BooleanFlags.SPLIT_PROCESS_INSTALLATION_FUNCTION, false, jiraHost)) {
+
+			const splitProcessInstallationFunctionFlagIsOn = await booleanFlag(BooleanFlags.SPLIT_PROCESS_INSTALLATION_FUNCTION, false, jiraHost);
+			if (splitProcessInstallationFunctionFlagIsOn) {
 				logger = rootLogger.child({job});
 			} else {
 				logger = rootLogger;
@@ -432,8 +434,9 @@ export const processInstallation =
 				jiraHost
 			});
 
-			if (await booleanFlag(BooleanFlags.SPLIT_PROCESS_INSTALLATION_FUNCTION, false, jiraHost)) {
-				return await doProcessInstallation(app, queues, job, installationId, jiraHost, logger);
+			if (splitProcessInstallationFunctionFlagIsOn) {
+				await doProcessInstallation(app, queues, job, installationId, jiraHost, logger);
+				return ;
 			}
 
 			// TODO: remove with SPLIT_PROCESS_INSTALLATION_FUNCTION feature flag cause it was moved to

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -210,13 +210,220 @@ export const isNotFoundError = (
 };
 
 // TODO: type queues
+async function doProcessInstallation(app, queues, job, installationId: number, jiraHost: string, logger: LoggerWithTarget): Promise<void> {
+	const subscription = await Subscription.getSingleInstallation(
+		jiraHost,
+		installationId
+	);
+	// TODO: should this reject instead? it's just ignoring an error
+	if (!subscription) return;
+
+	const jiraClient = await getJiraClient(
+		subscription.jiraHost,
+		installationId,
+		logger
+	);
+	const github = await getEnhancedGitHub(app, installationId);
+	const nextTask = await getNextTask(subscription);
+
+	if (!nextTask) {
+		await subscription.update({ syncStatus: "COMPLETE" });
+		statsd.increment(metricSyncStatus.complete);
+		logger.info({ job, task: nextTask }, "Sync complete");
+		return;
+	}
+
+	await subscription.update({ syncStatus: "ACTIVE" });
+
+	const { task, repositoryId, cursor } = nextTask;
+	let { repository } = nextTask;
+
+	if (!repository) {
+		// Old records don't have this info. New ones have it
+		const { data: repo } = await github.request("GET /repositories/:id", {
+			id: repositoryId
+		});
+		repository = getRepositorySummary(repo);
+		await subscription.updateSyncState({
+			repos: {
+				[repository.id]: {
+					repository
+				}
+			}
+		});
+	}
+
+	logger.info({ job, task: nextTask }, "Starting task");
+
+	const processor = tasks[task];
+
+	const execute = async () => {
+		if (await booleanFlag(BooleanFlags.SIMPLER_PROCESSOR, true)) {
+
+			// just try with one page size
+			return await processor(github, repository, cursor, 20);
+
+		} else {
+
+			for (const perPage of [20, 10, 5, 1]) {
+				// try for decreasing page sizes in case GitHub returns errors that should be retryable with smaller requests
+				try {
+					return await processor(github, repository, cursor, perPage);
+				} catch (err) {
+					logger.error({
+						err,
+						job,
+						github,
+						repository,
+						cursor,
+						task
+					}, `Error processing job with page size ${perPage}, retrying with next smallest page size`);
+					if (isRetryableWithSmallerRequest(err)) {
+						// error is retryable, retrying with next smaller page size
+						continue;
+					} else {
+						// error is not retryable, re-throwing it
+						throw err;
+					}
+				}
+			}
+
+		}
+
+		throw new Error(`Error processing GraphQL query: installationId=${installationId}, repositoryId=${repositoryId}, task=${task}`);
+	};
+
+	try {
+		const { edges, jiraPayload } = await execute();
+
+		if (jiraPayload) {
+			try {
+				await jiraClient.devinfo.repository.update(jiraPayload, {
+					preventTransitions: true
+				});
+			} catch (err) {
+				if (err?.response?.status === 400) {
+					job.sentry.setExtra(
+						"Response body",
+						err.response.data.errorMessages
+					);
+					job.sentry.setExtra("Jira payload", err.response.data.jiraPayload);
+				}
+
+				if (err.request) {
+					job.sentry.setExtra("Request", {
+						host: err.request.domain,
+						path: err.request.path,
+						method: err.request.method
+					});
+				}
+
+				if (err.response) {
+					job.sentry.setExtra("Response", {
+						status: err.response.status,
+						statusText: err.response.statusText,
+						body: err.response.body
+					});
+				}
+
+				throw err;
+			}
+		}
+
+		await updateJobStatus(
+			queues,
+			job,
+			edges,
+			task,
+			repositoryId,
+			logger,
+		);
+
+		statsd.increment(metricTaskStatus.complete, [`type: ${nextTask.task}`]);
+
+	} catch (err) {
+		const rateLimit = Number(err?.headers?.["x-ratelimit-reset"]);
+		const delay = Math.max(Date.now() - rateLimit * 1000, 0);
+
+		if (delay) {
+			// if not NaN or 0
+			logger.info({ delay, job, task: nextTask }, `Delaying job for ${delay}ms`);
+			queues.installation.add(job.data, { delay });
+			return;
+		}
+
+		if (String(err).includes("connect ETIMEDOUT")) {
+			// There was a network connection issue.
+			// Add the job back to the queue with a 5 second delay
+			logger.warn({ job, task: nextTask }, "ETIMEDOUT error, retrying in 5 seconds");
+			queues.installation.add(job.data, { delay: 5000 });
+			return;
+		}
+
+		if (
+			String(err.message).includes(
+				"You have triggered an abuse detection mechanism"
+			)
+		) {
+			// Too much server processing time, wait 60 seconds and try again
+			logger.warn({ job, task: nextTask }, "Abuse detection triggered. Retrying in 60 seconds");
+			queues.installation.add(job.data, { delay: 60000 });
+			return;
+		}
+
+		// Continue sync when a 404/NOT_FOUND is returned
+		if (isNotFoundError(err, job, nextTask, logger)) {
+			const edgesLeft = []; // No edges left to process since the repository doesn't exist
+			await updateJobStatus(queues, job, edgesLeft, task, repositoryId, logger);
+			return;
+		}
+
+		if (await booleanFlag(BooleanFlags.CONTINUE_SYNC_ON_ERROR, false, jiraHost)) {
+
+			// TODO: add the jiraHost to the logger with logger.child()
+			const host = subscription.jiraHost || "none";
+			logger.warn({ job, task: nextTask, err, jiraHost: host }, "Task failed, continuing with next task");
+
+			// marking the current task as failed
+			await subscription.updateRepoSyncStateItem(nextTask.repositoryId, getStatusKey(nextTask.task as TaskType), "failed");
+
+			statsd.increment(metricTaskStatus.failed, [`type: ${nextTask.task}`]);
+
+			// queueing the job again to pick up the next task
+			queues.installation.add(job.data);
+		} else {
+
+			await subscription.update({ syncStatus: "FAILED" });
+
+			// TODO: add the jiraHost to the logger with logger.child()
+			const host = subscription.jiraHost || "none";
+			logger.warn({ job, task: nextTask, err, jiraHost: host }, "Sync failed");
+
+			job.sentry.setExtra("Installation FAILED", JSON.stringify(err, null, 2));
+			job.sentry.captureException(err);
+
+			statsd.increment(metricSyncStatus.failed);
+
+			throw err;
+		}
+	}
+}
+
+// TODO: type queues
 export const processInstallation =
 	(app: Application, queues) =>
-		async (job, logger: LoggerWithTarget): Promise<void> => {
-			const { installationId, jiraHost } = job.data;
+		async (job, rootLogger: LoggerWithTarget): Promise<void> => {
+			const {installationId, jiraHost} = job.data;
+
+			let logger: LoggerWithTarget;
+			if (await booleanFlag(BooleanFlags.SPLIT_PROCESS_INSTALLATION_FUNCTION, false, jiraHost)) {
+				logger = rootLogger.child({job});
+			} else {
+				logger = rootLogger;
+			}
 
 			if (await isBlocked(installationId, logger)) {
-				logger.warn({ job }, "blocking installation job");
+				logger.warn({job}, "blocking installation job");
 				return;
 			}
 
@@ -225,6 +432,12 @@ export const processInstallation =
 				jiraHost
 			});
 
+			if (await booleanFlag(BooleanFlags.SPLIT_PROCESS_INSTALLATION_FUNCTION, false, jiraHost)) {
+				return await doProcessInstallation(app, queues, job, installationId, jiraHost, logger);
+			}
+
+			// TODO: remove with SPLIT_PROCESS_INSTALLATION_FUNCTION feature flag cause it was moved to
+			// doProcessInstallation()
 			const subscription = await Subscription.getSingleInstallation(
 				jiraHost,
 				installationId


### PR DESCRIPTION
Splitting processInstallation() onto two functions (feature flagged) and adding "job"  to the logger as a property.

This is needed for the future step once I add deduplication logic around the invocation of the new function.