### PR TITLE
ARC-1462 Added check to make sure pipeline is not running before triggering new one

### DIFF
--- a/deploy/lambda/auto-deployment.js
+++ b/deploy/lambda/auto-deployment.js
@@ -1,5 +1,7 @@
 const https = require('https');
 
+const pipelinesURL = 'https://api.bitbucket.org/2.0/repositories/atlassian/github-for-jira-deployment/pipelines/';
+
 exports.handler = async function (event, context) {
     const autoDeployUsername = process.env.AUTO_DEPLOY_USERNAME;
     const autoDeployToken = process.env.AUTO_DEPLOY_TOKEN;
@@ -27,7 +29,6 @@ exports.handler = async function (event, context) {
         if (deployedCommitSHA !== mainCommitSHA && ! await isPipelineRunning()) {
             console.log('Changes found, starting deployment...');
 
-            const pipelinesURL = 'https://api.bitbucket.org/2.0/repositories/atlassian/github-for-jira-deployment/pipelines/';
             const body = {
                 "target": {
                     "type": "pipeline_ref_target",
@@ -57,7 +58,7 @@ exports.handler = async function (event, context) {
 
 // Returns true if any pipline is running for deployment to stage/prod
 async function isPipelineRunning() {
-    const url = "https://api.bitbucket.org/2.0/repositories/atlassian/github-for-jira-deployment/pipelines/?page=1&pagelen=20&sort=-created_on"
+    const url = `${pipelinesURL}?page=1&pagelen=20&sort=-created_on`;
     const pipelines = await getRequest(url, {
         'Authorization': 'Basic ' + new Buffer(autoDeployUsername + ':' + autoDeployToken).toString('base64')
     });
@@ -136,3 +137,5 @@ function postRequest(url, body, headers = {}) {
         req.end();
     });
 }
+
+isPipelineRunning()

--- a/deploy/lambda/auto-deployment.js
+++ b/deploy/lambda/auto-deployment.js
@@ -59,7 +59,7 @@ exports.handler = async function (event, context) {
 async function isPipelineRunning() {
     const url = "https://api.bitbucket.org/2.0/repositories/atlassian/github-for-jira-deployment/pipelines/?page=1&pagelen=20&sort=-created_on"
     const pipelines = await getRequest(url, {
-        'Authorization': 'Basic ' + new Buffer('fusion-release-bot:2nXHekMCpxc3T8rGPKwP').toString('base64')
+        'Authorization': 'Basic ' + new Buffer(autoDeployUsername + ':' + autoDeployToken).toString('base64')
     });
     const runningPipelines = pipelines.values.filter((pipeline) => {
         return (pipeline?.target?.selector?.type === "custom"

--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -650,7 +650,7 @@ environmentOverrides:
           timeout: 60
           scheduledRules:
             - name: 'PipelinesExecutionForGH4J'
-              # Cron for running 20 minutes
-              expression: 'cron(0/60 * * * ? *)'
+              # Cron for running 10 minutes
+              expression: 'cron(0/10 * * * ? *)'
           dataType:
             - Atlassian/Configuration


### PR DESCRIPTION
**What's in this PR?**
- Added condition to make sure not other pipeline is running  before trigerring new pipeline.
- Updated cron expression to run auto deployment lambda in every 10 mins

**Why**
We want to run auto-deployment lambda in every 10 mins and starts deployment if any change in master branch. The pipeline takes ~40 mins to deploy to prod. If auto-deployment lambda again runs in that timeframe, it will trigger the pipeline again. This will result in muti pipelines running for same commit in master branch.

**Added feature flags**
NA

**Affected issues**  
NA

**How has this been tested?**  
This is running only in Prod. By looking into lamda invocations timestamp and logs.

**Whats Next?**
NA