### PR TITLE
ARC-1435 - Update the validation error for GitHub Cloud URL when creating GHE server

### DIFF
--- a/static/js/jira-connect-ghe.js
+++ b/static/js/jira-connect-ghe.js
@@ -1,5 +1,16 @@
 const ALLOWED_PROTOCOLS = ["http:", "https:"];
 const GITHUB_CLOUD = ["github.com", "www.github.com"];
+const defaultError = {
+	message: 'The entered URL is not valid.',
+	linkMessage: 'Learn more',
+	// TODO: add URL for this
+	linkUrl: '#'
+}
+const cloudURLError = {
+	message: 'The entered URL is a GitHub Cloud site.',
+	linkMessage: 'Connect a GitHub Cloud site',
+	linkUrl: '/session/github/configuration'
+}
 
 /**
  * Method that checks the validity of the passed URL
@@ -12,31 +23,44 @@ const checkValidGHEUrl = inputURL => {
 		const { protocol, hostname } = new URL(inputURL);
 
 		if (!ALLOWED_PROTOCOLS.includes(protocol)) {
+			setErrorMessage(defaultError);
 			return false;
 		}
 		// This checks whether the hostname whether there is an extension like `.com`, `.net` etc.
 		if (hostname.split('.').length < 2) {
+			setErrorMessage(defaultError);
+			return false;
+		}
+		if (GITHUB_CLOUD.includes(hostname)) {
+			setErrorMessage(cloudURLError);
 			return false;
 		}
 
 		return true;
 	} catch (e) {
+		setErrorMessage(defaultError);
 		return false;
 	}
 };
 
 /**
- * Checks if the passed valid URL is GitHub enterprise or GitHub Cloud
+ * Sets an error message with the passed parameters
  *
- * @param {string} url
- * @returns {boolean}
+ * @param {Object<defaultError | cloudURLError>} error
  */
-const checkGHEServerUrl = url => {
-	const { hostname } = new URL(url);
-	if (GITHUB_CLOUD.includes(hostname)) {
-		return false;
-	}
-	return true;
+const setErrorMessage = error => {
+	$("#gheServerURLError").show();
+	$("#gheServerURLError > span").html(error.message);
+	$("#gheServerURLError > a").html(error.linkMessage).attr("href", error.linkUrl);
+	$("#gheServerURL").addClass("has-error");
+};
+
+/**
+ * Hides the error messages
+ */
+const hideErrorMessage = () => {
+	$("#gheServerURLError").hide();
+	$("#gheServerURL").removeClass("has-error");
 };
 
 $("#gheServerURL").on("keyup", event => {
@@ -45,8 +69,7 @@ $("#gheServerURL").on("keyup", event => {
 		"aria-disabled": !hasUrl,
 		"disabled": !hasUrl
 	});
-	$("#gheServerURLError").hide();
-	$("#gheServerURL").removeClass("has-error");
+	hideErrorMessage();
 });
 
 $("#gheServerBtn").on("click", event => {
@@ -60,23 +83,13 @@ $("#gheServerBtn").on("click", event => {
 	});
 
 	if (isValid) {
-		$("#gheServerURLError").hide();
+		hideErrorMessage();
+
+		// Changing the text on the button and displaying the spinner
 		$("#gheServerBtnText").hide();
 		$("#gheServerBtnSpinner").show();
-		$("#gheServerURL").removeClass("has-error");
 
-		if (checkGHEServerUrl(typedURL)) {
-			//	TODO: Need to add the action for the GHE server
-			console.log("GHE server URL: ", typedURL);
-		} else {
-			// TODO: Need to alert the users that this URL is GitHub cloud and not Enterprise
-			// Waiting for design: https://softwareteams.atlassian.net/browse/ARC-1418
-			console.log('Cloud URL Entered', typedURL);
-		}
-
-
-	} else {
-		$("#gheServerURLError").show();
-		$("#gheServerURL").addClass("has-error");24
+		//	TODO: Need to add the action for the GHE server
+		console.log("GHE server URL: ", typedURL);
 	}
 });

--- a/views/jira-connect-ghe.hbs
+++ b/views/jira-connect-ghe.hbs
@@ -61,9 +61,8 @@
             <input type="text" class="jiraConnectGHE__input" id="gheServerURL" placeholder="https://example.com" />
             <div class="jiraConnectGHE__error" id="gheServerURLError">
               <i class="aui-icon aui-iconfont-error"></i>
-              The entered URL is not valid.
-              <!--TODO: Add a link here-->
-              <a href="" target="_blank">Learn more.</a>
+              <span></span>
+              <a href="" target="_blank"></a>
             </div>
           </div>
 


### PR DESCRIPTION
**Rationale**
- When users type in a GitHub cloud URL when trying to connect to a GitHub Enterprise server, it is now treated as a URL validation error, displaying an error message with a link that redirects to GitHub Cloud site.

**Changes**
- The separate method `checkGHEServerUrl` was removed and the logic was added to `checkValidGHEUrl`.
- A new method was created which simply displays the error messages, based on the error object passed to it.
- Minor code cleanup 
  - A new method `hideErrorMessage` was created.

**Video**
https://www.loom.com/share/0605e2c39ac5443a8b76089cbb5bf267

**Whats not done**
- No validation in terms of duplication nor security has been implemented. It will be done in backend.