### PR TITLE
Revert "Changing external proxy for whitelist proxy"

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -30,8 +30,9 @@ if (env.error && nodeEnv !== EnvironmentEnum.production) {
 }
 
 const getProxyFromEnvironment = (): string | undefined => {
-	const proxy = process.env.WHITELIST_PROXY;
-	return proxy ? `http://${proxy}` : undefined;
+	const proxyHost = process.env.EXTERNAL_ONLY_PROXY_HOST;
+	const proxyPort = process.env.EXTERNAL_ONLY_PROXY_PORT;
+	return proxyHost && proxyPort ? `http://${proxyHost}:${proxyPort}` : undefined;
 };
 
 // TODO: Make envvars dynamic


### PR DESCRIPTION
Reverts atlassian/github-for-jira#768

Even though the whitelist proxy was recommended to us for use, it isn't considered the right proxy for using with IP allowlisting on Github.  The network team has updated their documentation and flowchart as to which proxy is the best to use moving forward.  We shouldn't hit rate limiting if we're using the JWT token authentication with the Jira API but we might hit the Jira IP ACLs.  There's currently a ticket to automatically add outbound IPs from our own proxy to all Jira configured ACLs as to not hit any issues if customers want to restrict IPs.

This revert should fix quite a few issues with our enterprise customers.