### PR TITLE
Removed use-new-github-client-for-push feature flag, removed `bull` dependency from push processor

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -22,7 +22,6 @@ export enum BooleanFlags {
 	SUPPORT_BRANCH_AND_MERGE_WORKFLOWS_FOR_DEPLOYMENTS = "support-branch-and-merge-workflows-for-deployments",
 	TRACE_LOGGING = "trace-logging",
 	SUPPORT_BRANCH_AND_MERGE_WORKFLOWS_FOR_BUILDS = "support-branch-and-merge-workflows-for-builds",
-	USE_NEW_GITHUB_CLIENT_FOR_PUSH = "use-new-github-client-for-push",
 	REPO_SYNC_STATE_AS_SOURCE = "repo-sync-state-as-source",
 	USE_SQS_FOR_DEPLOYMENT = "use-sqs-for-deployment",
 	USE_SQS_FOR_BRANCH = "use-sqs-for-branch",

--- a/src/github/client/github-client.ts
+++ b/src/github/client/github-client.ts
@@ -91,7 +91,6 @@ export default class GitHubClient {
 		const response = await this.axios.get<T>(url, {
 			...await this.installationAuthenticationHeaders(),
 			params: {
-				installationId: this.githubInstallationId,
 				...params,
 			},
 			urlParams,
@@ -106,9 +105,6 @@ export default class GitHubClient {
 			},
 			{
 				...await this.installationAuthenticationHeaders(),
-				params: {
-					installationId: this.githubInstallationId,
-				}
 			});
 	}
 

--- a/src/transforms/push.ts
+++ b/src/transforms/push.ts
@@ -1,23 +1,17 @@
 import {Subscription} from "../models";
 import getJiraClient from "../jira/client";
 import issueKeyParser from "jira-issue-key-parser";
-import enhanceOctokit from "../config/enhance-octokit";
-import {Application, GitHubAPI} from "probot";
-import {Job} from "bull";
 import {getJiraAuthor} from "../util/jira";
 import {emitWebhookProcessedMetrics} from "../util/webhooks";
 import {JiraCommit} from "../interfaces/jira";
 import _ from "lodash";
 import {LoggerWithTarget} from "probot/lib/wrap-logger";
-import {booleanFlag, BooleanFlags, isBlocked} from "../config/feature-flags";
+import {isBlocked} from "../config/feature-flags";
 import sqsQueues from "../sqs/queues";
 import {PushQueueMessagePayload} from "../sqs/push";
 import GitHubClient from "../github/client/github-client";
-import { getCloudInstallationId } from "../github/client/installation-id";
 
 // TODO: define better types for this file
-
-export const PUSH_LOGGER_NAME = "transforms.push";
 
 const mapFile = (
 	githubFile,
@@ -87,23 +81,7 @@ export async function enqueuePush(
 	return sqsQueues.push.sendMessage(createJobData(payload, jiraHost));
 }
 
-export function processPushJob(app: Application) {
-	return async (job: Job, logger: LoggerWithTarget): Promise<void> => {
-		let githubOld;
-		try {
-			githubOld = await app.auth(job.data.installationId);
-		} catch (err) {
-			logger.error({ err, job }, "Could not authenticate");
-			return;
-		}
-		enhanceOctokit(githubOld);
-
-		const github = new GitHubClient(getCloudInstallationId(job.data.installationId), logger);
-		await processPush(githubOld, github, job.data, logger);
-	};
-}
-
-export const processPush = async (githubOld: GitHubAPI, github: GitHubClient, payload, rootLogger: LoggerWithTarget) => {
+export const processPush = async (github: GitHubClient, payload: PushQueueMessagePayload, rootLogger: LoggerWithTarget) => {
 	const {
 		repository,
 		repository: { owner, name: repo },
@@ -150,18 +128,11 @@ export const processPush = async (githubOld: GitHubAPI, github: GitHubClient, pa
 		const commits: JiraCommit[] = await Promise.all(
 			shas.map(async (sha): Promise<JiraCommit> => {
 				log.info("Calling GitHub to fetch commit info " + sha.id);
-				const useNewGithubClient = await booleanFlag(BooleanFlags.USE_NEW_GITHUB_CLIENT_FOR_PUSH, false, subscription.jiraHost);
 				try {
 					const {
 						data,
 						data: {commit: githubCommit},
-					} = useNewGithubClient
-						? await github.getCommit(owner.login, repo, sha.id)
-						: await githubOld.repos.getCommit({
-							owner: owner.login,
-							repo,
-							ref: sha.id,
-						});
+					} = await github.getCommit(owner.login, repo, sha.id);
 
 					const {files, author, parents, sha: commitSha, html_url} = data;
 
@@ -173,7 +144,7 @@ export const processPush = async (githubOld: GitHubAPI, github: GitHubClient, pa
 					// merge commits will have 2 or more parents, depending how many are in the sequence
 					const isMergeCommit = parents?.length > 1;
 
-					console.info("GitHub call succeeded");
+					log.info("GitHub call succeeded");
 					return {
 						hash: commitSha,
 						message,
@@ -191,7 +162,7 @@ export const processPush = async (githubOld: GitHubAPI, github: GitHubClient, pa
 						flags: isMergeCommit ? ["MERGE_COMMIT"] : undefined,
 					}
 				} catch (err) {
-					console.warn({ err },"Failed to fetch data from GitHub");
+					log.warn({ err },"Failed to fetch data from GitHub");
 					throw err;
 				}
 			})

--- a/test/safe/branch.test.ts
+++ b/test/safe/branch.test.ts
@@ -38,6 +38,15 @@ describe("Branch Webhook", () => {
 			jiraHost,
 			jiraClientKey: clientKey
 		});
+
+		githubNock.post(`/app/installations/1234/access_tokens`)
+			.optionally()
+			.reply(200, {
+				expires_at: Date.now() + 3600,
+				permissions: {},
+				repositories: {},
+				token: "token"
+			})
 	});
 
 	afterEach(async () => {
@@ -58,14 +67,6 @@ describe("Branch Webhook", () => {
 
 			const ref = encodeURIComponent("heads/TES-123-test-ref");
 			const sha = "test-branch-ref-sha";
-
-			githubNock.post(`/app/installations/1234/access_tokens`)
-				.reply(200, {
-					expires_at: Date.now() + 3600,
-					permissions: {},
-					repositories: {},
-					token: "token"
-				})
 
 			githubNock.get(`/repos/test-repo-owner/test-repo-name/git/ref/${ref}`)
 				.reply(200, {


### PR DESCRIPTION
Second PR, here I did the following:

* Removed `use-new-github-client-for-push` feature flag
* Removed `bull` library dependency from the `push` queue processing code
* Changed integration test to use SQS handler instead of old redis job processor
* Removed installationID parameter from GitHub Client, which we were passing wrongly