### PR TITLE
limited the commit message length on push events

### DIFF
--- a/src/transforms/push.ts
+++ b/src/transforms/push.ts
@@ -1,6 +1,6 @@
 import { Subscription } from "models/subscription";
 import { getJiraClient } from "../jira/client/jira-client";
-import { getJiraAuthor, jiraIssueKeyParser } from "utils/jira-utils";
+import { getJiraAuthor, jiraIssueKeyParser, limitCommitMessage } from "utils/jira-utils";
 import { emitWebhookProcessedMetrics } from "utils/webhook-utils";
 import { JiraCommit } from "interfaces/jira";
 import { LoggerWithTarget } from "probot/lib/wrap-logger";
@@ -143,7 +143,7 @@ export const processPush = async (github: GitHubInstallationClient, payload: Pus
 					log.info("GitHub call succeeded");
 					return {
 						hash: commitSha,
-						message,
+						message: limitCommitMessage(message),
 						author: getJiraAuthor(author, githubCommitAuthor),
 						authorTimestamp: githubCommitAuthor.date,
 						displayId: commitSha.substring(0, 6),


### PR DESCRIPTION
There is still some noise coming through for the data depot migration. Commit message length > 1024

_Kinda tempted to change out limiter to 1023 incase there is a off by 1 error in the logic somewhere e.g. `data < 1024`_

https://splunk.paas-inf.net/en-GB/app/search/search?earliest=-60m%40m&latest=now&q=search%20%60micros_jswdd-processor%60%20env%3Dprod*%20level%3DWARN%20%22submitDevInfo%20failed%20parse%2Fvalidate%22%20provider-namespace%3Dclassic%20provider-id%3Dcom.github.integration.production&display.events.fields=%5B%22message%22%2C%20%22m.sv%22%5D&display.page.search.mode=fast&dispatch.sample_ratio=1&display.page.search.tab=events&display.general.type=events&sid=1653878702.704393_62D9EEBE-1751-48A5-B0C6-CDABAC40F831

Feel like there is more than this change to resolve it, but will monitor the numbers to see any significant change.

Then will try get more information to track down the exact location of the error if we can.