### PR TITLE
ARC-1428: Assert optional when getting PR review status

### DIFF
--- a/src/transforms/transform-pull-request.ts
+++ b/src/transforms/transform-pull-request.ts
@@ -29,7 +29,7 @@ function mapReviews(reviews: Octokit.PullsListReviewsResponse = []) {
 		if (!usernames[author?.login]) {
 			usernames[author?.login] = {
 				...getJiraAuthor(author),
-				approvalStatus: review.state === "APPROVED" ? "APPROVED" : "UNAPPROVED"
+				approvalStatus: review?.state === "APPROVED" ? "APPROVED" : "UNAPPROVED"
 			};
 			acc.push(usernames[author?.login]);
 			// If user is already added (not unique) but the previous approval status is different than APPROVED and current approval status is APPROVED, updates approval status.


### PR DESCRIPTION
From [Sentry](https://sentry.io/organizations/atlassian-2y/issues/3147532533/events/a0eb3e1e5fb9491cbecb9a1d18924b5c/?project=5988951&query=is%3Aunresolved)
> TypeError
> Cannot read property 'state' of null
> /app/src/transforms/transform-pull-request.js in null.<anonymous> at line 29:40

Wasn't able to quite replicate this one locally but at least this PR will fix type errors.

However, I did come across a scenario where if I add a reviewer while creating the pull request before hitting the "Create pull request" button, the reviewers don't appear in Jira because we do a `getReviews` instead of looking through the `requested_reviewers` field in the payload. Raising a ticket [ARC-1430] in our backlog to address this.

[ARC-1430]: https://softwareteams.atlassian.net/browse/ARC-1430