### PR TITLE
ARC-779 Fixed worker restart and added a test

### DIFF
--- a/src/worker/startup.ts
+++ b/src/worker/startup.ts
@@ -141,7 +141,8 @@ export async function start() {
 		queues.metrics.process(1, commonMiddleware(metricsJob, METRICS_LOGGER_NAME));
 		firstInitialisation = false;
 	} else {
-		//resumes all Bull queues globally
+		//Resumes all Bull queues globally.
+		//The first parameter of this function "isLocal" controls if all queues will be resummed
 		await queues.discovery.resume(false)
 	}
 
@@ -162,7 +163,8 @@ export async function stop() {
 	// Stop sending metrics for queues
 	clearInterval(timer);
 
-	// Pauses messagse processing in all queue.
+	// Pauses message processing in all queues globally.
+	// The first parameter of this function "isLocal" controls if all queues will be paused
 	await queues.discovery.pause(false, true)
 
 	sqsQueues.stop();

--- a/test/safe/push.test.ts
+++ b/test/safe/push.test.ts
@@ -8,7 +8,7 @@ import {Installation, Subscription} from "../../src/models";
 import {booleanFlag, BooleanFlags} from "../../src/config/feature-flags";
 import {when} from "jest-when";
 import waitUntil from "../utils/waitUntil";
-import {start, stop} from "../../src/worker/startup";
+import {start, stop,  shutdown} from "../../src/worker/startup";
 
 jest.mock("../../src/models");
 jest.mock("../../src/config/feature-flags");
@@ -18,6 +18,7 @@ describe("GitHub Push", () => {
 	const mockGithubAccessToken = () => {
 		githubNock
 			.post("/app/installations/1234/access_tokens")
+			.optionally()
 			.reply(200, {
 				token: "token",
 				expires_at: new Date().getTime()
@@ -57,6 +58,10 @@ describe("GitHub Push", () => {
 		nock.cleanAll();
 		jest.restoreAllMocks();
 	});
+
+	afterAll(async () => {
+		await shutdown();
+	})
 
 	const getAtlassianUrl = () => process.env.ATLASSIAN_URL || "";
 	const createJob = (payload, jiraHost:string) => ({data: createJobData(payload, jiraHost)} as any);

--- a/test/unit/sqs/index.test.ts
+++ b/test/unit/sqs/index.test.ts
@@ -2,6 +2,7 @@ import { Context, SqsQueue } from "../../../src/sqs";
 import { v4 as uuidv4 } from "uuid";
 import envVars from "../../../src/config/env";
 import DoneCallback = jest.DoneCallback;
+import delay from "../../utils/delay";
 
 
 const TEST_QUEUE_URL = envVars.SQS_BACKFILL_QUEUE_URL;
@@ -9,10 +10,6 @@ const TEST_QUEUE_REGION = envVars.SQS_BACKFILL_QUEUE_REGION;
 const TEST_QUEUE_NAME = "test";
 
 type TestMessage = { msg: string }
-
-function delay(time) {
-	return new Promise(resolve => setTimeout(resolve, time));
-}
 
 //We have to disable this rule here hence there is no way to have a proper test for sqs queue with await here
 /* eslint-disable jest/no-done-callback */

--- a/test/unit/worker/startup.test.ts
+++ b/test/unit/worker/startup.test.ts
@@ -1,0 +1,185 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import nock from "nock";
+import {start, stop, shutdown} from "../../../src/worker/startup";
+import {enqueuePush} from "../../../src/transforms/push";
+import waitUntil from "../../utils/waitUntil";
+import {mocked} from "ts-jest/utils";
+import {Installation, Subscription} from "../../../src/models";
+import delay from "../../utils/delay";
+import {queues} from "../../../src/worker/queues";
+
+jest.mock("../../../src/models");
+jest.mock("../../../src/config/feature-flags");
+
+describe("worker stop test", () => {
+
+	const cleanupQueue = async () => {
+		const jobs = await queues.installation.getJobs(["active", "delayed", "waiting", "paused"]);
+		for (const job of jobs) {
+			await job.remove();
+		}
+	}
+
+	beforeEach(async () => {
+		Date.now = jest.fn(() => 12345678);
+
+		mocked(Subscription.getAllForInstallation).mockResolvedValue([
+			{
+				jiraHost: process.env.ATLASSIAN_URL,
+				gitHubInstallationId: 1234,
+				enabled: true
+			}] as any);
+		mocked(Subscription.getSingleInstallation).mockResolvedValue(
+			{
+				id: 1,
+				jiraHost: process.env.ATLASSIAN_URL
+			} as any);
+		mocked(Installation.getForHost).mockResolvedValue(
+			{
+				jiraHost: process.env.ATLASSIAN_URL,
+				sharedSecret: process.env.ATLASSIAN_SECRET,
+				enabled: true
+			} as any
+		);
+
+		//Start worker node for queues processing
+		await start();
+	});
+
+
+	afterEach(async () => {
+		try {
+			if (!nock.isDone()) {
+				// eslint-disable-next-line jest/no-jasmine-globals
+				fail("nock is not done yet");
+			}
+		} finally {
+			nock.cleanAll();
+			jest.restoreAllMocks();
+
+			//Stop worker node
+			await stop();
+			cleanupQueue();
+		}
+	})
+
+	afterAll(async () => {
+		await shutdown();
+	})
+
+	async function enqueueTestPushEvent() {
+		const event = require("../../fixtures/push-no-username.json");
+		await enqueuePush(event.payload, process.env.ATLASSIAN_URL || "")
+	}
+
+	const mockGithubAccessToken = () => {
+		githubNock
+			.post("/app/installations/1234/access_tokens")
+			.optionally()
+			.reply(200, {
+				token: "token",
+				expires_at: new Date().getTime()
+			});
+	}
+
+	function mockGitHubAndJiraResponsesForRequestProcessing() {
+
+		mockGithubAccessToken();
+
+		githubNock.get("/repos/test-repo-owner/test-repo-name/commits/commit-no-username")
+			.reply(200, require("../../fixtures/push-non-merge-commit"));
+
+		// flag property should not be present
+		jiraNock.post("/rest/devinfo/0.10/bulk", {
+			preventTransitions: false,
+			repositories: [
+				{
+					name: "test-repo-name",
+					url: "test-repo-url",
+					id: "test-repo-id",
+					commits: [
+						{
+							hash: "commit-no-username",
+							message: "[TEST-123] Test commit.",
+							author: {
+								avatar: "https://github.com/users/undefined.png",
+								name: "test-commit-name",
+								email: "test-email@example.com",
+								url: "https://github.com/users/undefined",
+							},
+							authorTimestamp: "test-commit-date",
+							displayId: "commit",
+							fileCount: 3,
+							files: [
+								{
+									path: "test-modified",
+									changeType: "MODIFIED",
+									linesAdded: 10,
+									linesRemoved: 2,
+									url: "https://github.com/octocat/Hello-World/blob/7ca483543807a51b6079e54ac4cc392bc29ae284/test-modified"
+								},
+								{
+									path: "test-added",
+									changeType: "ADDED",
+									linesAdded: 4,
+									linesRemoved: 0,
+									url: "https://github.com/octocat/Hello-World/blob/7ca483543807a51b6079e54ac4cc392bc29ae284/test-added"
+								},
+								{
+									path: "test-removal",
+									changeType: "DELETED",
+									linesAdded: 0,
+									linesRemoved: 4,
+									url: "https://github.com/octocat/Hello-World/blob/7ca483543807a51b6079e54ac4cc392bc29ae284/test-removal"
+								}
+							],
+							id: "commit-no-username",
+							issueKeys: ["TEST-123"],
+							url: "https://github.com/octokit/Hello-World/commit/commit-no-username",
+							updateSequenceId: 12345678
+						}
+					],
+					updateSequenceId: 12345678
+				}
+			],
+			properties: {installationId: 1234}
+		}).reply(200);
+	}
+
+	it("should normally process push events sync after restart", async () => {
+
+		mockGitHubAndJiraResponsesForRequestProcessing();
+
+		await stop();
+
+		await start();
+
+		await enqueueTestPushEvent();
+
+		await waitUntil( async () => {
+			// eslint-disable-next-line jest/no-standalone-expect
+			expect(githubNock.pendingMocks()).toEqual([]);
+			// eslint-disable-next-line jest/no-standalone-expect
+			expect(jiraNock.pendingMocks()).toEqual([]);
+		})
+	});
+
+	it("should not process push events when stopped", async () => {
+
+		mockGitHubAndJiraResponsesForRequestProcessing();
+
+		//await stop();
+
+		await enqueueTestPushEvent();
+
+		delay(1000)
+
+		//No calls to GitHub or Jira werwe made after some time since message was pushed
+		expect(githubNock.pendingMocks()).toHaveLength(1);
+		expect(jiraNock.pendingMocks()).toHaveLength(1);
+
+		nock.cleanAll();
+
+	});
+
+});

--- a/test/utils/delay.ts
+++ b/test/utils/delay.ts
@@ -1,0 +1,3 @@
+export default function delay(time: number) {
+	return new Promise(resolve => setTimeout(resolve, time));
+}


### PR DESCRIPTION
In this PR i've fixed the queue re-initialisation. It turned out that our rollbacks could be broken, hence when we are trying to add listener to the queue again, it will fail if listener is already there.

I've changed the way stop and start works. Instead of shutting down the queue we just pausing it and then resuming on restart.

+Added tests which checks that worker can be restarted properly