### PR TITLE
clearing redis keys before tests to prevent having test data still there

### DIFF
--- a/test/setup/setup.ts
+++ b/test/setup/setup.ts
@@ -5,9 +5,13 @@ import "./matchers/nock";
 import "./matchers/to-promise";
 import { sequelize } from "../../src/models/sequelize";
 import { mocked } from "ts-jest/utils";
+import Redis from "ioredis";
+import getRedisInfo from "../../src/config/redis-info";
 // WARNING: Be very careful what you import here as it might affect test
 // in other tests because of dependency tree.  Keep imports to a minimum.
 jest.mock("lru-cache");
+
+const redis = new Redis(getRedisInfo("test"));
 
 type AccessTokenNockFunc = (id: number, returnToken?: string, expires?: number, expectedAuthToken?: string) => void
 type MockSystemTimeFunc = (time: number | string | Date) => jest.MockInstance<number, []>;
@@ -67,6 +71,9 @@ const accessToken = (scope: nock.Scope): AccessTokenNockFunc =>
 beforeAll(async () => {
 	resetEnvVars();
 	await clearState();
+	// clear redis keys
+	await redis.flushall();
+	redis.disconnect();
 });
 
 beforeEach(() => {


### PR DESCRIPTION
While doing tests, I stopped a test halfway through and when I restarted it, some tests data was still in redis (deduplicator) which made my tests fail.  After scratching my head for a while, I figured out the issue and had to stop the redis docker container and delete the volume, then spin it back up.

This prevents having to do that extra work or waste time head scratching.