### PR TITLE
HOT-98735: scale up workers twice

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -486,7 +486,7 @@ environmentOverrides:
       - name: Worker
         scaling:
           instance: c5.2xlarge
-          min: 3
+          min: 6
           max: 15 # keep in sync with PGBOUNCER_DEFAULT_POOL_SIZE
           metrics: *CpuMemAndQueuesScalingRules
     alarms:

--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -15,7 +15,7 @@ compose:
       PGBOUNCER_DEFAULT_POOL_SIZE: 15 # Max scale up:
                                       #   (15 web servers + 15 workers) * 15 pool size  = 450 connections (See postgres-db connections limit)
                                       # Normal business:
-                                      #   (5 web servers + 6 workers) * 15 pool size = 165 connections
+                                      #   (5 web servers + 10 workers) * 15 pool size = 225 connections
       PGBOUNCER_SERVER_IDLE_TIMEOUT: 60
       PGBOUNCER_MAX_CLIENT_CONN: 2000
   microservice:
@@ -486,7 +486,7 @@ environmentOverrides:
       - name: Worker
         scaling:
           instance: c5.2xlarge
-          min: 6
+          min: 10
           max: 15 # keep in sync with PGBOUNCER_DEFAULT_POOL_SIZE
           metrics: *CpuMemAndQueuesScalingRules
     alarms:

--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -538,7 +538,6 @@ environmentOverrides:
             DBInstanceClass: db.r5.4xlarge
             AllocatedStorage: 40 # GB
             MaxAllocatedStorage: 100
-
             ConnectionAlarm: 900 # keep in sync with PGBOUNCER_DEFAULT_POOL_SIZE * 2 * N (cause two stacks can work
                                  # together during the deploy)
             TransactionLogsDiskUsageAlarm: 4000000000 # approximately 4GB

--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -15,7 +15,7 @@ compose:
       PGBOUNCER_DEFAULT_POOL_SIZE: 15 # Max scale up:
                                       #   (15 web servers + 15 workers) * 15 pool size  = 450 connections (See postgres-db connections limit)
                                       # Normal business:
-                                      #   (5 web servers + 3 workers) * 15 pool size = 120 connections
+                                      #   (5 web servers + 6 workers) * 15 pool size = 165 connections
       PGBOUNCER_SERVER_IDLE_TIMEOUT: 60
       PGBOUNCER_MAX_CLIENT_CONN: 2000
   microservice:
@@ -538,6 +538,7 @@ environmentOverrides:
             DBInstanceClass: db.r5.4xlarge
             AllocatedStorage: 40 # GB
             MaxAllocatedStorage: 100
+
             ConnectionAlarm: 900 # keep in sync with PGBOUNCER_DEFAULT_POOL_SIZE * 2 * N (cause two stacks can work
                                  # together during the deploy)
             TransactionLogsDiskUsageAlarm: 4000000000 # approximately 4GB


### PR DESCRIPTION
DB connections has plenty of room to scale up
<img width="200" alt="image" src="https://user-images.githubusercontent.com/20631664/163300945-61b3da5d-c3d4-4fed-bfae-488321008d32.png">

As to the queue, I cannot see any significant/sharp increase in the number of messages because of syncs, but I do see some, arguably that is caused by the resyncs we are triggering. 

Let's bump it to twice just to be better prepared for bigger syncs.
<img width="400" alt="image" src="https://user-images.githubusercontent.com/20631664/163301226-b97f8434-ccd8-448b-a81b-f8a878ef3168.png">
<img width="200" alt="image" src="https://user-images.githubusercontent.com/20631664/163301261-3c8bfaea-b887-4248-a335-f928c5288560.png">

 