### PR TITLE
ARC-1487 - Update jira connect to hide pages in dropdown

### DIFF
--- a/src/routes/jira/jira-atlassian-connect-get.ts
+++ b/src/routes/jira/jira-atlassian-connect-get.ts
@@ -70,6 +70,7 @@ const modules = {
 				value: "GitHub Select Version"
 			},
 			url: "/jira/select-version",
+			location: "none",
 			conditions: adminCondition
 		},
 		{
@@ -78,6 +79,7 @@ const modules = {
 				value: "GitHub Server Url"
 			},
 			url: "/jira/server-url",
+			location: "none",
 			conditions: adminCondition
 		},
 		{
@@ -86,6 +88,7 @@ const modules = {
 				value: "GitHub App Creation"
 			},
 			url: "/jira/app-creation",
+			location: "none",
 			conditions: adminCondition
 		}
 	],

--- a/test/snapshots/routes/jira/jira-atlassian-connect.test.ts.snap
+++ b/test/snapshots/routes/jira/jira-atlassian-connect.test.ts.snap
@@ -39,6 +39,7 @@ Object {
           },
         ],
         "key": "github-select-version-page",
+        "location": "none",
         "name": Object {
           "value": "GitHub Select Version",
         },
@@ -51,6 +52,7 @@ Object {
           },
         ],
         "key": "github-server-url-page",
+        "location": "none",
         "name": Object {
           "value": "GitHub Server Url",
         },
@@ -63,6 +65,7 @@ Object {
           },
         ],
         "key": "github-app-creation-page",
+        "location": "none",
         "name": Object {
           "value": "GitHub App Creation",
         },

--- a/test/snapshots/routes/maintenance/maintenance-router.test.ts.snap
+++ b/test/snapshots/routes/maintenance/maintenance-router.test.ts.snap
@@ -39,6 +39,7 @@ Object {
           },
         ],
         "key": "github-select-version-page",
+        "location": "none",
         "name": Object {
           "value": "GitHub Select Version",
         },
@@ -51,6 +52,7 @@ Object {
           },
         ],
         "key": "github-server-url-page",
+        "location": "none",
         "name": Object {
           "value": "GitHub Server Url",
         },
@@ -63,6 +65,7 @@ Object {
           },
         ],
         "key": "github-app-creation-page",
+        "location": "none",
         "name": Object {
           "value": "GitHub App Creation",
         },


### PR DESCRIPTION
**What's in this PR?**
- Added `location: none` to all the `generalPages` in the app-connector file.

**Why**
- To hide the pages from showing up in the dropdown(screenshot below). We don’t want our customers to be able to jump ahead in the flow/navigate to any parts of that flow if they’re trying to connect to cloud so we need to figure out a way to prevent them from rendering in the dropdown.
- ![image](https://user-images.githubusercontent.com/13076255/178199673-018295f6-c648-4309-9137-3ebb82ed40e9.png)