### PR TITLE
Arc 1177 - Replace Octokit with GitHub Client for Branch events

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,7 +49,6 @@
 		],
 		"indent": ["error", "tab", {
 			"SwitchCase": 1
-		}],
-		"@import/no-unresolved": "off"
+		}]
 	}
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,6 +49,7 @@
 		],
 		"indent": ["error", "tab", {
 			"SwitchCase": 1
-		}]
+		}],
+		"@import/no-unresolved": "off"
 	}
 }

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -25,7 +25,8 @@ export enum BooleanFlags {
 	USE_NEW_GITHUB_CLIENT_FOR_DISCOVERY = "use-new-github-client-for-discovery",
 	USE_NEW_GITHUB_CLIENT_FOR_DEPLOYMENTS = "use-new-github-client-for-deployments",
 	USE_NEW_GITHUB_CLIENT_FOR_BACKFILL = "use-new-github-client-for-backfill_z7ps8",
-	USE_NEW_GITHUB_PULL_REQUEST_URL_FORMAT = "use-new-github-pull-request-url-format"
+	USE_NEW_GITHUB_PULL_REQUEST_URL_FORMAT = "use-new-github-pull-request-url-format",
+	USE_NEW_GITHUB_CLIENT_FOR_BRANCH_EVENT = "use-new-github-client-for-branch-event"
 }
 
 export enum StringFlags {

--- a/src/github/branch.ts
+++ b/src/github/branch.ts
@@ -27,7 +27,7 @@ export const createBranch = async (context: CustomContext, jiraClient, _util, gi
 	} else {
 
 		const gitHubClient = new GitHubClient(getCloudInstallationId(githubInstallationId), context.log);
-		const github = await booleanFlag(BooleanFlags.USE_NEW_GITHUB_CLIENT_FOR_BRANCH_EVENT, false, jiraHost) ? gitHubClient : context.github;
+		const github = await booleanFlag(BooleanFlags.USE_NEW_GITHUB_CLIENT_FOR_BRANCH_EVENT, false, jiraClient.baseURL) ? gitHubClient : context.github;
 		const jiraPayload = await transformBranch(github, webhookPayload);
 
 		if (!jiraPayload) {

--- a/src/github/client/github-client.ts
+++ b/src/github/client/github-client.ts
@@ -5,25 +5,12 @@ import AppTokenHolder from "./app-token-holder";
 import InstallationTokenCache from "./installation-token-cache";
 import AuthToken from "./auth-token";
 import { GetPullRequestParams } from "./types";
-import {
-	handleFailedRequest,
-	instrumentFailedRequest,
-	instrumentRequest,
-	setRequestStartTime,
-	setRequestTimeout
-} from "./interceptors";
+import { handleFailedRequest, instrumentFailedRequest, instrumentRequest, setRequestStartTime, setRequestTimeout } from "./interceptors";
 import { metricHttpRequest } from "../../config/metric-names";
 import { getLogger } from "../../config/logger";
 import { urlParamsMiddleware } from "../../util/axios/url-params-middleware";
 import { InstallationId } from "./installation-id";
-import {
-	GetBranchesQuery,
-	GetBranchesResponse,
-	ViewerRepositoryCountQuery,
-	getCommitsQueryWithChangedFiles,
-	getCommitsQueryWithoutChangedFiles,
-	getCommitsResponse
-} from "./github-queries";
+import { GetBranchesQuery, GetBranchesResponse, ViewerRepositoryCountQuery, getCommitsQueryWithChangedFiles, getCommitsQueryWithoutChangedFiles, getCommitsResponse } from "./github-queries";
 import { GithubClientGraphQLError, GraphQLError, RateLimitingError } from "./errors";
 
 type GraphQlQueryResponse<ResponseData> = {

--- a/src/github/pull-request.ts
+++ b/src/github/pull-request.ts
@@ -46,8 +46,8 @@ export default async (
 		context.log
 	);
 
-	const { number: pullRequestNumber, body: pullRequestBody, id: pullRequestId } =  pull_request
-	const logPayload = { pullRequestId, pullRequestNumber, jiraPayload }
+	const { number: pullRequestNumber, body: pullRequestBody, id: pullRequestId } =  pull_request;
+	const logPayload = { pullRequestId, pullRequestNumber, jiraPayload };
 
 	context.log.info(logPayload, "Pullrequest mapped to Jira Payload");
 

--- a/src/interfaces/jira.ts
+++ b/src/interfaces/jira.ts
@@ -27,6 +27,24 @@ export interface JiraBuildData {
 	builds: JiraBuild[];
 }
 
+export interface JiraBranch {
+	createPullRequestUrl: string,
+	lastCommit: JiraCommit,
+	id: string,
+	issueKeys: string[],
+	name: string,
+	url: string,
+	updateSequenceId: number
+}
+
+export interface JiraBranchData  {
+	id: number,
+	name: string,
+	url: string,
+	branches: JiraBranch[],
+	updateSequenceId: number
+}
+
 export interface JiraCommit {
 	author: JiraAuthor;
 	authorTimestamp: string;

--- a/src/sqs/branch.ts
+++ b/src/sqs/branch.ts
@@ -24,7 +24,7 @@ export const branchQueueMessageHandler: MessageHandler<BranchMessagePayload> = a
 	const messagePayload: BranchMessagePayload = context.payload;
 	const gitHubClient = new GitHubClient(getCloudInstallationId(messagePayload.installationId), context.log);
 	const githubApi = await app.auth(messagePayload.installationId);
-	const github = await booleanFlag(BooleanFlags.USE_NEW_GITHUB_CLIENT_FOR_BRANCH_EVENT, false, jiraHost) ? gitHubClient : githubApi;
+	const github = await booleanFlag(BooleanFlags.USE_NEW_GITHUB_CLIENT_FOR_BRANCH_EVENT, false, messagePayload.jiraHost) ? gitHubClient : githubApi;
 
 	await processBranch(
 		github,

--- a/src/sqs/branch.ts
+++ b/src/sqs/branch.ts
@@ -2,6 +2,9 @@ import { WebhookPayloadCreate } from "@octokit/webhooks";
 import { Context, MessageHandler } from "./index";
 import app from "../worker/app";
 import { processBranch } from "../github/branch";
+import GitHubClient from "../github/client/github-client";
+import { booleanFlag, BooleanFlags } from "../config/feature-flags";
+import { getCloudInstallationId } from "../github/client/installation-id";
 
 export type BranchMessagePayload = {
 	jiraHost: string,
@@ -19,8 +22,9 @@ export const branchQueueMessageHandler: MessageHandler<BranchMessagePayload> = a
 	context.log.info("Handling branch message from the SQS queue")
 
 	const messagePayload: BranchMessagePayload = context.payload;
-
-	const github = await app.auth(messagePayload.installationId);
+	const gitHubClient = new GitHubClient(getCloudInstallationId(messagePayload.installationId), context.log);
+	const githubApi = await app.auth(messagePayload.installationId);
+	const github = await booleanFlag(BooleanFlags.USE_NEW_GITHUB_CLIENT_FOR_BRANCH_EVENT, false, jiraHost) ? gitHubClient : githubApi;
 
 	await processBranch(
 		github,

--- a/src/sync/branches.ts
+++ b/src/sync/branches.ts
@@ -1,7 +1,7 @@
 import { transformBranches } from "./transforms/branch";
 import { GitHubAPI } from "probot";
 import { Repository } from "../models/subscription";
-import { Repository as OctokitRepository} from "@octokit/graphql-schema";
+import { Repository as OctokitRepository } from "@octokit/graphql-schema";
 import GitHubClient from "../github/client/github-client";
 import { booleanFlag, BooleanFlags } from "../config/feature-flags";
 import { LoggerWithTarget } from "probot/lib/wrap-logger";
@@ -17,7 +17,7 @@ export default async (logger: LoggerWithTarget, github: GitHubAPI, newGithub: Gi
 
 	let result;
 	if(useNewGHClient) {
-		result = await newGithub.getBranchesPage(repository.owner.login, repository.name, perPage, cursor as string)
+		result = await newGithub.getBranchesPage(repository.owner.login, repository.name, perPage, cursor as string);
 	} else {
 		result = ((await github.graphql(GetBranchesQuery, {
 			owner: repository.owner.login,

--- a/src/sync/commits.ts
+++ b/src/sync/commits.ts
@@ -20,7 +20,6 @@ const fetchCommits = async (gitHubClient: GitHubClient, repository: Repository, 
 export const getCommits = async (logger: LoggerWithTarget, github: GitHubAPI, gitHubClient: GitHubClient, jiraHost: string, repository: Repository, cursor?: string | number, perPage?: number) => {
 	logger.info("Syncing commits: started");
 	if (await booleanFlag(BooleanFlags.USE_NEW_GITHUB_CLIENT_FOR_BACKFILL, false, jiraHost)) {
-		console.log("IM GETTING FROM GHCLIENT");
 		const { edges, commits }  = await fetchCommits(gitHubClient, repository, cursor, perPage);
 		const jiraPayload = await transformCommit({ commits, repository });
 		logger.info("Syncing commits: finished");
@@ -30,8 +29,7 @@ export const getCommits = async (logger: LoggerWithTarget, github: GitHubAPI, gi
 			jiraPayload
 		};
 	}
-	console.log("IM GETTING FROM OCTO");
-	return getCommitsOctoKit(logger, github, gitHubClient, jiraHost, repository, cursor, perPage) 
+	return getCommitsOctoKit(logger, github, gitHubClient, jiraHost, repository, cursor, perPage);
 };
 
 /*

--- a/src/transforms/branch.ts
+++ b/src/transforms/branch.ts
@@ -1,67 +1,64 @@
 import { getJiraId } from "../jira/util/id";
 import issueKeyParser from "jira-issue-key-parser";
 import { getJiraAuthor } from "../util/jira";
-import _ from "lodash";
+import { isEmpty } from "lodash";
 import { WebhookPayloadCreate } from "@octokit/webhooks";
 import { GitHubAPI } from "probot";
 import { generateCreatePullRequestUrl } from "./util/pullRequestLinkGenerator";
+import GitHubClient from "../github/client/github-client";
+import { getCloudInstallationId } from "../github/client/installation-id";
 import { booleanFlag, BooleanFlags } from "../config/feature-flags";
+import { LoggerWithTarget } from "probot/lib/wrap-logger";
+import { JiraBranchData, JiraCommit } from "src/interfaces/jira";
 
-async function getLastCommit(github: GitHubAPI, webhookPayload: WebhookPayloadCreate, issueKeys: string[]) {
+const getLastCommit = async (useNewGitHubClient: boolean, github: GitHubAPI, gitHubClient: GitHubClient, webhookPayload: WebhookPayloadCreate, issueKeys: string[]): Promise<JiraCommit> => {
+	const { data: { object: { sha: ref } } } = useNewGitHubClient ?
+		await gitHubClient.getRef(webhookPayload.repository.owner.login, webhookPayload.repository.name, `heads/${webhookPayload.ref}`) :
+		await github.git.getRef({ owner: webhookPayload.repository.owner.login, repo: webhookPayload.repository.name, ref: `heads/${webhookPayload.ref}` });
 
-	const {
-		data: { object: { sha } }
-	} = await github.git.getRef({
-		owner: webhookPayload.repository.owner.login,
-		repo: webhookPayload.repository.name,
-		ref: `heads/${webhookPayload.ref}`
-	});
-
-	const {
-		data: { commit, author, html_url: url }
-	} = await github.repos.getCommit({
-		owner: webhookPayload.repository.owner.login,
-		repo: webhookPayload.repository.name,
-		ref: sha
-	});
+	const { data: { commit, author, html_url: url } } = useNewGitHubClient ?
+		await gitHubClient.getCommit(webhookPayload.repository.owner.login, webhookPayload.repository.name, ref) :
+		await github.repos.getCommit({ owner: webhookPayload.repository.owner.login, repo: webhookPayload.repository.name, ref });
 
 	return {
 		author: getJiraAuthor(author, commit.author),
 		authorTimestamp: commit.author.date,
-		displayId: sha.substring(0, 6),
+		displayId: ref.substring(0, 6),
 		fileCount: 0,
-		hash: sha,
-		id: sha,
+		hash: ref,
+		id: ref,
 		issueKeys,
 		message: commit.message,
 		url,
 		updateSequenceId: Date.now()
 	};
-}
+};
 
-export const transformBranch = async (github: GitHubAPI, webhookPayload: WebhookPayloadCreate) => {
-	if (webhookPayload.ref_type !== "branch") return undefined;
-
-	const { ref, repository } = webhookPayload;
-
-	const issueKeys = issueKeyParser().parse(ref) || [];
-
-	if (_.isEmpty(issueKeys)) {
-		return undefined;
+export const transformBranch = async (github: GitHubAPI, webhookPayload: WebhookPayloadCreate, jiraHost: string, installationId: number, logger: LoggerWithTarget): Promise<JiraBranchData | undefined> => {
+	if (webhookPayload.ref_type !== "branch") {
+		return;
 	}
 
-	const lastCommit = await getLastCommit(github, webhookPayload, issueKeys);
+	const { ref, repository } = webhookPayload;
+	const issueKeys = issueKeyParser().parse(ref) || [];
 
-	const newPrUrl = await booleanFlag(BooleanFlags.USE_NEW_GITHUB_PULL_REQUEST_URL_FORMAT, false);
+	if (isEmpty(issueKeys)) {
+		return;
+	}
 
-	// TODO: type this return
+	const gitHubClient = new GitHubClient(getCloudInstallationId(installationId), logger);
+	const newPrUrl = booleanFlag(BooleanFlags.USE_NEW_GITHUB_PULL_REQUEST_URL_FORMAT, false, jiraHost);
+	const newGitHubClient = booleanFlag(BooleanFlags.USE_NEW_GITHUB_CLIENT_FOR_BRANCH_EVENT, false, jiraHost);
+	const [useNewPrUrl, useNewGitHubClient] = await Promise.all([newPrUrl, newGitHubClient]);
+	const lastCommit = await getLastCommit(useNewGitHubClient, github, gitHubClient, webhookPayload, issueKeys);
+
 	return {
 		id: repository.id,
 		name: repository.full_name,
 		url: repository.html_url,
 		branches: [
 			{
-				createPullRequestUrl: newPrUrl ? generateCreatePullRequestUrl(repository.html_url, ref, issueKeys) : `${repository.html_url}/pull/new/${ref}`, 
+				createPullRequestUrl: useNewPrUrl ? generateCreatePullRequestUrl(repository.html_url, ref, issueKeys) : `${repository.html_url}/pull/new/${ref}`,
 				lastCommit,
 				id: getJiraId(ref),
 				issueKeys,

--- a/src/transforms/branch.ts
+++ b/src/transforms/branch.ts
@@ -12,21 +12,21 @@ import { LoggerWithTarget } from "probot/lib/wrap-logger";
 import { JiraBranchData, JiraCommit } from "src/interfaces/jira";
 
 const getLastCommit = async (useNewGitHubClient: boolean, github: GitHubAPI, gitHubClient: GitHubClient, webhookPayload: WebhookPayloadCreate, issueKeys: string[]): Promise<JiraCommit> => {
-	const { data: { object: { sha: ref } } } = useNewGitHubClient ?
+	const { data: { object: { sha } } } = useNewGitHubClient ?
 		await gitHubClient.getRef(webhookPayload.repository.owner.login, webhookPayload.repository.name, `heads/${webhookPayload.ref}`) :
 		await github.git.getRef({ owner: webhookPayload.repository.owner.login, repo: webhookPayload.repository.name, ref: `heads/${webhookPayload.ref}` });
 
 	const { data: { commit, author, html_url: url } } = useNewGitHubClient ?
-		await gitHubClient.getCommit(webhookPayload.repository.owner.login, webhookPayload.repository.name, ref) :
-		await github.repos.getCommit({ owner: webhookPayload.repository.owner.login, repo: webhookPayload.repository.name, ref });
+		await gitHubClient.getCommit(webhookPayload.repository.owner.login, webhookPayload.repository.name, sha) :
+		await github.repos.getCommit({ owner: webhookPayload.repository.owner.login, repo: webhookPayload.repository.name, ref: sha });
 
 	return {
 		author: getJiraAuthor(author, commit.author),
 		authorTimestamp: commit.author.date,
-		displayId: ref.substring(0, 6),
+		displayId: sha.substring(0, 6),
 		fileCount: 0,
-		hash: ref,
-		id: ref,
+		hash: sha,
+		id: sha,
 		issueKeys,
 		message: commit.message,
 		url,

--- a/test/safe/branch.test.ts
+++ b/test/safe/branch.test.ts
@@ -38,14 +38,14 @@ describe("Branch Webhook", () => {
 		await sqsQueues.branch.purgeQueue();
 	});
 
-	describe("Create Branch", () => {
+	describe.each([true, false])("Create Branch - New GH Client feature flag is '%s'", (useNewGithubClient) => {
 		it("should queue and process a create webhook", async () => {
 
 			when(booleanFlag).calledWith(
 				BooleanFlags.USE_NEW_GITHUB_CLIENT_FOR_BRANCH_EVENT,
 				expect.anything(),
 				expect.anything()
-			).mockResolvedValue(true);
+			).mockResolvedValue(useNewGithubClient);
 
 			when(booleanFlag).calledWith(
 				BooleanFlags.USE_SQS_FOR_BRANCH,
@@ -163,130 +163,6 @@ describe("Branch Webhook", () => {
 		});
 	});
 
-	describe("Create Branch With Octokit(delete with USE_NEW_GITHUB_CLIENT_FOR_BRANCH_EVENT cleanup)", () => {
-		it("should queue and process a create webhook", async () => {
-
-			when(booleanFlag).calledWith(
-				BooleanFlags.USE_NEW_GITHUB_CLIENT_FOR_BRANCH_EVENT,
-				expect.anything(),
-				expect.anything()
-			).mockResolvedValue(false);
-
-			when(booleanFlag).calledWith(
-				BooleanFlags.USE_SQS_FOR_BRANCH,
-				expect.anything(),
-				expect.anything()
-			).mockResolvedValue(true);
-
-			when(booleanFlag).calledWith(
-				BooleanFlags.USE_NEW_GITHUB_PULL_REQUEST_URL_FORMAT,
-				expect.anything(),
-				expect.anything()
-			).mockResolvedValue(true);
-
-			const fixture = require("../fixtures/branch-basic.json");
-
-			const ref = encodeURIComponent("heads/TES-123-test-ref");
-			const sha = "test-branch-ref-sha";
-
-			githubUserTokenNock(gitHubInstallationId);
-			githubUserTokenNock(gitHubInstallationId);
-			githubNock.get(`/repos/test-repo-owner/test-repo-name/git/ref/${ref}`)
-				.reply(200, {
-					ref: `refs/${ref}`,
-					object: {
-						sha
-					}
-				});
-			githubNock.get(`/repos/test-repo-owner/test-repo-name/commits/${sha}`)
-				.reply(200, {
-					commit: {
-						author: {
-							name: "test-branch-author-name",
-							email: "test-branch-author-name@github.com",
-							date: "test-branch-author-date"
-						},
-						message: "test-commit-message"
-					},
-					html_url: `test-repo-url/commits/${sha}`
-				});
-
-			jiraNock.post("/rest/devinfo/0.10/bulk", {
-				preventTransitions: false,
-				repositories: [
-					{
-						name: "example/test-repo-name",
-						url: "test-repo-url",
-						id: "test-repo-id",
-						branches: [
-							{
-								createPullRequestUrl: "test-repo-url/compare/TES-123-test-ref?title=TES-123%20-%20TES-123-test-ref&quick_pull=1",
-								lastCommit: {
-									author: {
-										name: "test-branch-author-name",
-										email: "test-branch-author-name@github.com"
-									},
-									authorTimestamp: "test-branch-author-date",
-									displayId: "test-b",
-									fileCount: 0,
-									hash: "test-branch-ref-sha",
-									id: "test-branch-ref-sha",
-									issueKeys: ["TES-123"],
-									message: "test-commit-message",
-									updateSequenceId: 12345678,
-									url: "test-repo-url/commits/test-branch-ref-sha"
-								},
-								id: "TES-123-test-ref",
-								issueKeys: ["TES-123"],
-								name: "TES-123-test-ref",
-								url: "test-repo-url/tree/TES-123-test-ref",
-								updateSequenceId: 12345678
-							}
-						],
-						updateSequenceId: 12345678
-					}
-				],
-				properties: {
-					installationId: gitHubInstallationId
-				}
-			}).reply(200);
-
-			mockSystemTime(12345678);
-
-			await expect(app.receive(fixture)).toResolve();
-
-			await waitUntil(async () => {
-				expect(githubNock).toBeDone();
-				expect(jiraNock).toBeDone();
-			});
-		});
-
-		it("should not update Jira issue if there are no issue Keys in the branch name", async () => {
-			const fixture = require("../fixtures/branch-no-issues.json");
-			const getLastCommit = jest.fn();
-
-			await expect(app.receive(fixture)).toResolve();
-			expect(getLastCommit).not.toBeCalled();
-
-			await waitUntil(async () => {
-				expect(githubNock).toBeDone();
-				expect(jiraNock).toBeDone();
-			});
-		});
-
-		it("should exit early if ref_type is not a branch", async () => {
-			const fixture = require("../fixtures/branch-invalid-ref_type.json");
-			const parseSmartCommit = jest.fn();
-
-			await expect(app.receive(fixture)).toResolve();
-			expect(parseSmartCommit).not.toBeCalled();
-
-			await waitUntil(async () => {
-				expect(githubNock).toBeDone();
-				expect(jiraNock).toBeDone();
-			});
-		});
-	});
 
 	describe("Create Branch (with disabled FF - delete this test with FF cleanup)", () => {
 		it("should update Jira issue with link to a branch on GitHub", async () => {

--- a/test/safe/branch.test.ts
+++ b/test/safe/branch.test.ts
@@ -55,7 +55,6 @@ describe("Branch Webhook", () => {
 
 			when(booleanFlag).calledWith(
 				BooleanFlags.USE_NEW_GITHUB_PULL_REQUEST_URL_FORMAT,
-				expect.anything(),
 				expect.anything()
 			).mockResolvedValue(true);
 
@@ -176,7 +175,6 @@ describe("Branch Webhook", () => {
 
 			when(booleanFlag).calledWith(
 				BooleanFlags.USE_NEW_GITHUB_PULL_REQUEST_URL_FORMAT,
-				expect.anything(),
 				expect.anything()
 			).mockResolvedValue(true);
 


### PR DESCRIPTION
Added new Feature flag use-new-github-client-for-branch-event to toggle github client in place of OctoKit for the create branch process.

There were 2 locations that Octokit has been replaced for the GetRef and GetCommit API calls.

