### PR TITLE
Added histogram metric for Jira client

### DIFF
--- a/src/jira/client/axios.ts
+++ b/src/jira/client/axios.ts
@@ -114,6 +114,7 @@ const setRequestStartTime = (config) => {
 export const extractPath = (someUrl = ""): string =>
 	decodeURIComponent(url.parse(someUrl).pathname || "");
 
+const RESPONSE_TIME_HISTOGRAM_BUCKETS = "100_1000_2000_3000_5000_10000_30000_60000";
 /**
  * Submit statsd metrics on successful requests.
  *
@@ -133,6 +134,8 @@ const instrumentRequest = (response) => {
 		status: response.status
 	};
 
+	statsd.histogram(metricHttpRequest.jira, requestDurationMs, tags);
+	tags["gsd_histogram"] = RESPONSE_TIME_HISTOGRAM_BUCKETS;
 	statsd.histogram(metricHttpRequest.jira, requestDurationMs, tags);
 
 	return response;


### PR DESCRIPTION
Currently Jira Client sends only old histogram metric. I've added another one with Histogram buckets like we do in other places.