### PR TITLE
Change name of util url function to better describe it

### DIFF
--- a/src/frontend/get-github-setup.ts
+++ b/src/frontend/get-github-setup.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { getGitHubConfigurationUrl, getJiraMarketplaceUrl } from "../util/get-url";
+import { getJiraAppUrl, getJiraMarketplaceUrl } from "../util/get-url";
 
 /*
 	Handles redirects for both the installation flow from Jira and
@@ -13,7 +13,7 @@ export default async (req: Request, res: Response): Promise<void> => {
 	req.log.info("Received get github setup page request");
 	const { jiraHost } = res.locals;
 	if (req.headers.referer && jiraHost) {
-		return res.redirect(getGitHubConfigurationUrl(jiraHost));
+		return res.redirect(getJiraAppUrl(jiraHost));
 	}
 	const marketplaceUrl = jiraHost ? getJiraMarketplaceUrl(jiraHost) : undefined;
 

--- a/src/util/get-url.ts
+++ b/src/util/get-url.ts
@@ -1,6 +1,6 @@
 import envVars from "../config/env";
 
-export const getGitHubConfigurationUrl = (jiraHost: string): string =>
+export const getJiraAppUrl = (jiraHost: string): string =>
 	jiraHost?.length ? `${jiraHost}/plugins/servlet/ac/com.github.integration.${envVars.INSTANCE_NAME}/github-post-install-page` : "";
 
 export const getJiraMarketplaceUrl = (jiraHost: string): string =>

--- a/test/unit/util/get-url.test.ts
+++ b/test/unit/util/get-url.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import envVars from "../../../src/config/env";
-import { getGitHubConfigurationUrl, getJiraMarketplaceUrl } from "../../../src/util/get-url";
+import { getJiraAppUrl, getJiraMarketplaceUrl } from "../../../src/util/get-url";
 
 describe("Get URL Utils", () => {
 	describe("getGitHubConfigurationUrl", () => {
@@ -9,18 +9,18 @@ describe("Get URL Utils", () => {
 		afterEach(() => envVars.INSTANCE_NAME = instanceName);
 
 		it("should return the correct default URL", () => {
-			expect(getGitHubConfigurationUrl(jiraHost)).toEqual(`${jiraHost}/plugins/servlet/ac/com.github.integration.test-atlassian-instance/github-post-install-page`);
-			expect(getGitHubConfigurationUrl("https://foo.com")).toEqual(`https://foo.com/plugins/servlet/ac/com.github.integration.test-atlassian-instance/github-post-install-page`);
+			expect(getJiraAppUrl(jiraHost)).toEqual(`${jiraHost}/plugins/servlet/ac/com.github.integration.test-atlassian-instance/github-post-install-page`);
+			expect(getJiraAppUrl("https://foo.com")).toEqual(`https://foo.com/plugins/servlet/ac/com.github.integration.test-atlassian-instance/github-post-install-page`);
 		});
 
 		it("should return the correct URL for different INSTANCE_NAME", () => {
 			envVars.INSTANCE_NAME = "foo";
-			expect(getGitHubConfigurationUrl(jiraHost)).toEqual(`${jiraHost}/plugins/servlet/ac/com.github.integration.foo/github-post-install-page`);
+			expect(getJiraAppUrl(jiraHost)).toEqual(`${jiraHost}/plugins/servlet/ac/com.github.integration.foo/github-post-install-page`);
 		});
 
 		it("should return empty string if missing jiraHost", () => {
-			expect(getGitHubConfigurationUrl("")).toEqual("");
-			expect(getGitHubConfigurationUrl(undefined as any)).toEqual("");
+			expect(getJiraAppUrl("")).toEqual("");
+			expect(getJiraAppUrl(undefined as any)).toEqual("");
 		});
 	});
 

--- a/test/unit/util/get-url.test.ts
+++ b/test/unit/util/get-url.test.ts
@@ -3,7 +3,7 @@ import envVars from "../../../src/config/env";
 import { getJiraAppUrl, getJiraMarketplaceUrl } from "../../../src/util/get-url";
 
 describe("Get URL Utils", () => {
-	describe("getGitHubConfigurationUrl", () => {
+	describe("getJiraAppUrl", () => {
 		let instanceName:string;
 		beforeEach(() => instanceName = envVars.INSTANCE_NAME);
 		afterEach(() => envVars.INSTANCE_NAME = instanceName);


### PR DESCRIPTION
From `getGitHubConfigurationUrl` to `getJiraAppUrl` as it wasn't getting the github configuration page, but instead would return to the app installation if it was already installed on the jira host.