### PR TITLE
ARC-1393 -GHE UI: Redirecting to GHE Server Instance 

### DIFF
--- a/static/assets/jira-logo.svg
+++ b/static/assets/jira-logo.svg
@@ -1,0 +1,11 @@
+
+<svg height="80" viewBox="2.59 0 214.091 224" width="80" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <linearGradient id="a" gradientTransform="matrix(1 0 0 -1 0 264)" gradientUnits="userSpaceOnUse" x1="102.4" x2="56.15" y1="218.63" y2="172.39">
+        <stop offset=".18" stop-color="#0052cc"/>
+        <stop offset="1" stop-color="#2684ff"/>
+    </linearGradient>
+    <linearGradient id="b" x1="114.65" x2="160.81" xlink:href="#a" y1="85.77" y2="131.92"/>
+    <path d="M214.06 105.73 117.67 9.34 108.33 0 35.77 72.56 2.59 105.73a8.89 8.89 0 0 0 0 12.54l66.29 66.29L108.33 224l72.55-72.56 1.13-1.12 32.05-32a8.87 8.87 0 0 0 0-12.59zm-105.73 39.39L75.21 112l33.12-33.12L141.44 112z" fill="#2684ff"/>
+    <path d="M108.33 78.88a55.75 55.75 0 0 1-.24-78.61L35.62 72.71l39.44 39.44z" fill="url(#a)"/>
+    <path d="m141.53 111.91-33.2 33.21a55.77 55.77 0 0 1 0 78.86L181 151.35z" fill="url(#b)"/>
+</svg>

--- a/static/css/ghe-loading.css
+++ b/static/css/ghe-loading.css
@@ -1,0 +1,44 @@
+.gheLoading___body {
+    background: #fff;
+}
+
+.gheLoading___container {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: center;
+    margin: auto;
+    max-width: 470px;
+}
+
+.gheLoading___header {
+    font-size: 1.5rem;
+}
+
+.gheLoading___imgDivider {
+    font-size: 2.8rem;
+}
+
+.gheLoading___imgContainer {
+    margin: 4.688em 0 4.063em;
+    display: flex;
+    width: 100%;
+    justify-content: space-evenly;
+    align-items: center;
+}
+
+.gheLoading___jiraImg {
+    height: 80px;
+}
+
+.gheLoading___GitHubImg {
+    height: 60px;
+}
+
+.gheLoading___message {
+    text-align: center;
+    max-width: 364px;
+    color: #344563;
+    font-size: 0.875rem;
+}

--- a/views/ghe-loading.hbs
+++ b/views/ghe-loading.hbs
@@ -1,0 +1,44 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="ap-local-base-url" content="{{localBaseUrl}}" />
+    <title>{{title}}</title>
+    <link rel="stylesheet" href="/public/css/ghe-loading.css" media="all" />
+    <link
+      rel="stylesheet"
+      href="/public/aui/aui-prototyping.css"
+      integrity="DTM1Q+8lU7SzJT+FWr0JFisCSZlwfM0GiAKYy7h1s9vIKa/CIh37s9NuOCqIOgK4tmqrjLK4NuWuIPUQNsikHA=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+    <script src="/public/js/jquery.min.js" nonce="{{nonce}}"></script>
+  </head>
+  <body class="gheLoading___body">
+    <section class="gheLoading___container">
+      <h3 class="gheLoading___header">Retrieving data from GitHub Enterprise Server</h3>
+
+      <div class="gheLoading___imgContainer">
+          <img class="gheLoading___jiraImg" src="/public/assets/jira-logo.svg" alt="Jira">
+          <div class="gheLoading___imgDivider">-</div>
+          <div>
+            <aui-spinner size="large"></aui-spinner>
+          </div>
+          <div class="gheLoading___imgDivider">-</div>
+          <img class="gheLoading___GitHubImg" src="/public/assets/github-logo.svg" alt="Github">
+      </div>
+
+      <p class="gheLoading___message">
+        If your instance doesn't load, check that your URL configuration is correct.
+      </p>
+
+    </section>
+  </body>
+<script
+  src="/public/aui/aui-prototyping.js"
+  integrity="sha512-DkENIkhNP5r+sfHUC5hhFAzApGNR5HTu1fzymBBhXZma4zytOUQh8qhz5xc3nSbSQfdYI6qdI281YwUNmubEMw=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+  nonce="{{nonce}}"
+></script>
+</html>


### PR DESCRIPTION
**Rationale**
- This PR includes a new screen for the loading state of GHE.

**Changes**
- Added a new view `ghe-loading.hbs` with its css file.
- Added a new `jira-logo.svg`.
  - Used `aui-spinner` and used **Jira** and **GitHub** svg logos for the image

**Preview**
![demo](https://user-images.githubusercontent.com/13076255/173479795-a632309d-23a9-4eb8-a245-b5d75d4881dc.gif)

