### PR TITLE
ARC-1512 - GHE UI tweaks

### DIFF
--- a/static/css/jira-server-url.css
+++ b/static/css/jira-server-url.css
@@ -29,6 +29,6 @@
   color: #fff;
 }
 
-.jiraServerUrl__validationError, .errorMessageBox__link {
+.jiraServerUrl__validationError {
   display: none;
 }

--- a/static/js/jira-server-url.js
+++ b/static/js/jira-server-url.js
@@ -61,7 +61,6 @@ const handleGheUrlRequestErrors = (err) => {
 	$(".jiraServerUrl__validationError").show();
 	$(".errorMessageBox__title").empty().append(title);
 	$(".errorMessageBox__message").empty().append(message);
-	title === gheServerUrlErrors.GHE_ERROR_ENOTFOUND.title && $(".errorMessageBox__link").show();
 }
 
 const mapErrorCode = (errorCode) => {

--- a/views/jira-server-url.hbs
+++ b/views/jira-server-url.hbs
@@ -47,7 +47,7 @@
             Connecting GitHub Enterprise Server to Jira requires opening a hole in your firewall,
             as Atlassian’s IP addresses must be able to call your GitHub Enterprise Server.
           <!--TODO: Add a link here-->
-          <a href="" target="_blank">Learn more.</a>
+          <a href="" target="_blank">Learn more about network configuration for GitHub for Jira.</a>
         </div>
 
         <div>

--- a/views/partials/server-error-message-box.hbs
+++ b/views/partials/server-error-message-box.hbs
@@ -3,7 +3,5 @@
   <div class="errorMessageBox__content">
     <div class="errorMessageBox__title"></div>
     <div class="errorMessageBox__message"></div>
-    <!--TODO:// Add URL-->
-    <a href="#" target="_blank" class="errorMessageBox__link">Learn more</a>
   </div>
 </div>


### PR DESCRIPTION
**What's in this PR?**
- In Jira Server URL page,
  - Changed the `Learn more` link to `Learn more about network configuration for GitHub for Jira`
  - Removed the `Learn more` link from all error messages
