### PR TITLE
propagate stack trace on GitHub API errors

### DIFF
--- a/src/github/client/errors.ts
+++ b/src/github/client/errors.ts
@@ -7,6 +7,7 @@ export class GithubClientError extends Error {
 		super(message);
 		this.status = status;
 		this.cause = { ...cause, config: {} };
+		this.stack = this.stack?.split("\n").slice(0, 2).join("\n") + "\n" + cause.stack
 	}
 }
 

--- a/test/github/client/errors.test.ts
+++ b/test/github/client/errors.test.ts
@@ -1,0 +1,23 @@
+import { BlockedIpError } from "../../../src/github/client/errors";
+
+describe("GitHubClientError", () => {
+
+	it("propagates the stacktrace", async () => {
+		const error = new BlockedIpError({
+			name: "BlockedIpError",
+			message: "ignored",
+			stack: "existing stack trace line 1\nexisting stack trace line 2\nexisting stack trace line 3",
+			config: {},
+			isAxiosError: true,
+			toJSON: () => {
+				return {};
+			}
+		});
+
+		expect(error.stack).toContain("Blocked by GitHub allowlist");
+		expect(error.stack).toContain("existing stack trace line 1");
+		expect(error.stack).toContain("existing stack trace line 2");
+		expect(error.stack).toContain("existing stack trace line 3");
+	});
+
+});


### PR DESCRIPTION
Currently, errors (like the infamous IP allowlist issue) don't propagate their stacktrace. That means, in the case of the IP allowlist issue, we can't see which IP addresses are being blocked, for example.

This PR makes it so that the stack trace is propagated