### PR TITLE
Issue/ARC-707 making sync queue agnostic

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -21,13 +21,13 @@ export enum BooleanFlags {
 	NEW_GITHUB_ERROR_PAGE = "new-git-hub-error-page",
 	NEW_SETUP_PAGE = "new-setup-page",
 	NEW_BACKFILL_PROCESS_ENABLED = "new-backfill-process-enabled",
-	USE_DEDUPLICATOR_FOR_BACKFILLING = "use-deduplicator-for-backfilling",
 	// When cleaning up the SEND_PUSH_TO_SQS feature flag, please also clean up the PRIORITIZE_PUSHES
 	// feature flag, because it doesn't make sense with SQS any more.
 	SEND_PUSH_TO_SQS = "send-push-events-to-sqs",
 	PRIORITIZE_PUSHES = "prioritize-pushes",
 	USE_NEW_GITHUB_CLIENT__FOR_PR = "git-hub-client-for-pullrequests",
-	NEW_REPO_SYNC_STATE = "new-repo-sync-state"
+	NEW_REPO_SYNC_STATE = "new-repo-sync-state",
+	USE_BACKFILL_QUEUE_SUPPLIER = "use-backfill-queue-supplier"
 }
 
 export enum StringFlags {

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -190,7 +190,7 @@ export default class Subscription extends Sequelize.Model {
 	static async startNewSyncProcess(subscription: Subscription) {
 		//TODO Add a sync start logic
 		await sqsQueues.backfill.sendMessage({
-			gitHubInstallationId: subscription.gitHubInstallationId,
+			installationId: subscription.gitHubInstallationId,
 			jiraHost: subscription.jiraHost
 		});
 	}

--- a/src/sqs/backfill.ts
+++ b/src/sqs/backfill.ts
@@ -1,10 +1,11 @@
-import { MessageHandler } from "./index"
+import {MessageHandler} from "./index"
 import {booleanFlag, BooleanFlags} from "../config/feature-flags";
 
 
 export type BackfillMessagePayload = {
-	gitHubInstallationId: number,
-	jiraHost: string
+	installationId: number,
+	jiraHost: string,
+	startTime?: string
 }
 
 export const backfillQueueMessageHandler : MessageHandler<BackfillMessagePayload> = async (context) => {

--- a/src/sqs/index.ts
+++ b/src/sqs/index.ts
@@ -26,7 +26,7 @@ export type Context<MessagePayload> = {
 	payload: MessagePayload;
 
 	/**
-	 * Oritinal SQS Mesage
+	 * Original SQS Mesage
 	 */
 	message: Message;
 
@@ -36,7 +36,7 @@ export type Context<MessagePayload> = {
 	log: Logger;
 
 	/**
-	 * How many times this messages attempted to be processed, including the current attempt
+	 * How many times this messages attempted to be processed, including the current attempt (always greater 0)
 	 */
 	receiveCount: number;
 

--- a/src/worker/startup.ts
+++ b/src/worker/startup.ts
@@ -131,7 +131,7 @@ export async function start() {
 			return Promise.resolve({
 				schedule: async (jobData, delayMsecs) => {
 					// TBD: switch to SQS with a FF
-					if ((delayMsecs || 0) > 0) {
+					if (delayMsecs) {
 						await queues.installation.add(jobData, {delay: delayMsecs});
 					} else {
 						await queues.installation.add(jobData);

--- a/test/unit/sync/branch.test.ts
+++ b/test/unit/sync/branch.test.ts
@@ -149,7 +149,7 @@ describe.skip("sync/branches", () => {
 				add: jest.fn()
 			}
 		};
-		await expect(processInstallation(app, queues)(job, getLogger('test'))).toResolve();
+		await expect(processInstallation(app, queues, jest.fn())(job, getLogger('test'))).toResolve();
 		expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts);
 	});
 
@@ -174,7 +174,7 @@ describe.skip("sync/branches", () => {
 				add: jest.fn()
 			}
 		};
-		await expect(processInstallation(app, queues)(job, getLogger('test'))).toResolve();
+		await expect(processInstallation(app, queues, jest.fn())(job, getLogger('test'))).toResolve();
 		expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts);
 	});
 
@@ -233,7 +233,7 @@ describe.skip("sync/branches", () => {
 				add: jest.fn()
 			}
 		};
-		await expect(processInstallation(app, queues)(job, getLogger('test'))).toResolve();
+		await expect(processInstallation(app, queues, jest.fn())(job, getLogger('test'))).toResolve();
 		expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts);
 	});
 
@@ -253,7 +253,7 @@ describe.skip("sync/branches", () => {
 		const interceptor = jiraNock.post(/.*/);
 		const scope = interceptor.reply(200);
 
-		await expect(processInstallation(app, queues)(job, getLogger('test'))).toResolve();
+		await expect(processInstallation(app, queues, jest.fn())(job, getLogger('test'))).toResolve();
 		expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts);
 		expect(scope).not.toBeDone();
 		nock.removeInterceptor(interceptor);

--- a/test/unit/sync/commits.test.ts
+++ b/test/unit/sync/commits.test.ts
@@ -110,7 +110,7 @@ describe.skip("sync/commits", () => {
 				add: jest.fn()
 			}
 		};
-		await expect(processInstallation(app, queues)(job, getLogger('test'))).toResolve();
+		await expect(processInstallation(app, queues, jest.fn())(job, getLogger('test'))).toResolve();
 		expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts);
 	});
 
@@ -199,7 +199,7 @@ describe.skip("sync/commits", () => {
 				add: jest.fn()
 			}
 		};
-		await expect(processInstallation(app, queues)(job, getLogger('test'))).toResolve();
+		await expect(processInstallation(app, queues, jest.fn())(job, getLogger('test'))).toResolve();
 		expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts);
 	});
 
@@ -254,7 +254,7 @@ describe.skip("sync/commits", () => {
 				add: jest.fn()
 			}
 		};
-		await expect(processInstallation(app, queues)(job, getLogger('test'))).toResolve();
+		await expect(processInstallation(app, queues, jest.fn())(job, getLogger('test'))).toResolve();
 		expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts);
 	});
 
@@ -280,7 +280,7 @@ describe.skip("sync/commits", () => {
 				add: jest.fn()
 			}
 		};
-		await expect(processInstallation(app, queues)(job, getLogger('test'))).toResolve();
+		await expect(processInstallation(app, queues, jest.fn())(job, getLogger('test'))).toResolve();
 		expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts);
 		expect(scope).not.toBeDone();
 		nock.removeInterceptor(interceptor);
@@ -305,7 +305,7 @@ describe.skip("sync/commits", () => {
 				add: jest.fn()
 			}
 		};
-		await expect(processInstallation(app, queues)(job, getLogger('test'))).toResolve();
+		await expect(processInstallation(app, queues, jest.fn())(job, getLogger('test'))).toResolve();
 		expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts);
 		expect(scope).not.toBeDone();
 		nock.removeInterceptor(interceptor);

--- a/test/unit/sync/installation.test.ts
+++ b/test/unit/sync/installation.test.ts
@@ -1,4 +1,5 @@
 import {
+	BackfillQueue,
 	isRetryableWithSmallerRequest,
 	maybeScheduleNextTask,
 	processInstallation
@@ -6,10 +7,22 @@ import {
 
 import {DeduplicatorResult} from "../../../src/sync/deduplicator";
 
+import '../../../src/config/feature-flags';
+import {BooleanFlags} from "../../../src/config/feature-flags";
+
 import {Application} from "probot";
 import {getLogger} from "../../../src/config/logger";
 
 import Queue from "bull";
+
+let mockedBooleanFeatureFlags = {};
+jest.mock('../../../src/config/feature-flags', () => {
+	return {
+		...jest.requireActual('../../../src/config/feature-flags'),
+		booleanFlag: (key) => Promise.resolve(mockedBooleanFeatureFlags[key])
+	};
+});
+
 
 const mockedExecuteWithDeduplication = jest.fn();
 jest.mock('../../../src/sync/deduplicator', () => {
@@ -25,8 +38,20 @@ jest.mock("../../../src/models");
 
 describe("sync/installation", () => {
 
+	const backfillQueue: BackfillQueue = {
+		schedule: jest.fn()
+	}
+
+	const backfillQueueSchedule: jest.Mock = backfillQueue.schedule as jest.Mock;
+
 	beforeEach(() => {
 		mockedExecuteWithDeduplication.mockReset();
+		mockedBooleanFeatureFlags[BooleanFlags.USE_BACKFILL_QUEUE_SUPPLIER] = true;
+	});
+
+	afterEach(() => {
+		mockedBooleanFeatureFlags = {};
+		(backfillQueue.schedule as jest.Mock).mockReset();
 	});
 
 	describe("isRetryableWithSmallerRequest()", () => {
@@ -89,20 +114,20 @@ describe("sync/installation", () => {
 		const logger = getLogger('test');
 
 		test('should process the installation with deduplication', async () => {
-			await processInstallation(app, queues)(job, logger);
+			await processInstallation(app, queues, () => Promise.resolve(backfillQueue))(job, logger);
 			expect(mockedExecuteWithDeduplication.mock.calls.length).toBe(1);
 		});
 
 		test('should reschedule the job if deduplicator is unsure', async () => {
 			mockedExecuteWithDeduplication.mockResolvedValue(DeduplicatorResult.E_NOT_SURE_TRY_AGAIN_LATER);
-			await processInstallation(app, queues)(job, logger);
-			expect(queues.installation.add.mock.calls).toEqual([[job.data, {delay: 60_000}]]);
+			await processInstallation(app, queues, () => Promise.resolve(backfillQueue))(job, logger);
+			expect(backfillQueueSchedule.mock.calls).toEqual([[job.data, 60_000]]);
 		});
 
 		test('should also reschedule the job if deduplicator is sure', async () => {
 			mockedExecuteWithDeduplication.mockResolvedValue(DeduplicatorResult.E_OTHER_WORKER_DOING_THIS_JOB);
-			await processInstallation(app, queues)(job, logger);
-			expect(queues.installation.add.mock.calls.length).toEqual(1);
+			await processInstallation(app, queues, () => Promise.resolve(backfillQueue))(job, logger);
+			expect(backfillQueueSchedule.mock.calls.length).toEqual(1);
 		});
 	});
 
@@ -113,28 +138,29 @@ describe("sync/installation", () => {
 			};
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore
-			maybeScheduleNextTask(queue as Queue.Queue, {foo: 'bar'}, [], getLogger('test'));
-			expect(queue.add.mock.calls).toHaveLength(0);
+			maybeScheduleNextTask(queue as Queue.Queue, backfillQueue, {foo: 'bar'}, [], getLogger('test'));
+			expect(backfillQueueSchedule.mock.calls).toHaveLength(0);
 		});
 
-		test('when multiple tasks, picks the one with the highest delay', () => {
+		test('when multiple tasks, picks the one with the highest delay', async () => {
 			const queue = {
 				add: jest.fn()
 			};
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore
-			maybeScheduleNextTask(queue as Queue.Queue, {foo: 'bar'}, [30, 60, 0], getLogger('test'));
-			expect(queue.add.mock.calls).toEqual([[{foo: 'bar'}, {'delay': 60}]]);
+
+			await maybeScheduleNextTask(queue as Queue.Queue, backfillQueue, {foo: 'bar'}, [30, 60, 0], getLogger('test'));
+			expect(backfillQueueSchedule.mock.calls).toEqual([[{foo: 'bar'}, 60]]);
 		});
 
-		test('not passing delay to queue when not provided', () => {
+		test('not passing delay to queue when not provided', async () => {
 			const queue = {
 				add: jest.fn()
 			};
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore
-			maybeScheduleNextTask(queue as Queue.Queue, {foo: 'bar'}, [0], getLogger('test'));
-			expect(queue.add.mock.calls).toEqual([[{foo: 'bar'}]]);
+			await maybeScheduleNextTask(queue as Queue.Queue, backfillQueue, {foo: 'bar'}, [0], getLogger('test'));
+			expect(backfillQueueSchedule.mock.calls).toEqual([[{foo: 'bar'}, 0]]);
 		});
 	});
 });

--- a/test/unit/sync/pull-requests.test.ts
+++ b/test/unit/sync/pull-requests.test.ts
@@ -115,7 +115,7 @@ describe.skip("sync/pull-request", () => {
 				properties: { installationId: 1234 }
 			}).reply(200);
 
-			await expect(processInstallation(app, queues)(job, getLogger("test"))).toResolve();
+			await expect(processInstallation(app, queues, jest.fn())(job, getLogger("test"))).toResolve();
 		});
 	});
 
@@ -128,7 +128,7 @@ describe.skip("sync/pull-request", () => {
 		const interceptor = jiraNock.post(/.*/);
 		const scope = interceptor.reply(200);
 
-		await expect(processInstallation(app, queues)(job, getLogger("test"))).toResolve();
+		await expect(processInstallation(app, queues, jest.fn())(job, getLogger("test"))).toResolve();
 		expect(queues.pullRequests.add).not.toHaveBeenCalled();
 		expect(scope).not.toBeDone();
 		nock.removeInterceptor(interceptor);
@@ -147,7 +147,7 @@ describe.skip("sync/pull-request", () => {
 		const interceptor = jiraNock.post(/.*/);
 		const scope = interceptor.reply(200);
 
-		await expect(processInstallation(app, queues)(job, getLogger("test"))).toResolve();
+		await expect(processInstallation(app, queues, jest.fn())(job, getLogger("test"))).toResolve();
 		expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts);
 		expect(scope).not.toBeDone();
 		nock.removeInterceptor(interceptor);


### PR DESCRIPTION
Once we remove the FF, the sync code will become queue-agnostic which we could use with both SQS and Redis queues (another step towards the migration)