### PR TITLE
Disabled transition mode for POCO/SLAuth and disabled GitHub token au…

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -50,7 +50,6 @@ serviceProxy:
   ingress:
     authentication:
       enabled: true
-      transitionMode: true
   plugins:
     auth:
       logLevel: info

--- a/src/routes/maintenance/maintenance-router.test.ts
+++ b/src/routes/maintenance/maintenance-router.test.ts
@@ -66,25 +66,9 @@ describe("Maintenance", () => {
 		});
 
 		describe("Admin API", () => {
-			beforeEach(() =>
-				githubNock
-					.post("/graphql")
-					.reply(200, {
-						data: {
-							viewer: {
-								login: "monalisa",
-								organization: {
-									viewerCanAdminister: true
-								}
-							}
-						}
-					})
-			);
-
 			it("should still work in maintenance mode", () =>
 				supertest(app)
 					.get("/api")
-					.set("Authorization", "Bearer xxx")
 					.expect(200)
 			);
 		});

--- a/test/snapshots/routes/api/api-router.test.ts.snap
+++ b/test/snapshots/routes/api/api-router.test.ts.snap
@@ -1,59 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`API Router Authentication should return 200 if a valid token is provided 1`] = `Object {}`;
+exports[`API Router Authentication is not handled on the App level anymore Doesnt matter if there is no token 1`] = `Object {}`;
 
-exports[`API Router Authentication should return 200 if token belongs to an admin 1`] = `Object {}`;
-
-exports[`API Router Authentication should return 401 if the GraphQL query returns errors 1`] = `
-Object {
-  "errors": Array [
-    Object {
-      "extensions": Object {
-        "code": "undefinedField",
-        "fieldName": "foo",
-        "typeName": "User",
-      },
-      "locations": Array [
-        Object {
-          "column": 5,
-          "line": 4,
-        },
-      ],
-      "message": "Field 'foo' doesn't exist on type 'User'",
-      "path": Array [
-        "query",
-        "viewer",
-        "foo",
-      ],
-    },
-  ],
-  "viewerPermissionQuery": "{
-  viewer {
-    login
-    organization(login: \\"fusion-arc\\") {
-      viewerCanAdminister
-    }
-  }
-}
-",
-}
-`;
-
-exports[`API Router Authentication should return 401 if the returned organization is null 1`] = `
-Object {
-  "error": "Unauthorized",
-  "message": "Token provided does not have required access",
-}
-`;
-
-exports[`API Router Authentication should return 401 if the token is invalid 1`] = `
-Object {
-  "documentation_url": "https://developer.github.com/v4",
-  "message": "Bad credentials",
-}
-`;
-
-exports[`API Router Authentication should return 404 if no token is provided 1`] = `Object {}`;
+exports[`API Router Authentication is not handled on the App level anymore should return 200 if authorization header set 1`] = `Object {}`;
 
 exports[`API Router Endpoints Delete Installation Should work with new delete installation route 1`] = `Object {}`;
 


### PR DESCRIPTION
This PR disables transition mode for Service Proxy.

Since it will be deployed, all requests to GitHub App will be authenticated and authorized by Service Proxy.

We won't need GitHub Token authentication anymore for admin endpoints. So I removed the code which was handling it. 
From the APP point of view, these endpoints will be OPEN for anyone. However, in fact these requests will be authenticated by Service Proxy and will require proper Slauth headers or ASAP tokens (for Pollinator tests). (I am going to write a runbook on how to access them)

