### PR TITLE
PCS-87130 fixing cursor issue that would save NaN to DB

### DIFF
--- a/src/sync/discovery.ts
+++ b/src/sync/discovery.ts
@@ -55,7 +55,7 @@ export const getRepositoryTask = async (
 	let edges: RepositoryNode[];
 	let repositories: Repository[];
 	if (await booleanFlag(BooleanFlags.USE_REST_API_FOR_DISCOVERY, false, jiraHost)) {
-		const page = Number(cursor);
+		const page = Number(cursor) || 1;
 		const response = await newGithub.getRepositoriesPageOld(page);
 		hasNextPage = response.hasNextPage;
 		totalCount = response.data.total_count;


### PR DESCRIPTION
Found small issue in FF code for customer that would save `NaN` in the DB for the repository cursor.