### PR TITLE
PCS-87130 remove duplicates in reposyncstate table

### DIFF
--- a/db/migrations/20220617130400-remove-duplicates-reposyncstate.js
+++ b/db/migrations/20220617130400-remove-duplicates-reposyncstate.js
@@ -1,0 +1,25 @@
+"use strict";
+
+module.exports = {
+	up: async (queryInterface) => {
+		// Deletes duplicates in RepoSyncState based on the partition between
+		// subscriptionId and repoId (no repoId can be the same under the same subscriptionId)
+		// The inner select gets all duplicates and returns the id (our primary key) in
+		// ascending order (first one created is first) and the current row number in a temp table.
+		// The outer select then only selects the id from the temp table for those of row number
+		// above 1 (leaving the first row out) essentially only selecting the extra duplicates.
+		// Then we just delete everything with those ids in RepoSyncState.
+		await queryInterface.sequelize.query(`
+			DELETE FROM "RepoSyncStates" WHERE id IN (
+				SELECT id FROM (
+					SELECT id, ROW_NUMBER() OVER(
+					    PARTITION BY "subscriptionId", "repoId" ORDER BY id
+					) AS row_num FROM "RepoSyncStates"
+			) t WHERE t.row_num > 1);
+		`);
+	},
+
+	down: async (queryInterface) => {
+		// There's no coming back from this....
+	}
+};


### PR DESCRIPTION
This script is to remove duplicates in the RepoSyncState table where `subscriptionId` and `repoId` are the same.  It should be impossible to have more than one `repoId` of the same number with the same `subscriptionId`.  I consider this being low risk since this is temporary data only and if data loss does occur, we can simply re-backfill everything.

I don't want to do that for one customer as it's taken days just to backfill to this very moment but they're currently stuck because of the duplicates.  I've tested this thoroughly on my local and from running the same script (minus the deletion bit) on read-replica, I know for a fact that `21684` duplicates will be deleted.  Only 2 customers will be affected with `subscriptionId` of 110062 and 126603.  One of which is the one I'm trying to unblock currently, which will have 21100 duplicates removed.  After the duplicates are gone, I can then continue the backfill by kicking off a partial for both these customers to make sure it completes.