### PR TITLE
fixing order of middleware because it can break things

### DIFF
--- a/src/jira/client/axios.ts
+++ b/src/jira/client/axios.ts
@@ -240,8 +240,9 @@ export default (
 		instrumentFailedRequest()
 	);
 
-	instance.interceptors.request.use(getAuthMiddleware(secret));
+	// URL params need to be before auth to get the correct path
 	instance.interceptors.request.use(urlParamsMiddleware);
+	instance.interceptors.request.use(getAuthMiddleware(secret));
 
 	instance.interceptors.response.use(
 		getSuccessMiddleware(logger),


### PR DESCRIPTION
order of interceptors is important because auth middleware uses the path (made by URL params) to create the token