### PR TITLE
ARC-747 Remove warning about missing issue association

### DIFF
--- a/views/jira-configuration.hbs
+++ b/views/jira-configuration.hbs
@@ -168,52 +168,33 @@
 
                     {{! Backfill status }}
                     <td class="jiraConfiguration__table__cell">
-                      {{#if syncWarning}}
-                        <a
-                          href="#trigger"
-                          data-ak-tooltip="{{syncWarning}}"
-                          data-ak-tooltip-position="top"
-                          class="jiraConfiguration__table__syncWarningLink"
-                        >
-                          <span
-                            id="{{id}}-status"
-                            class="jiraConfiguration__table__{{toLowerCase
-                                (replaceSpaceWithHyphen syncStatus)
-                              }}
-                              jiraConfiguration__table__syncStatus"
+                      <span
+                        id="{{id}}-status"
+                        class="jiraConfiguration__table__{{toLowerCase
+                            (replaceSpaceWithHyphen syncStatus)
+                          }}
+                          jiraConfiguration__table__syncStatus"
+                      >
+                        {{syncStatus}}
+                      </span>
+                      {{#if (inProgressOrPendingSync syncStatus)}}
+                        <div class="jiraConfiguration__loaderContainer">
+                          <aui-spinner size="small"></aui-spinner>
+                        </div>
+                      {{/if}}
+                      {{#if (failedSync syncStatus)}}
+                        <div class="jiraConfiguration__retryContainer">
+                          <button
+                            class="jiraConfiguration__retry sync-connection-link restart-backfill-button"
+                            data-jira-host="{{ ../host }}"
+                            data-installation-id="{{ id }}"
+                            id="restart-backfill"
                           >
-                            {{syncStatus}}
-                          </span>*
-                        </a>
-                      {{else}}
-                        <span
-                          id="{{id}}-status"
-                          class="jiraConfiguration__table__{{toLowerCase
-                              (replaceSpaceWithHyphen syncStatus)
-                            }}
-                            jiraConfiguration__table__syncStatus"
-                        >
-                          {{syncStatus}}
-                        </span>
-                        {{#if (inProgressOrPendingSync syncStatus)}}
-                          <div class="jiraConfiguration__loaderContainer">
-                            <aui-spinner size="small"></aui-spinner>
-                          </div>
-                        {{/if}}
-                        {{#if (failedSync syncStatus)}}
-                          <div class="jiraConfiguration__retryContainer">
-                            <button
-                              class="jiraConfiguration__retry sync-connection-link restart-backfill-button"
-                              data-jira-host="{{ ../host }}"
-                              data-installation-id="{{ id }}"
-                              id="restart-backfill"
-                            >
-                              &#x21bb;
-                            </button>
-                            <input type="hidden" id="_csrf" name="_csrf" value="{{../csrfToken}}">
-                            <div class="jiraConfiguration__retryMsg">Retry</div>
-                          </div>
-                        {{/if}}
+                            &#x21bb;
+                          </button>
+                          <input type="hidden" id="_csrf" name="_csrf" value="{{../csrfToken}}">
+                          <div class="jiraConfiguration__retryMsg">Retry</div>
+                        </div>
                       {{/if}}
                     </td>
 


### PR DESCRIPTION
In-depth context: https://atlassian.slack.com/archives/C01PERFAUHZ/p1633927476248100 

Summary: the * and message we added to show customers the issue key reference limit had been exceeded was causing problems where there didn't need to be problems. Essentially, we were drawing attention to something customers will most likely not even notice. Because of this, we have decided to simply remove it altogether.

<img width="537" alt="Screen Shot 2022-01-25 at 12 35 36 pm" src="https://user-images.githubusercontent.com/37155488/150894343-f851ba90-bd30-40db-9f10-b5274a5fc250.png">

Somewhat long video of me installing and uninstalling orgs to make sure nothing broke.

https://user-images.githubusercontent.com/37155488/150894472-2c1fb19f-d4b4-4879-affa-cc550da2703f.mov

 