### PR TITLE
ARC-764: always reschedule duplicate messages

### DIFF
--- a/test/unit/sync/installation.test.ts
+++ b/test/unit/sync/installation.test.ts
@@ -114,10 +114,10 @@ describe("sync/installation", () => {
 			expect(queues.installation.add.mock.calls).toEqual([[job.data, {delay: 60_000}]]);
 		});
 
-		test('should drop the job if deduplicator is sure', async () => {
+		test('should also reschedule the job if deduplicator is sure', async () => {
 			mockedExecuteWithDeduplication.mockResolvedValue(DeduplicatorResult.E_OTHER_WORKER_DOING_THIS_JOB);
 			await processInstallation(app, queues)(job, logger);
-			expect(queues.installation.add.mock.calls.length).toEqual(0);
+			expect(queues.installation.add.mock.calls.length).toEqual(1);
 		});
 	});
 


### PR DESCRIPTION
Just realised that actually there could be a corner-case which might led to a staled sync. 

Let's try to always reschedule :holdonyourbutts: