### PR TITLE
Use url params for GitHub installation Id

### DIFF
--- a/src/github/client/github-client.ts
+++ b/src/github/client/github-client.ts
@@ -88,8 +88,11 @@ export default class GitHubClient {
 	 * API in the name of an installation of that app (to access the users' data).
 	 */
 	private async createInstallationToken(githubInstallationId: number): Promise<AuthToken> {
-		const response = await this.axios.post<Octokit.AppsCreateInstallationTokenResponse>(`/app/installations/${githubInstallationId}/access_tokens`, {}, {
-			...this.appAuthenticationHeaders()
+		const response = await this.axios.post<Octokit.AppsCreateInstallationTokenResponse>(`/app/installations/{githubInstallationId}/access_tokens`, {}, {
+			...this.appAuthenticationHeaders(),
+			urlParams: {
+				githubInstallationId
+			}
 		});
 		const tokenResponse: Octokit.AppsCreateInstallationTokenResponse = response.data;
 		return new AuthToken(tokenResponse.token, new Date(tokenResponse.expires_at));
@@ -104,7 +107,7 @@ export default class GitHubClient {
 	}
 
 	private async graphql<T>(query: string, variables?: Record<string, string | number | undefined>): Promise<AxiosResponse<GraphQlQueryResponse<T>>> {
-		const response = await this.axios.post<GraphQlQueryResponse<T>>(this.githubInstallationId.githubBaseUrl +"/graphql",
+		const response = await this.axios.post<GraphQlQueryResponse<T>>("/graphql",
 			{
 				query,
 				variables


### PR DESCRIPTION
Because we use path of the original URL as a metric tag, doing this:
```
this.axios.post<Octokit.AppsCreateInstallationTokenResponse>(`/app/installations/${githubInstallationId}/access_tokens`
```
exploded our metrics cardinality.

I've reeplaced it with urlParams