### PR TITLE
VULN-645422: bump alpine to 3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17-alpine3.15 as build
+FROM node:14.18-alpine3.15 as build
 
 # adding python for node-gyp
 RUN apk add g++ make python3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17-alpine3.14 as build
+FROM node:14.17-alpine3.15 as build
 
 # adding python for node-gyp
 RUN apk add g++ make python3


### PR DESCRIPTION
Fixing VULN-645422.

alpine:3.14 has a high sev issue that was introduced by a vulnerable module (busybox). More details [here](https://snyk.io/test/docker/alpine%3A3.14.2?tab=dependencies)
alpine:15 fixed the issue. More details [here](https://snyk.io/test/docker/alpine%3A3.15?tab=dependencies)

We're using it in conjunction with node though and `node:14.17-alpine3.15` isn't a valid tag, so I bumped to `node:14.18-alpine3.15`. See valid tags [here](https://hub.docker.com/_/node).

