### PR TITLE
ARC-1427 return early if no array values

### DIFF
--- a/src/transforms/transform-code-scanning-alert.ts
+++ b/src/transforms/transform-code-scanning-alert.ts
@@ -68,6 +68,9 @@ export const transformCodeScanningAlert = async (context: WebhookContext, github
 	// Grab branch names or PR titles
 	const entityTitles: string[] = [];
 	if (action === "closed_by_user" || action === "reopened_by_user") {
+		if (!alert.instances?.length) {
+			return undefined;
+		}
 		// These are manual operations done by users and are not associated to a specific Issue.
 		// The webhook contains ALL instances of this alert, so we need to grab the ref from each instance.
 		entityTitles.push(...await Promise.all(alert.instances.map(


### PR DESCRIPTION
**What's in this PR?**
Returning early if the code scan alert webhook does not contain any instances or undefined.
Over 7000 errors in the last 30 days 
Splunk query - `micros_github-for-jira env="prod*" "Cannot read property 'map'*" | stats count by event`

**Why**
Firstly, to stop subsequent code try to use a map in an undefined value.

If there are no instances, then we can't extract any refs from the webhook, so exiting early is the best option.

**Whats Next?**
Monitor