### PR TITLE
Allow  decimal values for the queue delays

### DIFF
--- a/src/sqs/index.ts
+++ b/src/sqs/index.ts
@@ -53,7 +53,8 @@ export type QueueSettings = {
 	readonly longPollingIntervalSec?: number,
 
 	/**
-	 * Timeout for processing a single message in seconds
+	 * Timeout for processing a single message in seconds.
+	 * If non-integer value passed then the timeout will be rounded to the closest integer
 	 */
 	readonly timeoutSec: number;
 
@@ -422,15 +423,15 @@ export class SqsQueue<MessagePayload> {
 			return;
 		}
 
-		if(!Number.isInteger(timeout) || timeout < 0) {
-			logger.error(`Timeout needs to be a positive integer.`);
+		if(timeout < 0) {
+			logger.error(`Timeout needs to be a positive number.`);
 			return;
 		}
 
 		const params: ChangeMessageVisibilityRequest = {
 			QueueUrl: this.queueUrl,
 			ReceiptHandle: message.ReceiptHandle,
-			VisibilityTimeout: timeout
+			VisibilityTimeout: Math.round(timeout)
 		};
 		try {
 			await this.sqs.changeMessageVisibility(params).promise();


### PR DESCRIPTION
In this PR I've fixed the visibility timeout change failure in case if we were getting decimal timeout value.

We currently have all Rate Limiting error delays broken, because they pass decimal values. So they use default timeout (Which adds additional load to the rate limited orgs)

Fixing it now