### PR TITLE
removed fixed height on popup box to allow it to go full size

### DIFF
--- a/static/css/github-configuration.css
+++ b/static/css/github-configuration.css
@@ -210,7 +210,6 @@
 }
 
 .gitHubConfiguration__manageSubscriptions {
-    height: 2.3em;
     left: 3em;
     top: -2.6em;
     width: 12.8em;

--- a/static/css/github-configuration.css
+++ b/static/css/github-configuration.css
@@ -170,6 +170,7 @@
 
 .gitHubConfiguration__orgContent__settingsContainer,
 .gitHubConfiguration__orgContent__settingsContainer--disabled {
+    margin-left: 10px;
     border-radius: 3px;
     cursor: pointer;
     padding: 0.45em;


### PR DESCRIPTION
**Prefix**
<img width="977" alt="Screen Shot 2022-04-06 at 10 16 13 AM" src="https://user-images.githubusercontent.com/3848691/161861804-902b59d9-c8d0-4761-bab4-1d8232914991.png">

**Post Fix**
<img width="977" alt="Screen Shot 2022-04-06 at 10 14 07 AM" src="https://user-images.githubusercontent.com/3848691/161861819-983ba4f7-fd87-4a07-94c4-ae6ea808c005.png">

Updated Margin left on the cog link ( followed aui's lead for a 10px margin-left (aui-button ~ aui-button)
**Before**
<img width="984" alt="Screen Shot 2022-04-07 at 10 10 29 AM" src="https://user-images.githubusercontent.com/3848691/162081901-40e089c5-d878-43d0-8e8f-20cd26bbdfe5.png">

**After**
<img width="984" alt="Screen Shot 2022-04-07 at 10 18 05 AM" src="https://user-images.githubusercontent.com/3848691/162082023-a09bdb2c-9e3a-4fcc-8f06-7b4d0dd62172.png">


