### PR TITLE
fixing JWT QSH verification to use the correct request parameter for full path

### DIFF
--- a/src/jira/util/jwt.ts
+++ b/src/jira/util/jwt.ts
@@ -75,7 +75,8 @@ function decodeAsymmetricToken(token: string, publicKey: string, noVerify: boole
 
 
 function verifyQsh(qsh: string, req: Request): boolean {
-	const requestInAtlassianJwtFormat = {...req, pathname: req.path}
+	// to get full path from express request, we need to add baseUrl with path
+	const requestInAtlassianJwtFormat = {...req, pathname: req.baseUrl + req.path}
 	let expectedHash = createQueryStringHash(requestInAtlassianJwtFormat, false, BASE_URL);
 	let signatureHashVerified = qsh === expectedHash;
 
@@ -206,7 +207,6 @@ export const verifyAsymmetricJwtTokenMiddleware = async (req: Request, res: Resp
 		}
 
 		const publicKey = await queryAtlassianConnectPublicKey(getKeyId(token), isStagingTenant(req));
-
 		const unverifiedClaims = decodeAsymmetricToken(token, publicKey, true)
 
 		const issuer = unverifiedClaims.iss;
@@ -235,4 +235,3 @@ export const verifyAsymmetricJwtTokenMiddleware = async (req: Request, res: Resp
 		sendError(res, 401, "Unauthorized")
 	}
 }
-

--- a/test/setup/setup.ts
+++ b/test/setup/setup.ts
@@ -18,7 +18,9 @@ type MockSystemTimeFunc = (time: number | string | Date) => jest.MockInstance<nu
 
 declare global {
 	let jiraHost: string;
+	let jiraStaginHost: string;
 	let jiraNock: nock.Scope;
+	let jiraStagingNock: nock.Scope;
 	let githubNock: nock.Scope;
 	let gheNock: nock.Scope;
 	let gheUrl: string;
@@ -29,7 +31,9 @@ declare global {
 	namespace NodeJS {
 		interface Global {
 			jiraHost: string;
+			jiraStaginHost: string;
 			jiraNock: nock.Scope;
+			jiraStagingNock: nock.Scope;
 			githubNock: nock.Scope;
 			gheNock: nock.Scope;
 			gheUrl: string;
@@ -77,8 +81,10 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
-	global.jiraHost = process.env.ATLASSIAN_URL || "";
+	global.jiraHost = process.env.ATLASSIAN_URL || `https://${process.env.INSTANCE_NAME}.atlassian.net`;
+	global.jiraStaginHost = process.env.ATLASSIAN_URL?.replace(".atlassian.net", ".jira-dev.com") || `https://${process.env.INSTANCE_NAME}.jira-dev.com`;
 	global.jiraNock = nock(global.jiraHost);
+	global.jiraStagingNock = nock(global.jiraHost);
 	global.githubNock = nock("https://api.github.com");
 	global.gheUrl = "https://github.mydomain.com";
 	global.gheNock = nock(global.gheUrl);

--- a/test/unit/jira/util/jwt.test.ts
+++ b/test/unit/jira/util/jwt.test.ts
@@ -1,174 +1,155 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {
-	TokenType,
-	verifyAsymmetricJwtTokenMiddleware,
-	verifySymmetricJwtTokenMiddleware
-} from "../../../../src/jira/util/jwt";
-import logger from "../../../../src/config/logger"
-import {AsymmetricAlgorithm, encodeAsymmetric, encodeSymmetric} from "atlassian-jwt";
+import { TokenType, verifyAsymmetricJwtTokenMiddleware, verifySymmetricJwtTokenMiddleware } from "../../../../src/jira/util/jwt";
+import logger from "../../../../src/config/logger";
+import { AsymmetricAlgorithm, encodeAsymmetric, encodeSymmetric } from "atlassian-jwt";
 import queryAtlassianConnectPublicKey from "../../../../src/jira/util/queryAtlassianConnectPublicKey";
-import {when} from "jest-when";
+import { when } from "jest-when";
+import { Request, Response } from "express";
+import Mock = jest.Mock;
 
 jest.mock("../../../../src/jira/util/queryAtlassianConnectPublicKey");
 jest.mock("../../../../src/models");
 
-
-const testRequestMethod = "GET"
-const testRequestPath = "/jira/configuration";
-const testQueryParams = {
-	xdm_e: "https://kabakumov.atlassian.net",
-	xdm_c: "channel-com.github.integration.konstantin__github-post-install-page",
-	cp: "",
-	xdm_deprecated_addon_key_do_not_use: "com.github.integration.konstantin",
-	lic: "none",
-	cv: "1001.0.0-SNAPSHOT"
-}
-
 describe("jwt", () => {
-//Query string hash corresponding to the request parameters above
-	const testQsh = "345c5da1c34c5126155b18ff4522446c89cc017debe4878bfa6056cacd5245ae"
+	let testQueryParams: Record<string, string>;
+	let res: Response;
+	let baseRequest: Request;
 
-	const baseRequest = {
-		query: testQueryParams,
-		method: testRequestMethod,
-		path: testRequestPath,
-		session: {
-			jiraHost: "https://test.atlassian.net"
+	let next:Mock;
+	const testSecret = "testSecret";
+
+	// Query string hash corresponding to the request parameters above
+	const testQsh = "345c5da1c34c5126155b18ff4522446c89cc017debe4878bfa6056cacd5245ae";
+
+	// RAS keypair used to sign test tokens. Base64 encoded to prevent security scanning from being triggered
+	const testPrivateKey = Buffer.from(
+		"LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlDWFFJQkFBS0JnUUROL2ZXZXg5dXJ2VHRYWGY0aVlodmU0akJDaDg2Uk4zUHc5YW1SaVovU241TTdlY1JzCjNWZE5TR2FvRGNEZG1MaEYzczZkTUVlN2ZzTW9SVXZ3cit0VnoyL2JpSDBLOTh4dlFETzhaNHd3ZlRKbjNHSE8Kamg2Nk5YcE5lRDhobzBrMFllZXcveHBGMGU0cys4Tkg2b0Jna09OMTJoS29mQ2FQOEFDeXViYk93UUlEQVFBQgpBb0dBSDM2SW96SWpYK3FhdkF6ZTRocmw3L25kTHc3Y2drOWNKcWNvdWR1MDE5c1dBNjNtWGs2cEhtUEhia0pNCkRwVmU5eS9ObnpMV2hOQW92bXQ1NU43QXVDTzJaQm1pWXROY1BCckU0aUVXN1NDMjlZOEFOKzBvTHVYTmt6OFAKVURJeUVsWFRNakJ5cFZpN3RNellKaFlOM1FhMWdVVnR2TmNDN0t0WW95cXVWd0VDUVFEcXN6VktwYlNwNVMyRgpEdU5nYlVsaTdCMDgwakNTRlJ4dkQ5ek9WdmkxckRVSC9aV1JHcDFDaFE0TUdYR2FoQWxJaUVLNklFMVYxR1NpCmhJZFY0Q01KQWtFQTRLL0hDN09vdTBiU3hhVVVqclVTMmYzRzE5Tk1TNHIrbXhLZ2s4UnBFWWMzVzJpRjB3eDkKUHNCYlVkbGlyRVVHaUpLWEdXNTNPLzRTQUptOTlMYWorUUpCQUw4RFgwb0Rsd2YyNTVjMVNNVC83UXcva29RZgpwVHdmUm1iMWlBVy9MdWZjNGNSQkZHdG1ON3Nkd3hNQjJqMmhYRlRWNFVqT1pXS0hXK2dRNkh4eDBORUNRQS85CmNuVHF2RDlYc3ZoTjMwQ29za2JCUUwxclZDcXNJYUozbU9YclBHNzY2SDJnMnFWQ1prZG8rUmJDR2J1WXpmWTYKT0hhZTNlMXZEMmpyaUJFNlRrRUNRUUNGNXpndDlhSHlzeDJwQmJTcjlCZVdTdFExdUJlcEpSajh5Skg2NisyYQpaR1ZJOEY2Tk9HaERSRDhwakZrclcydXdoemhDbkZ4U2Nza3FVWm1BcHBuUwotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQ==",
+		"base64"
+	).toString("ascii");
+
+	const testPublicKey = Buffer.from(
+		"LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTkFEQ0JpUUtCZ1FETi9mV2V4OXVydlR0WFhmNGlZaHZlNGpCQwpoODZSTjNQdzlhbVJpWi9TbjVNN2VjUnMzVmROU0dhb0RjRGRtTGhGM3M2ZE1FZTdmc01vUlV2d3IrdFZ6Mi9iCmlIMEs5OHh2UURPOFo0d3dmVEpuM0dIT2poNjZOWHBOZUQ4aG8wazBZZWV3L3hwRjBlNHMrOE5INm9CZ2tPTjEKMmhLb2ZDYVA4QUN5dWJiT3dRSURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQ==",
+		"base64"
+	).toString("ascii");
+
+	const wrongPrivateKey = Buffer.from(
+		"LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlDV3dJQkFBS0JnRlVCSkFUdDJyd0M4NUtvdmM5eC9DYnZmTWdiRUw4UGorRmRlNUpENjJsK3B1WENJejk1CkJPMzIvUG9JNE5SNnZzWVhJN213UmsyV1A1VGV5dkxXVjFTYS9IekFqbWQxQzVlbGVJNkM5dERjYXVxU2VpR1UKQ2FTS0JVTkhmS3VBK0pCSi9GYUlZMWphTE1peGxCa09uYnNNZ1hxb0ZHSUtzZGhhMnBKaXJ6QXBBZ01CQUFFQwpnWUFFYmtMS1h2dC93VWVnNVZxL2JWbVBUZnhiRWM0VnAySUFoVGJqc05hY2NSV1I5RVNTRW1USFlwQmRHQWxnCkNlWFh2VzBIU01EaFdtdUYvdmJsSVhiN3lvd1JOSkxNVmpoYldScHU1dE1uVmErS0U3eDYrbFJjMzJ1dVVXYkkKL1MwdnJsTVJWYlZjYThqVGxLS1VsV0draWJzMWlhMVMvWlBmWFlqKzc5Ym9BUUpCQUo4c1lVcm9DK0ozR0k0TQovZmFHWUg3UWNGcm1HQm41YThZVVVJUTJYQnpwL1NmOU1CNTdpbnJzN2xTSHhrczk3QjNSNFkxOGMxclB0dXJECmZaWUxzK0VDUVFDSXRxVk54OXordmxpY3JyWTVqTUU5VUNjOGU0MTJnLzI2VHFVSzFnVEFoWVI3SHZObE5QeHoKUFlDZnUrVU5QK09wd2owQ1pkSktwYzZZMU13eGhZVkpBa0IvYlZZT1U2cUFDSHdkN0lTOEFXUHE0Zyt3bFpnaAo0eTNHaTZqUnozcjZvdEJLWFVWU2dmQ2c3R0Q0UnlJV1JtSnFsUVdPOFZ5Z0RMNFJQNk9ncFluQkFrQSs1eHJECjRQUFQyaXpYV3FQSmN2UHVqQlNoaFkrZk9qZmlJeEZaSFFQdXVRQXR6aDNiTVRmK3BndXFjejkraXlqckVNNFYKYmxnRnRLaU1OVTBHZEJMUkFrRUFsa1FxcjFiK3VKZG1PdHVFQmtEb09VeERvcmx6VkhtTVhwMjBKSjEyTm1KTgpOV1RDZm44YWs1c1lEdEZ1eEtCV3JPcEJVOXA2cEF6blVRR0hzaHI0N1E9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQ==",
+		"base64"
+	).toString("ascii");
+	const testKid = "1234435235352";
+
+	const buildRequestWithNoToken = () => baseRequest;
+
+	const buildRequest = (jwtValue: string) => ({
+		...baseRequest,
+		query: {
+			...testQueryParams,
+			jwt: jwtValue
 		},
-		addLogFields: jest.fn(),
-		log: logger
-	}
+		method: "GET",
+		path: "/configuration",
+		baseUrl: "/jira"
+	});
 
-	const buildRequestWithNoToken = (): any => {
-		return {
-			...baseRequest,
-		};
-	};
-
-	const buildRequest = (jwtValue: string) => {
-		return {
-			...baseRequest,
-			query: {
-				...testQueryParams,
-				jwt: jwtValue
-			},
-			method: testRequestMethod,
-			path: testRequestPath,
-		};
-	}
-
-	const next = jest.fn()
-
-
-	let res;
-
-	const testSecret = "testSecret"
+	const buildRequestWithJwt = (secret = "secret", qsh: string): any =>
+		buildRequest(
+			encodeSymmetric({
+				qsh: qsh,
+				iss: "jira"
+			}, secret)
+		);
 
 	beforeEach(async () => {
+		next = jest.fn();
+		// TODO: need to create a route with express Router and use supertest to actually
+		// test the real flow instead of mocking everything based on the assumption that
+		// we know exactly how express is going to behave
 		res = {
 			locals: {},
 			status: jest.fn().mockReturnValue(res),
 			json: jest.fn().mockReturnValue(res)
+		} as any;
+
+		// TODO: need to remove all references to 'kabakumov' in this file, just use jiraHost instead
+		testQueryParams = {
+			xdm_e: "https://kabakumov.atlassian.net",
+			xdm_c: "channel-com.github.integration.konstantin__github-post-install-page",
+			cp: "",
+			xdm_deprecated_addon_key_do_not_use: "com.github.integration.konstantin",
+			lic: "none",
+			cv: "1001.0.0-SNAPSHOT"
 		};
+
+		baseRequest = {
+			query: testQueryParams,
+			method: "GET",
+			path: "/jira/configuration",
+			session: {
+				jiraHost: "https://test.atlassian.net"
+			},
+			log: logger
+		} as any;
 	});
 
 	describe("#verifySymmetricJwtTokenMiddleware", () => {
 
-		const buildRequestWithJwt = (secret = "secret", qsh: string): any => {
-			const jwtValue = encodeSymmetric({
-				qsh: qsh,
-				iss: "jira",
-			}, secret);
-
-			return buildRequest(jwtValue);
-		};
-
 		describe("Normal Token", () => {
 			it("should pass when token is valid", async () => {
-
 				const req = buildRequestWithJwt(testSecret, testQsh);
-
-				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.normal, req, res, next)
-
-				expect(res.status).toHaveBeenCalledTimes(0)
-				expect(next).toBeCalledTimes(1)
-
+				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.normal, req, res, next);
+				expect(res.status).toHaveBeenCalledTimes(0);
+				expect(next).toBeCalledTimes(1);
 			});
 
-
 			it("should fail if qsh don't match", async () => {
-
 				const req = buildRequestWithJwt(testSecret, "q123123124");
-
-				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.normal, req, res, next)
-
-				expect(res.status).toHaveBeenCalledWith(401)
-				expect(next).toBeCalledTimes(0)
-
+				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.normal, req, res, next);
+				expect(res.status).toHaveBeenCalledWith(401);
+				expect(next).toBeCalledTimes(0);
 			});
 
 			it("should fail if secret is wrong", async () => {
-
 				const req = buildRequestWithJwt("wrongSecret", testQsh);
-
-				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.normal, req, res, next)
-
-				expect(res.status).toHaveBeenCalledWith(400)
-				expect(next).toBeCalledTimes(0)
-
+				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.normal, req, res, next);
+				expect(res.status).toHaveBeenCalledWith(400);
+				expect(next).toBeCalledTimes(0);
 			});
 		});
 
 		describe("Context Token", () => {
 
 			it("should pass if qsh is 'context-qsh'", async () => {
-
 				const req = buildRequestWithJwt(testSecret, "context-qsh");
-
-				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next)
-
-				expect(res.status).toHaveBeenCalledTimes(0)
-				expect(next).toBeCalledTimes(1)
-
+				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next);
+				expect(res.status).toHaveBeenCalledTimes(0);
+				expect(next).toBeCalledTimes(1);
 			});
 
 			it("should fail if there is a proper qsh", async () => {
-
 				const req = buildRequestWithJwt(testSecret, testQsh);
-
-				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next)
-
-				expect(res.status).toHaveBeenCalledWith(401)
-				expect(next).toBeCalledTimes(0)
-
+				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next);
+				expect(res.status).toHaveBeenCalledWith(401);
+				expect(next).toBeCalledTimes(0);
 			});
 
 
 			it("should fail if qsh is not valid", async () => {
-
 				const req = buildRequestWithJwt(testSecret, "q123123124");
-
-				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next)
-
-				expect(res.status).toHaveBeenCalledWith(401)
-				expect(next).toBeCalledTimes(0)
+				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next);
+				expect(res.status).toHaveBeenCalledWith(401);
+				expect(next).toBeCalledTimes(0);
 
 			});
 
 			it("should fail if secret is wrong", async () => {
-
 				const req = buildRequestWithJwt("wrongSecret", testQsh);
-
-				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next)
-
-				expect(res.status).toHaveBeenCalledWith(400)
-				expect(next).toBeCalledTimes(0)
-
+				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next);
+				expect(res.status).toHaveBeenCalledWith(400);
+				expect(next).toBeCalledTimes(0);
 			});
 		});
 
 		describe("Expiry date", () => {
-
 			const buildRequest = (expiryDate: number): any => {
 				const jwtValue = encodeSymmetric({
 					qsh: "context-qsh",
@@ -181,37 +162,30 @@ describe("jwt", () => {
 					query: {
 						...testQueryParams,
 						jwt: jwtValue
-					},
+					}
 				};
 			};
 
 			it("should pass if expiry date after current date", async () => {
-
 				const req = buildRequest(Date.now() / 1000 + 100000);
-
-				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next)
-
-				expect(res.status).toHaveBeenCalledTimes(0)
-				expect(next).toBeCalledTimes(1)
-
+				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next);
+				expect(res.status).toHaveBeenCalledTimes(0);
+				expect(next).toBeCalledTimes(1);
 			});
 
 			it("should fail if expiry date before current date", async () => {
-
 				const req = buildRequest(Date.now() / 1000 - 100000);
-
-				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next)
-
-				expect(res.status).toHaveBeenCalledWith(401)
-				expect(next).toBeCalledTimes(0)
+				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next);
+				expect(res.status).toHaveBeenCalledWith(401);
+				expect(next).toBeCalledTimes(0);
 			});
-		})
+		});
 
 		describe("Token in different places", () => {
 			const buildRequestWithTokenInBody = (): any => {
 				const jwtValue = encodeSymmetric({
 					qsh: "context-qsh",
-					iss: "jira",
+					iss: "jira"
 				}, testSecret);
 
 				return {
@@ -219,24 +193,21 @@ describe("jwt", () => {
 					method: "POST",
 					body: {
 						jwt: jwtValue
-					},
+					}
 				};
 			};
 
 			it("Passes if token is in body", async () => {
-
 				const req = buildRequestWithTokenInBody();
-
-				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next)
-
-				expect(res.status).toHaveBeenCalledTimes(0)
-				expect(next).toBeCalledTimes(1)
+				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next);
+				expect(res.status).toHaveBeenCalledTimes(0);
+				expect(next).toBeCalledTimes(1);
 			});
 
 			const buildRequestWithTokenInHeader = (): any => {
 				const jwtValue = encodeSymmetric({
 					qsh: "context-qsh",
-					iss: "jira",
+					iss: "jira"
 				}, testSecret);
 
 				return {
@@ -245,49 +216,27 @@ describe("jwt", () => {
 					method: "POST",
 					headers: {
 						authorization: `JWT ${jwtValue}`
-					},
+					}
 				};
 			};
 
 			it("Passes if token is in header", async () => {
-
 				const req = buildRequestWithTokenInHeader();
-
-				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next)
-
-				expect(res.status).toHaveBeenCalledTimes(0)
-				expect(next).toBeCalledTimes(1)
+				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next);
+				expect(res.status).toHaveBeenCalledTimes(0);
+				expect(next).toBeCalledTimes(1);
 			});
 
 			it("Fails if there is no token", async () => {
-
 				const req = buildRequestWithNoToken();
-
-				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next)
-
-				expect(res.status).toHaveBeenCalledWith(401)
-				expect(next).toBeCalledTimes(0)
+				verifySymmetricJwtTokenMiddleware(testSecret, TokenType.context, req, res, next);
+				expect(res.status).toHaveBeenCalledWith(401);
+				expect(next).toBeCalledTimes(0);
 			});
 		});
 	});
 
-
-	//RAS keypair used to sign test tokens. Base64 encoded to prevent security scanning from being triggered
-	const testPrivateKey = Buffer.from("LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlDWFFJQkFBS0JnUUROL2ZXZXg5dXJ2VHRYWGY0aVlodmU0akJDaDg2Uk4zUHc5YW1SaVovU241TTdlY1JzCjNWZE5TR2FvRGNEZG1MaEYzczZkTUVlN2ZzTW9SVXZ3cit0VnoyL2JpSDBLOTh4dlFETzhaNHd3ZlRKbjNHSE8Kamg2Nk5YcE5lRDhobzBrMFllZXcveHBGMGU0cys4Tkg2b0Jna09OMTJoS29mQ2FQOEFDeXViYk93UUlEQVFBQgpBb0dBSDM2SW96SWpYK3FhdkF6ZTRocmw3L25kTHc3Y2drOWNKcWNvdWR1MDE5c1dBNjNtWGs2cEhtUEhia0pNCkRwVmU5eS9ObnpMV2hOQW92bXQ1NU43QXVDTzJaQm1pWXROY1BCckU0aUVXN1NDMjlZOEFOKzBvTHVYTmt6OFAKVURJeUVsWFRNakJ5cFZpN3RNellKaFlOM1FhMWdVVnR2TmNDN0t0WW95cXVWd0VDUVFEcXN6VktwYlNwNVMyRgpEdU5nYlVsaTdCMDgwakNTRlJ4dkQ5ek9WdmkxckRVSC9aV1JHcDFDaFE0TUdYR2FoQWxJaUVLNklFMVYxR1NpCmhJZFY0Q01KQWtFQTRLL0hDN09vdTBiU3hhVVVqclVTMmYzRzE5Tk1TNHIrbXhLZ2s4UnBFWWMzVzJpRjB3eDkKUHNCYlVkbGlyRVVHaUpLWEdXNTNPLzRTQUptOTlMYWorUUpCQUw4RFgwb0Rsd2YyNTVjMVNNVC83UXcva29RZgpwVHdmUm1iMWlBVy9MdWZjNGNSQkZHdG1ON3Nkd3hNQjJqMmhYRlRWNFVqT1pXS0hXK2dRNkh4eDBORUNRQS85CmNuVHF2RDlYc3ZoTjMwQ29za2JCUUwxclZDcXNJYUozbU9YclBHNzY2SDJnMnFWQ1prZG8rUmJDR2J1WXpmWTYKT0hhZTNlMXZEMmpyaUJFNlRrRUNRUUNGNXpndDlhSHlzeDJwQmJTcjlCZVdTdFExdUJlcEpSajh5Skg2NisyYQpaR1ZJOEY2Tk9HaERSRDhwakZrclcydXdoemhDbkZ4U2Nza3FVWm1BcHBuUwotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQ==",
-		"base64").toString("ascii");
-
-	const testPublicKey = Buffer.from("LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlHZk1BMEdDU3FHU0liM0RRRUJBUVVBQTRHTkFEQ0JpUUtCZ1FETi9mV2V4OXVydlR0WFhmNGlZaHZlNGpCQwpoODZSTjNQdzlhbVJpWi9TbjVNN2VjUnMzVmROU0dhb0RjRGRtTGhGM3M2ZE1FZTdmc01vUlV2d3IrdFZ6Mi9iCmlIMEs5OHh2UURPOFo0d3dmVEpuM0dIT2poNjZOWHBOZUQ4aG8wazBZZWV3L3hwRjBlNHMrOE5INm9CZ2tPTjEKMmhLb2ZDYVA4QUN5dWJiT3dRSURBUUFCCi0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQ==",
-		"base64").toString("ascii")
-
-
-	const wrongPrivateKey = Buffer.from("LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlDV3dJQkFBS0JnRlVCSkFUdDJyd0M4NUtvdmM5eC9DYnZmTWdiRUw4UGorRmRlNUpENjJsK3B1WENJejk1CkJPMzIvUG9JNE5SNnZzWVhJN213UmsyV1A1VGV5dkxXVjFTYS9IekFqbWQxQzVlbGVJNkM5dERjYXVxU2VpR1UKQ2FTS0JVTkhmS3VBK0pCSi9GYUlZMWphTE1peGxCa09uYnNNZ1hxb0ZHSUtzZGhhMnBKaXJ6QXBBZ01CQUFFQwpnWUFFYmtMS1h2dC93VWVnNVZxL2JWbVBUZnhiRWM0VnAySUFoVGJqc05hY2NSV1I5RVNTRW1USFlwQmRHQWxnCkNlWFh2VzBIU01EaFdtdUYvdmJsSVhiN3lvd1JOSkxNVmpoYldScHU1dE1uVmErS0U3eDYrbFJjMzJ1dVVXYkkKL1MwdnJsTVJWYlZjYThqVGxLS1VsV0draWJzMWlhMVMvWlBmWFlqKzc5Ym9BUUpCQUo4c1lVcm9DK0ozR0k0TQovZmFHWUg3UWNGcm1HQm41YThZVVVJUTJYQnpwL1NmOU1CNTdpbnJzN2xTSHhrczk3QjNSNFkxOGMxclB0dXJECmZaWUxzK0VDUVFDSXRxVk54OXordmxpY3JyWTVqTUU5VUNjOGU0MTJnLzI2VHFVSzFnVEFoWVI3SHZObE5QeHoKUFlDZnUrVU5QK09wd2owQ1pkSktwYzZZMU13eGhZVkpBa0IvYlZZT1U2cUFDSHdkN0lTOEFXUHE0Zyt3bFpnaAo0eTNHaTZqUnozcjZvdEJLWFVWU2dmQ2c3R0Q0UnlJV1JtSnFsUVdPOFZ5Z0RMNFJQNk9ncFluQkFrQSs1eHJECjRQUFQyaXpYV3FQSmN2UHVqQlNoaFkrZk9qZmlJeEZaSFFQdXVRQXR6aDNiTVRmK3BndXFjejkraXlqckVNNFYKYmxnRnRLaU1OVTBHZEJMUkFrRUFsa1FxcjFiK3VKZG1PdHVFQmtEb09VeERvcmx6VkhtTVhwMjBKSjEyTm1KTgpOV1RDZm44YWs1c1lEdEZ1eEtCV3JPcEJVOXA2cEF6blVRR0hzaHI0N1E9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQ==",
-		"base64").toString("ascii")
-
-
-	const testKid = "1234435235352"
-
 	describe("#verifyAsymmetricJwtTokenMiddleware", () => {
-
 		beforeEach(async () => {
 			when(queryAtlassianConnectPublicKey).calledWith(
 				testKid,
@@ -295,16 +244,14 @@ describe("jwt", () => {
 			).mockResolvedValue(testPublicKey);
 		});
 
-
-		const buildRequestWithJwtPayload = (jwtPayload: any,  key ?: string): any => {
+		const buildRequestWithJwtPayload = (jwtPayload: any, key ?: string): any => {
 			key = key || testPrivateKey;
 			const jwtValue = encodeAsymmetric(jwtPayload, key, AsymmetricAlgorithm.RS256,
 				{
 					kid: "1234435235352"
 				});
-
 			return buildRequest(jwtValue);
-		}
+		};
 
 		const buildRequestWithJwt = (qsh: string, exp ?: number, key ?: string): any => {
 			exp = exp || Date.now() / 1000 + 100000;
@@ -317,115 +264,82 @@ describe("jwt", () => {
 		};
 
 		it("should pass when token is valid", async () => {
-
 			const req = buildRequestWithJwt(testQsh);
-
-			await verifyAsymmetricJwtTokenMiddleware(req, res, next)
-
-			expect(res.status).toHaveBeenCalledTimes(0)
-			expect(next).toBeCalledTimes(1)
-			expect(queryAtlassianConnectPublicKey).toHaveBeenCalledWith(testKid, false)
+			await verifyAsymmetricJwtTokenMiddleware(req, res, next);
+			expect(res.status).toHaveBeenCalledTimes(0);
+			expect(next).toBeCalledTimes(1);
+			expect(queryAtlassianConnectPublicKey).toHaveBeenCalledWith(testKid, false);
 		});
 
-
 		it("should pass when token is valid for Staging Jira Instance", async () => {
-
 			const req = buildRequestWithJwt(testQsh);
-			req.body = { baseUrl: "https://kabakumov2.jira-dev.com/jira/your-work"}
-
-			await verifyAsymmetricJwtTokenMiddleware(req, res, next)
-
-			expect(res.status).toHaveBeenCalledTimes(0)
-			expect(next).toBeCalledTimes(1)
-			expect(queryAtlassianConnectPublicKey).toHaveBeenCalledWith(testKid, true)
+			req.body = { baseUrl:  "https://kabakumov2.jira-dev.com/jira/your-work" };
+			await verifyAsymmetricJwtTokenMiddleware(req, res, next);
+			expect(res.status).toHaveBeenCalledTimes(0);
+			expect(next).toBeCalledTimes(1);
+			expect(queryAtlassianConnectPublicKey).toHaveBeenCalledWith(testKid, true);
 		});
 
 		it("should pass when token is valid for Prod Jira Instance", async () => {
-
 			const req = buildRequestWithJwt(testQsh);
-			req.body = { baseUrl: "https://kabakumov.atlassian.net"}
-
-			await verifyAsymmetricJwtTokenMiddleware(req, res, next)
-
-			expect(res.status).toHaveBeenCalledTimes(0)
-			expect(next).toBeCalledTimes(1)
-			expect(queryAtlassianConnectPublicKey).toHaveBeenCalledWith(testKid, false)
+			req.body = { baseUrl: "https://kabakumov.atlassian.net" };
+			await verifyAsymmetricJwtTokenMiddleware(req, res, next);
+			expect(res.status).toHaveBeenCalledTimes(0);
+			expect(next).toBeCalledTimes(1);
+			expect(queryAtlassianConnectPublicKey).toHaveBeenCalledWith(testKid, false);
 		});
 
-
 		it("should return 401 when was encrypted with wrong key", async () => {
-
 			const req = buildRequestWithJwt(testQsh, undefined, wrongPrivateKey);
-
-			await verifyAsymmetricJwtTokenMiddleware(req, res, next)
-
-			expect(res.status).toHaveBeenCalledWith(401)
-			expect(next).toBeCalledTimes(0)
+			await verifyAsymmetricJwtTokenMiddleware(req, res, next);
+			expect(res.status).toHaveBeenCalledWith(401);
+			expect(next).toBeCalledTimes(0);
 		});
 
 		it("should return 401 when when call fails with Not Found", async () => {
-
 			const req = buildRequestWithJwt(testQsh);
-
 			when(queryAtlassianConnectPublicKey).calledWith(
 				testKid,
 				false
 			).mockRejectedValueOnce(new Error("404"));
-
-			await verifyAsymmetricJwtTokenMiddleware(req, res, next)
-
-			expect(res.status).toHaveBeenCalledWith(401)
-			expect(next).toBeCalledTimes(0)
+			await verifyAsymmetricJwtTokenMiddleware(req, res, next);
+			expect(res.status).toHaveBeenCalledWith(401);
+			expect(next).toBeCalledTimes(0);
 		});
 
 		it("should return 401 when expiration date is wrong", async () => {
-
 			const req = buildRequestWithJwt(testQsh, Date.now() / 1000 - 100);
-
-			await verifyAsymmetricJwtTokenMiddleware(req, res, next)
-
-			expect(res.status).toHaveBeenCalledWith(401)
-			expect(next).toBeCalledTimes(0)
+			await verifyAsymmetricJwtTokenMiddleware(req, res, next);
+			expect(res.status).toHaveBeenCalledWith(401);
+			expect(next).toBeCalledTimes(0);
 		});
 
 		it("should return 401 when qsh is wrong", async () => {
-
 			const req = buildRequestWithJwt("13113wrong13123");
-
-			await verifyAsymmetricJwtTokenMiddleware(req, res, next)
-
-			expect(res.status).toHaveBeenCalledWith(401)
-			expect(next).toBeCalledTimes(0)
+			await verifyAsymmetricJwtTokenMiddleware(req, res, next);
+			expect(res.status).toHaveBeenCalledWith(401);
+			expect(next).toBeCalledTimes(0);
 		});
 
 		it("should return 401 when no audience", async () => {
-
 			const req = buildRequestWithJwtPayload({
 				qsh: testQsh,
-				iss: "jira",
+				iss: "jira"
 			});
-
-			await verifyAsymmetricJwtTokenMiddleware(req, res, next)
-
-			expect(res.status).toHaveBeenCalledWith(401)
-			expect(next).toBeCalledTimes(0)
+			await verifyAsymmetricJwtTokenMiddleware(req, res, next);
+			expect(res.status).toHaveBeenCalledWith(401);
+			expect(next).toBeCalledTimes(0);
 		});
 
 		it("should return 401 when wrong audience", async () => {
-
 			const req = buildRequestWithJwtPayload({
 				qsh: testQsh,
 				iss: "jira",
 				aud: "https://wrong-addon.example.com"
 			});
-
-			await verifyAsymmetricJwtTokenMiddleware(req, res, next)
-
-			expect(res.status).toHaveBeenCalledWith(401)
-			expect(next).toBeCalledTimes(0)
+			await verifyAsymmetricJwtTokenMiddleware(req, res, next);
+			expect(res.status).toHaveBeenCalledWith(401);
+			expect(next).toBeCalledTimes(0);
 		});
-
-
-
 	});
 });


### PR DESCRIPTION
JWT verification was using `req.path` which is not the full path but the local router path.  If you want the full path, you need to concatenate `req.baseUrl + req.path` to get the full path.