### PR TITLE
ARC-467 - ARC-467-add-tag-web-worker-metrics

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -43,6 +43,7 @@ export const envVars: EnvVars = {
 	...process.env,
 	MICROS_ENV: EnvironmentEnum[process.env.MICROS_ENV || EnvironmentEnum.development],
 	MICROS_SERVICE_VERSION: process.env.MICROS_SERVICE_VERSION,
+	MICROS_GROUP: process.env.MICROS_GROUP || "",
 	NODE_ENV: nodeEnv,
 	SENTRY_DSN: process.env.SENTRY_DSN,
 	JIRA_LINK_TRACKING_ID: process.env.JIRA_LINK_TRACKING_ID,
@@ -62,6 +63,7 @@ export interface EnvVars {
 	NODE_ENV: EnvironmentEnum,
 	MICROS_ENV: EnvironmentEnum;
 	MICROS_SERVICE_VERSION?: string;
+  MICROS_GROUP: string;
 	SQS_BACKFILL_QUEUE_URL: string;
 	SQS_BACKFILL_QUEUE_REGION: string;
 	SQS_PUSH_QUEUE_URL: string;

--- a/src/config/statsd.ts
+++ b/src/config/statsd.ts
@@ -3,12 +3,13 @@ import { getLogger } from "./logger";
 import { NextFunction, Request, Response } from "express";
 import { isNodeDev, isNodeTest } from "utils/is-node-env";
 import { metricHttpRequest } from "./metric-names";
+import { envVars } from "./env";
 
 export const globalTags = {
 	environment: isNodeTest() ? "test" : process.env.MICROS_ENV || "",
 	environment_type: isNodeTest() ? "testenv" : process.env.MICROS_ENVTYPE || "",
-	deployment_id: process.env.MICROS_DEPLOYMENT_ID || "1",
-	region: process.env.MICROS_AWS_REGION || "us-west-1"
+	region: process.env.MICROS_AWS_REGION || "us-west-1",
+	micros_group: envVars.MICROS_GROUP
 };
 
 const RESPONSE_TIME_HISTOGRAM_BUCKETS = "100_1000_2000_3000_5000_10000_30000_60000";

--- a/src/github/issue.ts
+++ b/src/github/issue.ts
@@ -3,7 +3,7 @@ import { CustomContext } from "middleware/github-webhook-middleware";
 import { GitHubInstallationClient } from "./client/github-installation-client";
 import { getCloudInstallationId } from "./client/installation-id";
 import { WebhookPayloadIssues } from "@octokit/webhooks";
-import { GitHubIssue, GitHubIssueData } from '../interfaces/github';
+import { GitHubIssue, GitHubIssueData } from "../interfaces/github";
 
 export const issueWebhookHandler = async (context: CustomContext<WebhookPayloadIssues>, _jiraClient, util, githubInstallationId: number): Promise<void> => {
 	const {

--- a/src/github/push.ts
+++ b/src/github/push.ts
@@ -2,7 +2,7 @@ import { enqueuePush } from "../transforms/push";
 import { Context } from "probot/lib/context";
 import { getCurrentTime } from "utils/webhook-utils";
 import { hasJiraIssueKey } from "utils/jira-utils";
-import { GitHubPushData } from '../interfaces/github';
+import { GitHubPushData } from "../interfaces/github";
 
 export const pushWebhookHandler = async (context: Context, jiraClient): Promise<void> => {
 	const webhookReceived = getCurrentTime();

--- a/src/github/workflow.ts
+++ b/src/github/workflow.ts
@@ -3,7 +3,7 @@ import { CustomContext } from "middleware/github-webhook-middleware";
 import { emitWebhookProcessedMetrics } from "utils/webhook-utils";
 import { GitHubInstallationClient } from "./client/github-installation-client";
 import { getCloudInstallationId } from "./client/installation-id";
-import { JiraBuildData } from '../interfaces/jira';
+import { JiraBuildData } from "../interfaces/jira";
 
 export const workflowWebhookHandler = async (context: CustomContext, jiraClient, _util, githubInstallationId: number): Promise<void> => {
 	const { payload, log: logger } = context;

--- a/src/transforms/transform-workflow.ts
+++ b/src/transforms/transform-workflow.ts
@@ -1,10 +1,9 @@
 import { LoggerWithTarget } from "probot/lib/wrap-logger";
-import { GitHubPullRequest } from "interfaces/github";
+import { GitHubPullRequest , GitHubWorkflowPayload } from "interfaces/github";
 import { JiraBuildData, JiraPullRequestHead } from "interfaces/jira";
 import { getAllCommitMessagesBetweenReferences } from "./util/github-api-requests";
 import { GitHubInstallationClient } from "../github/client/github-installation-client";
 import { jiraIssueKeyParser } from "utils/jira-utils";
-import { GitHubWorkflowPayload } from '../interfaces/github';
 
 // We need to map the status and conclusion of a GitHub workflow back to a valid build state in Jira.
 // https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository


### PR DESCRIPTION
Add new metrics group to global configuration of statd to indicate whether it is from WebServer or Worker.

Have deployed to stg-west and verify it in the dashboard.

![webserver](https://user-images.githubusercontent.com/105693507/170162755-d07df9b4-a063-4cc3-b6b8-f7f1480865d1.png)

![worker](https://user-images.githubusercontent.com/105693507/170162777-4623587d-322f-4943-8d64-472333c94c52.png)
