### PR TITLE
ARC-1426: Assert optional when getting repo name

### DIFF
--- a/src/transforms/transform-pull-request.ts
+++ b/src/transforms/transform-pull-request.ts
@@ -54,12 +54,12 @@ export const transformPullRequest = async (github: GitHubAPI | GitHubInstallatio
 
 	const logPayload = {
 		prTitle: prTitle || "none",
-		repoName: head?.repo.name || "none",
+		repoName: head?.repo?.name || "none",
 		prRef: pullRequest.head.ref || "none"
 	};
 
 	if (isEmpty(issueKeys) || !head?.repo) {
-		log?.info(logPayload, "Ignoring pullrequest hence it has no issue keys or repo");
+		log?.info(logPayload, "Ignoring pullrequest since it has no issue keys or repo");
 		return undefined;
 	}
 


### PR DESCRIPTION
From Sentry:

> TypeError
>  transformPullRequest(transforms:transform-pull-request)
> Cannot read property 'name' of null
> /app/src/transforms/transform-pull-request.js` in transformPullRequest at line 46:29

We do get some payloads that don't contain a repo for some reason, which we do validate on line 61. This PR only adds a `?` before getting the repo name in case there's no repo.