### PR TITLE
ARC-1441: remove `this` within static method.

### DIFF
--- a/src/util/encryption-client.ts
+++ b/src/util/encryption-client.ts
@@ -28,7 +28,7 @@ interface DecryptResponse {
  */
 export class EncryptionClient {
 
-	protected static readonly axios: AxiosInstance = axios.create({
+	private static readonly axiosInst: AxiosInstance = axios.create({
 		baseURL: envVars.CRYPTOR_URL,
 		headers: {
 			"X-Cryptor-Client": envVars.CRYPTOR_SIDECAR_CLIENT_IDENTIFICATION_CHALLENGE,
@@ -38,7 +38,7 @@ export class EncryptionClient {
 
 	static async encrypt(secretKey: EncryptionSecretKeyEnum, plainText: string, encryptionContext: EncryptionContext = {}): Promise<string> {
 		try {
-			const response = await this.axios.post<EncryptResponse>(`/cryptor/encrypt/micros/github-for-jira/${secretKey}`, {
+			const response = await EncryptionClient.axiosInst.post<EncryptResponse>(`/cryptor/encrypt/micros/github-for-jira/${secretKey}`, {
 				plainText,
 				encryptionContext
 			});
@@ -52,7 +52,7 @@ export class EncryptionClient {
 
 	static async decrypt(cipherText: string, encryptionContext: EncryptionContext = {}): Promise<string> {
 		try {
-			const response = await this.axios.post<DecryptResponse>(`/cryptor/decrypt`, {
+			const response = await EncryptionClient.axiosInst.post<DecryptResponse>(`/cryptor/decrypt`, {
 				cipherText,
 				encryptionContext
 			});
@@ -64,6 +64,6 @@ export class EncryptionClient {
 	}
 
 	static async healthcheck(): Promise<AxiosResponse> {
-		return await this.axios.get("/healthcheck");
+		return await EncryptionClient.axiosInst.get("/healthcheck");
 	}
 }


### PR DESCRIPTION
**What's in this PR?**
Remove the `this` usage in a static method.

**Why**
Since it is static method, `this` doesn't make sense. 
But above it is just in theory. When compiled, typescript make `this` same as the class itself. Hence why unit test didn't pick this up. But I think we should still use it like static method.

**Added feature flags**
N/A

**Affected issues**  
ARC-1441

**How has this been tested?**  
Unit test.

**Whats Next?**
N/A