### PR TITLE
Added a hitbox for the sync warning hover icon

### DIFF
--- a/static/css/jira-configuration.css
+++ b/static/css/jira-configuration.css
@@ -159,8 +159,7 @@
 /* Hit box */
 .jiraConfiguration__syncWarning:before {
   content: '';
-  width: 3rem;
-  height: 3rem;
+  padding: 1.25em;
   position: absolute;
 }
 

--- a/static/css/jira-configuration.css
+++ b/static/css/jira-configuration.css
@@ -156,6 +156,14 @@
   padding: 0.2rem;
 }
 
+/* Hit box */
+.jiraConfiguration__syncWarning:before {
+  content: '';
+  width: 3rem;
+  height: 3rem;
+  position: absolute;
+}
+
 .jiraConfiguration__syncWarning:hover {
   background: #0914E208;
 }


### PR DESCRIPTION
**In this PR**

Added a hitbox to the sync warning icon to keep popup open when transitioning from icon to popup.

Couple of options here in how to achieve it... went with least intrusive.

**Proof**
The thing to look for in the screenshot is the location of the cursor(just above the warning icon) before the change the popup would vanish if the cursor went to the deadzone between icon and popup, much annoying.

It now has a generous hitbox around it so that its more consistent with that atlas feel.

<img width="1201" alt="Screen Shot 2022-06-08 at 10 23 06 AM" src="https://user-images.githubusercontent.com/3848691/172493250-9bdf872a-1d3e-483f-945e-2a71d91c4c72.png">

