### PR TITLE
ARC-872: use GraphQL to count repos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8092,7 +8092,7 @@
       "dependencies": {
         "clone": {
           "version": "2.1.2",
-          "resolved": "https://packages.atlassian.com/api/npm/npm-remote/clone/-/clone-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
           "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
         }
       }
@@ -10024,7 +10024,7 @@
     },
     "semver-compare": {
       "version": "1.0.0",
-      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/semver-compare/-/semver-compare-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "semver-diff": {

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -29,7 +29,8 @@ export enum BooleanFlags {
 	TRACE_LOGGING = "trace-logging",
 	USE_SQS_FOR_BACKFILL = "use-sqs-for-backfill",
 	SUPPORT_BRANCH_AND_MERGE_WORKFLOWS_FOR_BUILDS = "support-branch-and-merge-workflows-for-builds",
-	USE_NEW_GITHUB_CLIENT_FOR_PUSH = "use-new-github-client-for-push"
+	USE_NEW_GITHUB_CLIENT_FOR_PUSH = "use-new-github-client-for-push",
+	USE_NEW_GITHUB_CLIENT_TO_COUNT_REPOS = "use-new-github-client-to-count-repos"
 }
 
 export enum StringFlags {

--- a/src/frontend/get-github-configuration.ts
+++ b/src/frontend/get-github-configuration.ts
@@ -8,6 +8,8 @@ import { Octokit } from "@octokit/rest";
 import { booleanFlag, BooleanFlags } from "../config/feature-flags";
 import { Errors } from "../config/errors";
 import { Tracer } from "../config/tracer";
+import GitHubClient from "../github/client/github-client";
+import { getLogger } from "../config/logger";
 
 const getConnectedStatus = (
 	installationsWithSubscriptions: any,
@@ -53,7 +55,7 @@ const installationConnectedStatus = async (
 	return mergeByLogin(installationsWithAdmin, connectedStatuses);
 };
 
-async function getInstallationsWithAdmin(installations: Octokit.AppsListInstallationsForAuthenticatedUserResponseInstallationsItem[], login: string, isAdmin: (args: { org: string, username: string, type: string }) => Promise<boolean>): Promise<InstallationWithAdmin[]> {
+async function getInstallationsWithAdmin(jiraHost: string, installations: Octokit.AppsListInstallationsForAuthenticatedUserResponseInstallationsItem[], login: string, isAdmin: (args: { org: string, username: string, type: string }) => Promise<boolean>): Promise<InstallationWithAdmin[]> {
 	const installationsWithAdmin: InstallationWithAdmin[] = [];
 
 	for (const installation of installations) {
@@ -65,21 +67,35 @@ async function getInstallationsWithAdmin(installations: Octokit.AppsListInstalla
 			type: installation.target_type
 		});
 
-		const authedApp = await app.auth(installation.id);
-		enhanceOctokit(authedApp);
+		if(await booleanFlag(BooleanFlags.USE_NEW_GITHUB_CLIENT_TO_COUNT_REPOS, true, jiraHost)){
+			const githubClient = new GitHubClient(installation.id, getLogger("getInstallationsWithAdmin"));
+			const numberOfReposPromise = githubClient.getNumberOfReposForInstallation();
 
-		const repositories = authedApp.paginate(
-			authedApp.apps.listRepos.endpoint.merge({ per_page: 100 }),
-			(res) => res.data
-		);
+			const [admin, numberOfRepos] = await Promise.all([checkAdmin, numberOfReposPromise]);
 
-		const [admin, numberOfRepos] = await Promise.all([checkAdmin, repositories]);
+			installationsWithAdmin.push({
+				...installation,
+				numberOfRepos: numberOfRepos || 0,
+				admin
+			});
+		}else {
 
-		installationsWithAdmin.push({
-			...installation,
-			numberOfRepos: numberOfRepos.length || 0,
-			admin
-		});
+			const authedApp = await app.auth(installation.id);
+			enhanceOctokit(authedApp);
+
+			const repositories = authedApp.paginate(
+				authedApp.apps.listRepos.endpoint.merge({ per_page: 100 }),
+				(res) => res.data
+			);
+
+			const [admin, numberOfRepos] = await Promise.all([checkAdmin, repositories]);
+
+			installationsWithAdmin.push({
+				...installation,
+				numberOfRepos: numberOfRepos.length || 0,
+				admin
+			});
+		}
 	}
 	return installationsWithAdmin;
 }
@@ -164,7 +180,7 @@ export default async (req: Request, res: Response, next: NextFunction): Promise<
 
 		tracer.trace(`got user's installations from GitHub`);
 
-		const installationsWithAdmin = await getInstallationsWithAdmin(installations, login, isAdmin);
+		const installationsWithAdmin = await getInstallationsWithAdmin(jiraHost, installations, login, isAdmin);
 
 		tracer.trace(`got user's installations with admin status from GitHub`);
 

--- a/src/frontend/get-jira-configuration.ts
+++ b/src/frontend/get-jira-configuration.ts
@@ -18,7 +18,7 @@ function mapSyncStatus(syncStatus: string): string {
 	}
 }
 
-export async function getInstallation(client, subscription, reqLog?) {
+export async function 	getInstallation(client, subscription, reqLog?) {
 	const id = subscription.gitHubInstallationId;
 	try {
 		const response = await client.apps.getInstallation({ installation_id: id });

--- a/src/github/client/github-client.ts
+++ b/src/github/client/github-client.ts
@@ -95,7 +95,6 @@ export default class GitHubClient {
 			},
 			urlParams,
 		});
-		//TODO: error handling
 		return response;
 	}
 
@@ -110,7 +109,6 @@ export default class GitHubClient {
 					installationId: this.githubInstallationId,
 				}
 			});
-		//TODO: error handling
 	}
 
 	/**

--- a/src/github/client/github-client.ts
+++ b/src/github/client/github-client.ts
@@ -166,7 +166,7 @@ export default class GitHubClient {
 				}
 			}`)
 
-		return response?.data?.viewer?.repositories?.totalCount as number;
+		return response?.data?.data?.viewer?.repositories?.totalCount as number;
 	}
 
 }


### PR DESCRIPTION
Replacing the iteration through all repositories, with a single GraphQL call. (Iteration was used to count all repos). 

At the same time the new GitHub Client is used to make GraphQL call