### PR TITLE
ARC-1347 Read webhook secret from env. variable for GitHub cloud

### DIFF
--- a/src/routes/github/webhook/webhook-receiver-post.test.ts
+++ b/src/routes/github/webhook/webhook-receiver-post.test.ts
@@ -55,7 +55,7 @@ describe("webhook-receiver-post", () => {
 
 	});
 
-	it("should throw an error if signature doesn't match", async () => {
+	it("should throw an error if signature doesn't match for GHE app", async () => {
 		const mockResSendFunc = jest.fn();
 		res = {
 			status: jest.fn().mockReturnValue({
@@ -68,6 +68,28 @@ describe("webhook-receiver-post", () => {
 			},
 			params: {
 				uuid
+			},
+			body: {}
+		};
+
+		await WebhookReceiverPost(req, res);
+		expect(res.status).toBeCalledWith(400);
+		expect(mockResSendFunc).toBeCalledWith("signature does not match event payload and secret");
+
+	});
+
+	it("should throw an error if signature doesn't match for GitHub cloud", async () => {
+		const mockResSendFunc = jest.fn();
+		res = {
+			status: jest.fn().mockReturnValue({
+				send: mockResSendFunc
+			})
+		};
+		req = {
+			headers: {
+				"x-hub-signature-256": "signature123"
+			},
+			params: {
 			},
 			body: {}
 		};

--- a/src/routes/github/webhook/webhook-receiver-post.test.ts
+++ b/src/routes/github/webhook/webhook-receiver-post.test.ts
@@ -36,11 +36,8 @@ describe("webhook-receiver-post", () => {
 	});
 
 	it("should throw an error if github app not found", async () => {
-		const mockResSendFunc = jest.fn();
 		res = {
-			status: jest.fn().mockReturnValue({
-				send: mockResSendFunc
-			})
+			sendStatus: jest.fn()
 		};
 		req = {
 			headers: {},
@@ -50,8 +47,7 @@ describe("webhook-receiver-post", () => {
 		};
 
 		await WebhookReceiverPost(req, res);
-		expect(res.status).toBeCalledWith(400);
-		expect(mockResSendFunc).toBeCalledWith("GitHub app not found");
+		expect(res.sendStatus).toBeCalledWith(400);
 
 	});
 


### PR DESCRIPTION
**What's in this PR?**
Pull webhook secret from env. variable for Github cloud and `GitHubServerApps` table for GHE

**Why**
GHE config data stored in `GitHubServerApps` where as Github cloud config in environment variables. 

**Added feature flags**
use the existing `ghe_server` flag

**Affected issues**  
ARC-1347

**How has this been tested?**  


