### PR TITLE
Arc 1284 route gh client

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -25,7 +25,8 @@ export enum BooleanFlags {
 	USE_NEW_GITHUB_CLIENT_FOR_GITHUB_CONFIG = "use-new-github-client-for-github-config",
 	USE_NEW_GITHUB_CLIENT_FOR_GITHUB_SETUP = "use-new-github-client-for-github-setup",
 	REGEX_FIX = "regex-fix",
-	REPO_DISCOVERY_BACKFILL = "repo-discovery-backfill"
+	REPO_DISCOVERY_BACKFILL = "repo-discovery-backfill",
+	USE_NEW_GITHUB_CLIENT_FOR_REDIRECT = "use-new-github-client-for-redirect"
 }
 
 export enum StringFlags {

--- a/src/github/client/app-token-holder.ts
+++ b/src/github/client/app-token-holder.ts
@@ -45,7 +45,7 @@ export class AppTokenHolder {
 	/**
 	 * Generates a JWT using the private key of the GitHub app to authorize against the GitHub API.
 	 */
-	private static createAppJwt(key: string, appId: number): AuthToken {
+	public static createAppJwt(key: string, appId: string): AuthToken {
 
 		const expirationDate = new Date(Date.now() + TEN_MINUTES);
 
@@ -55,7 +55,7 @@ export class AppTokenHolder {
 			// expiration date, GitHub allows max 10 minutes
 			exp: Math.floor(expirationDate.getTime() / 1000),
 			// issuer is the GitHub app ID
-			iss: appId.toString()
+			iss: appId
 		};
 
 		return new AuthToken(
@@ -72,7 +72,7 @@ export class AppTokenHolder {
 
 		if (!currentToken || currentToken.isAboutToExpire()) {
 			const key = this.privateKeyLocator(appId);
-			currentToken = AppTokenHolder.createAppJwt(key, appId.appId);
+			currentToken = AppTokenHolder.createAppJwt(key, appId.appId.toString());
 			this.appTokenCache.set(appId.toString(), currentToken);
 		}
 		return currentToken;

--- a/src/github/client/github-app-client.ts
+++ b/src/github/client/github-app-client.ts
@@ -22,12 +22,13 @@ export class GitHubAppClient {
 
 	constructor(
 		logger: Logger,
-		appId = envVars.GITHUB_CLIENT_ID,
+		appId = envVars.APP_ID,
 		baseURL = "https://api.github.com"
 	) {
 		this.logger = logger || getLogger("github.app.client");
 		// TODO - change this for GHE, to get from github apps table
 		const privateKey = PrivateKey.findPrivateKey() || "";
+
 		this.appToken = AppTokenHolder.createAppJwt(privateKey, appId);
 		this.axios = axios.create({
 			baseURL,

--- a/src/routes/github/configuration/github-configuration-get.ts
+++ b/src/routes/github/configuration/github-configuration-get.ts
@@ -162,11 +162,11 @@ export const GithubConfigurationGet = async (req: Request, res: Response, next: 
 			res.status(404).send(`Missing installation for host '${jiraHost}'`);
 			return;
 		}
-		const gitHubAppClient = new GitHubAppClient(getCloudInstallationId(installation.id), log);		
+		const gitHubAppClient = new GitHubAppClient(log);
 
 		tracer.trace(`found installation in DB with id ${installation.id}`);
 
-		const { data: { installations }, headers } = useNewGitHubClient ? 
+		const { data: { installations }, headers } = useNewGitHubClient ?
 			await githubUserClient.getInstallations() :
 			await github.apps.listInstallationsForAuthenticatedUser();
 

--- a/src/routes/github/setup/github-setup-get.ts
+++ b/src/routes/github/setup/github-setup-get.ts
@@ -3,7 +3,6 @@ import Logger from "bunyan";
 import { getJiraAppUrl, getJiraMarketplaceUrl, jiraSiteExists } from "utils/jira-utils";
 import { Installation } from "models/installation";
 import { GitHubAppClient } from "~/src/github/client/github-app-client";
-import { getCloudInstallationId } from "~/src/github/client/installation-id";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
 import { GitHubAPI } from "probot";
 
@@ -21,7 +20,7 @@ import { GitHubAPI } from "probot";
 const getInstallationData = async (githubAppClient: GitHubAppClient | GitHubAPI, githubInstallationId: number, logger: Logger) => {
 	let githubInstallation;
 
-	const { data: info } = githubAppClient instanceof GitHubAppClient ? 
+	const { data: info } = githubAppClient instanceof GitHubAppClient ?
 		await githubAppClient.getApp() :
 		await githubAppClient.apps.getAuthenticated();
 
@@ -45,7 +44,7 @@ const getInstallationData = async (githubAppClient: GitHubAppClient | GitHubAPI,
 export const GithubSetupGet = async (req: Request, res: Response): Promise<void> => {
 	const { jiraHost, client } = res.locals;
 	const githubInstallationId = Number(req.query.installation_id);
-	const githubAppClient = new GitHubAppClient(getCloudInstallationId(githubInstallationId), req.log);
+	const githubAppClient = new GitHubAppClient(req.log);
 	const useNewGithubClient = await booleanFlag(BooleanFlags.USE_NEW_GITHUB_CLIENT_FOR_GITHUB_SETUP, false, jiraHost);
 	const { githubInstallation, info } = await getInstallationData(useNewGithubClient ? githubAppClient : client, githubInstallationId, req.log);
 

--- a/src/routes/github/subscription/github-subscription-delete.ts
+++ b/src/routes/github/subscription/github-subscription-delete.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from "express";
 import { Subscription } from "models/subscription";
-import { getCloudInstallationId } from "~/src/github/client/installation-id";
 import { GitHubAppClient } from "~/src/github/client/github-app-client";
 import { GitHubUserClient } from "~/src/github/client/github-user-client";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
@@ -12,7 +11,7 @@ export const GithubSubscriptionDelete = async (req: Request, res: Response): Pro
 	const logger = req.log.child({ jiraHost, gitHubInstallationId });
 
 	const useNewGitHubClient = await booleanFlag(BooleanFlags.USE_NEW_GITHUB_CLIENT_FOR_DELETE_SUBSCRIPTION, false, jiraHost) ;
-	const gitHubAppClient = new GitHubAppClient(getCloudInstallationId(gitHubInstallationId), logger);
+	const gitHubAppClient = new GitHubAppClient(logger);
 	const gitHubUserClient = new GitHubUserClient(githubToken, logger);
 
 	if (!githubToken) {

--- a/src/routes/github/subscription/github-subscription-get.ts
+++ b/src/routes/github/subscription/github-subscription-get.ts
@@ -1,6 +1,5 @@
 import { Subscription } from "models/subscription";
 import { NextFunction, Request, Response } from "express";
-import { getCloudInstallationId } from "~/src/github/client/installation-id";
 import { GitHubAppClient } from "~/src/github/client/github-app-client";
 import { GitHubUserClient } from "~/src/github/client/github-user-client";
 import { isUserAdminOfOrganization } from "utils/github-utils";
@@ -20,7 +19,7 @@ export const GithubSubscriptionGet = async (req: Request, res: Response, next: N
 
 	const logger = req.log.child({ jiraHost, gitHubInstallationId });
 	const useNewGitHubClient = await booleanFlag(BooleanFlags.USE_NEW_GITHUB_CLIENT_FOR_GET_SUBSCRIPTION, false, jiraHost);
-	const gitHubAppClient = new GitHubAppClient(getCloudInstallationId(gitHubInstallationId), logger);
+	const gitHubAppClient = new GitHubAppClient( logger);
 	const gitHubUserClient = new GitHubUserClient(githubToken, logger);
 
 	try {

--- a/src/routes/jira/configuration/jira-configuration-get.ts
+++ b/src/routes/jira/configuration/jira-configuration-get.ts
@@ -8,7 +8,6 @@ import { RepoSyncState } from "models/reposyncstate";
 import { statsd }  from "config/statsd";
 import { metricError } from "config/metric-names";
 import { AppInstallation, FailedAppInstallation } from "config/interfaces";
-import { getCloudInstallationId } from "~/src/github/client/installation-id";
 import { GitHubAppClient } from "~/src/github/client/github-app-client";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
 
@@ -47,7 +46,7 @@ const getInstallation = async (client: GitHubAPI, subscription: Subscription, lo
 	const { jiraHost } = subscription;
 	const useNewGitHubClient = await booleanFlag(BooleanFlags.USE_NEW_GITHUB_CLIENT_FOR_GET_INSTALLATION, false, jiraHost) ;
 	const { gitHubInstallationId } = subscription;
-	const gitHubAppClient = new GitHubAppClient(getCloudInstallationId(gitHubInstallationId), log);
+	const gitHubAppClient = new GitHubAppClient(log);
 
 	try {
 		const response = useNewGitHubClient ?


### PR DESCRIPTION
Replace the need for githubinstallationID on the github app client

introduced new feature flag use-new-github-client-for-redirect to use ghclient in place of octokit

