### PR TITLE
ARC-1501: add a ping endpoint to test outbound connections

### DIFF
--- a/src/routes/api/api-ping-get.ts
+++ b/src/routes/api/api-ping-get.ts
@@ -1,0 +1,34 @@
+import { Request, Response } from "express";
+import axios from "axios";
+
+/**
+ * Makes a call to the URL passed into the "url" field of the body JSON.
+ */
+export const ApiPingGet = async (req: Request, res: Response): Promise<void> => {
+
+	const { data } = req.body;
+
+	if (!data || !data.url) {
+		res.status(400)
+			.json({
+				message: "Please provide a JSON object with the field 'url'."
+			});
+		return;
+	}
+
+	try {
+		const pingResponse = await axios.get(data.url);
+		res.json({
+			url: data.url,
+			method: "GET",
+			statusCode: pingResponse.status,
+			statusText: pingResponse.statusText
+		});
+	} catch (err) {
+		res.json({
+			url: data.url,
+			method: "GET",
+			error: err
+		});
+	}
+};

--- a/src/routes/api/api-router.test.ts
+++ b/src/routes/api/api-router.test.ts
@@ -330,5 +330,45 @@ describe("API Router", () => {
 			});
 
 		});
+
+		describe("Ping", () => {
+
+			it("Should fail on missing url", () => {
+				return supertest(app)
+					.get("/api/ping")
+					.set("host", "127.0.0.1")
+					.set("X-Slauth-Mechanism", "slauthtoken")
+					.expect(400)
+					.then((response) => {
+						expect(response.body?.message).toEqual("Please provide a JSON object with the field 'url'.");
+					});
+			});
+
+			it("Should return error on failed ping", () => {
+				return supertest(app)
+					.get("/api/ping")
+					.set("host", "127.0.0.1")
+					.set("X-Slauth-Mechanism", "slauthtoken")
+					.send({ data: { url: "http://github-does-not-exist.internal.atlassian.com" } })
+					.expect(200)
+					.then((response) => {
+						expect(response.body?.error.code).toEqual("ENOTFOUND");
+					});
+			});
+
+			// skipped out because I just used it as a manual test and don't want to make real calls in CI
+			it.skip("Should return 200 on successful ping", () => {
+				return supertest(app)
+					.get("/api/ping")
+					.set("host", "127.0.0.1")
+					.set("X-Slauth-Mechanism", "slauthtoken")
+					.send({ data: { url: "https://google.com" } })
+					.expect(200)
+					.then((response) => {
+						expect(response.body?.statusCode).toEqual(200);
+					});
+			});
+
+		});
 	});
 });

--- a/src/routes/api/api-router.ts
+++ b/src/routes/api/api-router.ts
@@ -14,6 +14,7 @@ import { json, urlencoded } from "body-parser";
 import { ApiInstallationDelete } from "./installation/api-installation-delete";
 import { ApiHashPost } from "./api-hash-post";
 import { EncryptionClient, EncryptionSecretKeyEnum } from "utils/encryption-client";
+import { ApiPingGet } from "routes/api/api-ping-get";
 
 export const ApiRouter = Router();
 
@@ -98,6 +99,8 @@ ApiRouter.post(
 
 // Hash incoming values with GLOBAL_HASH_SECRET.
 ApiRouter.post("/hash", ApiHashPost);
+
+ApiRouter.get("/ping", ApiPingGet);
 
 // TODO: remove once move to DELETE /:installationId/:jiraHost
 ApiRouter.delete(


### PR DESCRIPTION
Adding an admin endpoint that "pings" a remote URL so we can test if a certain URL is accessible from our staging and production servers.

This is so we can test any network changes, specifically the change we need to do so that our internal GitHub Enterprise Server instance is accessible from our Micros service.