### PR TITLE
JST-761382: Use repo owner login instead of repo owner name for orgName

### DIFF
--- a/src/middleware/github-webhook-middleware.ts
+++ b/src/middleware/github-webhook-middleware.ts
@@ -93,7 +93,7 @@ export const GithubWebhookMiddleware = (
 
 		const { name, payload, id: webhookId } = context;
 		const repoName = payload?.repository?.name || "none";
-		const orgName = payload?.repository?.owner?.name || "none";
+		const orgName = payload?.repository?.owner?.login || "none";
 		const gitHubInstallationId = Number(payload?.installation?.id);
 
 		context.log = context.log.child({


### PR DESCRIPTION
Attempt to fix JST-761382.

According to the GH API docs, not all repo owners have a name but all have a login https://docs.github.com/en/rest/repos/repos#get-a-repository.