### PR TITLE
HOT-98735: make the Admin API less susceptible to human error

### DIFF
--- a/src/routes/api/api-router.ts
+++ b/src/routes/api/api-router.ts
@@ -80,6 +80,11 @@ ApiRouter.post(
 		// only resync installations whose "updatedAt" date is older than x seconds
 		const inactiveForSeconds = Number(req.body.inactiveForSeconds) || undefined;
 
+		if(!statusTypes && !installationIds && !limit && !inactiveForSeconds){
+			res.status(400).send("please provide at least one of the filter parameters!");
+			return;
+		}
+
 		const subscriptions = await Subscription.getAllFiltered(installationIds, statusTypes, offset, limit, inactiveForSeconds);
 
 		await Promise.all(subscriptions.map((subscription) =>


### PR DESCRIPTION
Adds a check to the `/resync` API to require a filter. Previously, it was possible to call the API without a filter and it would start a backfill for all installations.