### PR TITLE
ARC-1200 Added maximums for message delay and visibility timeout

### DIFF
--- a/test/setup/matchers/to-be-called-with-delay.ts
+++ b/test/setup/matchers/to-be-called-with-delay.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-namespace */
+declare namespace jest {
+	interface Matchers<R> {
+
+		toBeCalledWithDelaySec(expectedDelaySec: number): Promise<R>;
+	}
+}
+
+expect.extend({
+	toBeCalledWithDelaySec: async (received: jest.Mock<unknown>, expectedDelaySec: number) => {
+		const actual = received.mock?.calls[0][0].DelaySeconds;
+		const pass = actual == expectedDelaySec;
+		const message = () => `Expected parameter to have DelaySeconds = ${expectedDelaySec} ${pass ? "" : `but was ${actual}`}`;
+
+		return {message, pass};
+	},
+});

--- a/test/setup/setup.ts
+++ b/test/setup/setup.ts
@@ -1,8 +1,9 @@
 import nock from "nock";
 import env from "../../src/config/env";
-import "./matchers/to-have-sent-metrics";
 import "./matchers/nock";
 import "./matchers/to-promise";
+import "./matchers/to-have-sent-metrics";
+import "./matchers/to-be-called-with-delay";
 import { sequelize } from "../../src/models/sequelize";
 import { mocked } from "ts-jest/utils";
 import IORedis from "ioredis";


### PR DESCRIPTION
Fixing an issue with Rate Limiting error which was never retried during the backfill.

I've added caps for Message delay and Visibility Timeout. 

We didn't have any checks when we set message delay, so when it we were passing the wrong value, the message remained unsent. It was causing backfill unexpectedly finish for some customers