### PR TITLE
Fd 28420 cleanup

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -23,7 +23,6 @@ export enum BooleanFlags {
 	TRACE_LOGGING = "trace-logging",
 	SUPPORT_BRANCH_AND_MERGE_WORKFLOWS_FOR_BUILDS = "support-branch-and-merge-workflows-for-builds",
 	USE_NEW_GITHUB_CLIENT_FOR_PUSH = "use-new-github-client-for-push",
-	USE_NEW_GITHUB_CLIENT_TO_COUNT_REPOS = "use-new-github-client-to-count-repos",
 	REPO_SYNC_STATE_AS_SOURCE = "repo-sync-state-as-source",
 	USE_SQS_FOR_DEPLOYMENT = "use-sqs-for-deployment",
 	ASSOCIATE_PR_TO_ISSUES_IN_BODY = "associate-pr-to-issues-in-body"

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -25,7 +25,6 @@ export enum BooleanFlags {
 	USE_NEW_GITHUB_CLIENT_FOR_PUSH = "use-new-github-client-for-push",
 	USE_NEW_GITHUB_CLIENT_TO_COUNT_REPOS = "use-new-github-client-to-count-repos",
 	REPO_SYNC_STATE_AS_SOURCE = "repo-sync-state-as-source",
-	USE_SQS_FOR_DISCOVERY_QUEUE = "use-sqs-for-discovery-queue",
 	USE_SQS_FOR_DEPLOYMENT = "use-sqs-for-deployment",
 	ASSOCIATE_PR_TO_ISSUES_IN_BODY = "associate-pr-to-issues-in-body"
 }

--- a/src/frontend/get-github-configuration.ts
+++ b/src/frontend/get-github-configuration.ts
@@ -1,7 +1,5 @@
 import { Installation, Subscription } from "../models";
 import { NextFunction, Request, Response } from "express";
-import enhanceOctokit from "../config/enhance-octokit";
-import app from "../worker/app";
 import { getInstallation } from "./get-jira-configuration";
 import { GitHubAPI } from "probot";
 import { Octokit } from "@octokit/rest";
@@ -55,8 +53,7 @@ const installationConnectedStatus = async (
 	return mergeByLogin(installationsWithAdmin, connectedStatuses);
 };
 
-async function getInstallationsWithAdmin(jiraHost: string,
-	log: Logger,
+async function getInstallationsWithAdmin(log: Logger,
 	installations: Octokit.AppsListInstallationsForAuthenticatedUserResponseInstallationsItem[],
 	login: string,
 	isAdmin: (args: { org: string, username: string, type: string }) => Promise<boolean>): Promise<InstallationWithAdmin[]> {
@@ -71,37 +68,18 @@ async function getInstallationsWithAdmin(jiraHost: string,
 			type: installation.target_type
 		});
 
-		if(await booleanFlag(BooleanFlags.USE_NEW_GITHUB_CLIENT_TO_COUNT_REPOS, true, jiraHost)){
-			const githubClient = new GitHubClient(installation.id, log);
-			const numberOfReposPromise = githubClient.getNumberOfReposForInstallation();
+		const githubClient = new GitHubClient(installation.id, log);
+		const numberOfReposPromise = githubClient.getNumberOfReposForInstallation();
 
-			const [admin, numberOfRepos] = await Promise.all([checkAdmin, numberOfReposPromise]);
+		const [admin, numberOfRepos] = await Promise.all([checkAdmin, numberOfReposPromise]);
 
-			log.info("Number of repos in the org received via GraphQL: " + numberOfRepos);
+		log.info("Number of repos in the org received via GraphQL: " + numberOfRepos);
 
-			installationsWithAdmin.push({
-				...installation,
-				numberOfRepos: numberOfRepos || 0,
-				admin
-			});
-		}else {
-
-			const authedApp = await app.auth(installation.id);
-			enhanceOctokit(authedApp);
-
-			const repositories = authedApp.paginate(
-				authedApp.apps.listRepos.endpoint.merge({ per_page: 100 }),
-				(res) => res.data
-			);
-
-			const [admin, numberOfRepos] = await Promise.all([checkAdmin, repositories]);
-
-			installationsWithAdmin.push({
-				...installation,
-				numberOfRepos: numberOfRepos.length || 0,
-				admin
-			});
-		}
+		installationsWithAdmin.push({
+			...installation,
+			numberOfRepos: numberOfRepos || 0,
+			admin
+		});
 	}
 	return installationsWithAdmin;
 }
@@ -185,7 +163,7 @@ export default async (req: Request, res: Response, next: NextFunction): Promise<
 
 		tracer.trace(`got user's installations from GitHub`);
 
-		const installationsWithAdmin = await getInstallationsWithAdmin(jiraHost, log, installations, login, isAdmin);
+		const installationsWithAdmin = await getInstallationsWithAdmin(log, installations, login, isAdmin);
 
 		tracer.trace(`got user's installations with admin status from GitHub`);
 

--- a/src/sync/sync-utils.ts
+++ b/src/sync/sync-utils.ts
@@ -1,6 +1,5 @@
 import {booleanFlag, BooleanFlags} from "../config/feature-flags";
 import RepoSyncState from "../models/reposyncstate";
-import {queues} from "../worker/queues";
 import sqsQueues from "../sqs/queues";
 import Subscription from "../models/subscription";
 import {LoggerWithTarget} from "probot/lib/wrap-logger";
@@ -29,11 +28,7 @@ export async function findOrStartSync(
 			await RepoSyncState.resetSyncFromSubscription(subscription);
 		}
 		logger.info("Starting Jira sync");
-		if(await booleanFlag(BooleanFlags.USE_SQS_FOR_DISCOVERY_QUEUE, false, subscription.jiraHost)) {
-			await sqsQueues.discovery.sendMessage({installationId, jiraHost}, 0, logger)
-		} else {
-			await queues.discovery.add({installationId, jiraHost});
-		}
+		await sqsQueues.discovery.sendMessage({installationId, jiraHost}, 0, logger)
 		return;
 	}
 


### PR DESCRIPTION
In this PR I am cleaning up another flag `use-new-github-client-to-count-repos` 

I've made it on the top of https://github.com/atlassian/github-for-jira/pull/1008 so you can review them separately but merge at once