### PR TITLE
ARC-642: changing GitHub auth for isAdmin()

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -456,6 +456,17 @@ environmentOverrides:
         name: cache
         attributes:
           size: 5000
+        alarms:
+          AlarmOnNumConnections:
+            MetricName: CurrConnections
+            Description: "The number of client connections is too high. Please follow the runbook: https://hello.atlassian.net/wiki/spaces/PF/pages/1453195358/HOWTO+Investigate+Redis+Issues"
+            Threshold: 10000
+            EvaluationPeriods: 3
+            Period: 120
+            Priority: Low
+            ComparisonOperator: GreaterThanThreshold
+            Statistic: Maximum
+            Unit: Count
 
       - name: database
         type: postgres-db

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -24,7 +24,8 @@ export enum BooleanFlags {
 	USE_SQS_FOR_BACKFILL = "use-sqs-for-backfill",
 	SUPPORT_BRANCH_AND_MERGE_WORKFLOWS_FOR_BUILDS = "support-branch-and-merge-workflows-for-builds",
 	USE_NEW_GITHUB_CLIENT_FOR_PUSH = "use-new-github-client-for-push",
-	USE_NEW_GITHUB_CLIENT_TO_COUNT_REPOS = "use-new-github-client-to-count-repos"
+	USE_NEW_GITHUB_CLIENT_TO_COUNT_REPOS = "use-new-github-client-to-count-repos",
+	CALL_IS_ADMIN_AS_APP = "call-is-admin-as-app"
 }
 
 export enum StringFlags {

--- a/src/frontend/get-github-configuration.ts
+++ b/src/frontend/get-github-configuration.ts
@@ -152,8 +152,8 @@ export default async (req: Request, res: Response, next: NextFunction): Promise<
 
 	tracer.trace(`found jira host: ${jiraHost}`);
 
-	const github: GitHubAPI = res.locals.github;
-	const client: GitHubAPI = res.locals.client;
+	const github: GitHubAPI = res.locals.github; // user-authenticated GitHub client
+	const client: GitHubAPI = res.locals.client; // app-authenticated GitHub client
 	const isAdmin = res.locals.isAdmin;
 
 	tracer.trace(`isAdmin: ${isAdmin}`);

--- a/src/frontend/github-client-middleware.ts
+++ b/src/frontend/github-client-middleware.ts
@@ -38,11 +38,11 @@ export const isAdmin = (githubClient: GitHubAPI, logger: Logger) =>
 				data: { role }
 			} = await githubClient.orgs.getMembership({ org, username });
 
-			logger.info(`isAdmin: User ${username} has ${role} role`);
+			logger.info(`isAdmin: User ${username} has ${role} role for org ${org}`);
 
 			return role === "admin";
 		} catch (err) {
-			logger.warn({err, org, username}, `${org} has not accepted new permission for getOrgMembership`);
+			logger.warn({err, org, username}, `could not determine admin status of user ${username} in org ${org}`);
 			return false;
 		}
 	};

--- a/src/frontend/github-client-middleware.ts
+++ b/src/frontend/github-client-middleware.ts
@@ -3,8 +3,9 @@ import { NextFunction, Request, RequestHandler, Response } from "express";
 import { App } from "@octokit/app";
 import { GitHubAPI } from "probot";
 import Logger from "bunyan";
+import { booleanFlag, BooleanFlags } from "../config/feature-flags";
 
-export default (octokitApp: App): RequestHandler => (req: Request, res: Response, next: NextFunction): void => {
+export default (octokitApp: App): RequestHandler => async (req: Request, res: Response, next: NextFunction): Promise<void> => {
 	if (req.session.githubToken) {
 		res.locals.github = GithubAPI({
 			auth: req.session.githubToken
@@ -16,7 +17,14 @@ export default (octokitApp: App): RequestHandler => (req: Request, res: Response
 	res.locals.client = GithubAPI({
 		auth: octokitApp.getSignedJsonWebToken()
 	});
-	res.locals.isAdmin = isAdmin(res.locals.github, req.log);
+
+	if (res.locals.jiraHost && await booleanFlag(BooleanFlags.CALL_IS_ADMIN_AS_APP, true, res.locals.jiraHost)){
+		req.log.info(`using app-authenticated github client for jira host ${res.locals.jiraHost}`);
+		res.locals.isAdmin = isAdmin(res.locals.client, req.log);
+	} else {
+		req.log.info(`using user-authenticated github client for jira host ${res.locals.jiraHost}`);
+		res.locals.isAdmin = isAdmin(res.locals.github, req.log);
+	}
 
 	next();
 };
@@ -42,7 +50,7 @@ export const isAdmin = (githubClient: GitHubAPI, logger: Logger) =>
 
 			return role === "admin";
 		} catch (err) {
-			logger.warn({err, org, username}, `could not determine admin status of user ${username} in org ${org}`);
+			logger.warn({ err, org, username }, `could not determine admin status of user ${username} in org ${org}`);
 			return false;
 		}
 	};


### PR DESCRIPTION
The `isAdmin()` function currently uses an user-based authentication. This PR changes it to an app-based auth in the hopes of fixing some IP allowlisting issues. 

Feature flag: https://hello.atlassian.net/browse/FD-28625