### PR TITLE
ARC-1167 update missing base image config

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -15,7 +15,7 @@ RUN npm ci
 # Building TypeScript files
 RUN npm run build:release
 
-FROM node:14.18-alpine3.15
+FROM node:14.19-alpine3.15
 USER node
 COPY --chown=node:node --from=build /app /app
 WORKDIR /app


### PR DESCRIPTION
Was missing the 3rd config change :(

All 14.18-alpine3.15 references are now updated to 14.19-alpine3.15

