### PR TITLE
ARC-1458 - GHE UI: Navigate from server url screen to select GH app screen

### DIFF
--- a/src/models/github-server-app.ts
+++ b/src/models/github-server-app.ts
@@ -71,6 +71,26 @@ export class GitHubServerApp extends EncryptedModel {
 	}
 
 	/**
+	 * Get all GitHubServerApps with installationId
+	 *
+	 * @param {{installationId: number}} installationId
+	 * @returns {GitHubServerApp[]}
+	 */
+	static async findForInstallationId(
+		installationId: number
+	): Promise<GitHubServerApp[] | null> {
+		if (!installationId) {
+			return null;
+		}
+
+		return this.findAll({
+			where: {
+				installationId: installationId
+			}
+		});
+	}
+
+	/**
 	 * Get all GitHubServerApps for gitHubBaseUrl with installationId
 	 *
 	 * @param gitHubBaseUrl

--- a/src/routes/jira/jira-atlassian-connect-get.ts
+++ b/src/routes/jira/jira-atlassian-connect-get.ts
@@ -90,6 +90,15 @@ const modules = {
 			url: "/jira/app-creation",
 			location: "none",
 			conditions: adminCondition
+		},
+		{
+			key: "github-list-servers-page",
+			name: {
+				value: "GitHub Enterprise Servers"
+			},
+			url: "/jira/ghe-servers",
+			location: "none",
+			conditions: adminCondition
 		}
 	],
 	webSections: [

--- a/src/routes/jira/jira-router.ts
+++ b/src/routes/jira/jira-router.ts
@@ -7,6 +7,7 @@ import { JiraSelectVersionRouter } from "./server/jira-select-version-router";
 import { JiraContextJwtTokenMiddleware } from "middleware/jira-jwt-middleware";
 import { JiraServerUrlRouter } from "routes/jira/server/jira-server-url-router";
 import { JiraAppCreationRouter } from "./server/jira-app-creation-router";
+import { JiraGheServersRouter } from "routes/jira/server/jira-ghe-servers-router";
 
 export const JiraRouter = Router();
 
@@ -18,3 +19,4 @@ JiraRouter.use("/events", JiraEventsRouter);
 JiraRouter.use("/select-version", JiraSelectVersionRouter);
 JiraRouter.use("/server-url", JiraServerUrlRouter);
 JiraRouter.use("/app-creation", JiraAppCreationRouter);
+JiraRouter.use("/ghe-servers", JiraGheServersRouter);

--- a/src/routes/jira/jira-router.ts
+++ b/src/routes/jira/jira-router.ts
@@ -4,14 +4,17 @@ import { JiraSyncPost } from "./jira-sync-post";
 import { JiraAtlassianConnectGet } from "./jira-atlassian-connect-get";
 import { JiraEventsRouter } from "./events/jira-events-router";
 import { JiraSelectVersionRouter } from "./server/jira-select-version-router";
-import { JiraContextJwtTokenMiddleware } from "middleware/jira-jwt-middleware";
+import { JiraContextJwtTokenMiddleware, JiraJwtTokenMiddleware } from "middleware/jira-jwt-middleware";
 import { JiraServerUrlRouter } from "routes/jira/server/jira-server-url-router";
 import { JiraAppCreationRouter } from "./server/jira-app-creation-router";
-import { JiraGheServersRouter } from "routes/jira/server/jira-ghe-servers-router";
+import { csrfMiddleware } from "middleware/csrf-middleware";
+import { JiraGheServers } from "routes/jira/server/jira-ghe-servers";
 
 export const JiraRouter = Router();
 
 JiraRouter.get("/atlassian-connect.json", JiraAtlassianConnectGet);
+JiraRouter.get("/ghe-servers", csrfMiddleware, JiraJwtTokenMiddleware, JiraGheServers);
+
 JiraRouter.use("/configuration", JiraConfigurationRouter);
 // TODO - add csrf middleware
 JiraRouter.post("/sync", JiraContextJwtTokenMiddleware, JiraSyncPost);
@@ -19,4 +22,3 @@ JiraRouter.use("/events", JiraEventsRouter);
 JiraRouter.use("/select-version", JiraSelectVersionRouter);
 JiraRouter.use("/server-url", JiraServerUrlRouter);
 JiraRouter.use("/app-creation", JiraAppCreationRouter);
-JiraRouter.use("/ghe-servers", JiraGheServersRouter);

--- a/src/routes/jira/server/jira-ghe-servers-router.ts
+++ b/src/routes/jira/server/jira-ghe-servers-router.ts
@@ -1,9 +1,0 @@
-import { Router } from "express";
-import { JiraJwtTokenMiddleware } from "middleware/jira-jwt-middleware";
-import { csrfMiddleware } from "middleware/csrf-middleware";
-import { JiraGheServers } from "routes/jira/server/jira-ghe-servers";
-
-export const JiraGheServersRouter = Router();
-
-JiraGheServersRouter.route("/")
-	.get(csrfMiddleware, JiraJwtTokenMiddleware, JiraGheServers);

--- a/src/routes/jira/server/jira-ghe-servers-router.ts
+++ b/src/routes/jira/server/jira-ghe-servers-router.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { JiraJwtTokenMiddleware } from "middleware/jira-jwt-middleware";
+import { csrfMiddleware } from "middleware/csrf-middleware";
+import { JiraGheServers } from "routes/jira/server/jira-ghe-servers";
+
+export const JiraGheServersRouter = Router();
+
+JiraGheServersRouter.route("/")
+	.get(csrfMiddleware, JiraJwtTokenMiddleware, JiraGheServers);

--- a/src/routes/jira/server/jira-ghe-servers.ts
+++ b/src/routes/jira/server/jira-ghe-servers.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { GitHubServerApp } from "models/github-server-app";
+import { groupBy, chain } from "lodash";
 
 export const JiraGheServers = async (
 	req: Request,
@@ -9,10 +10,11 @@ export const JiraGheServers = async (
 	try {
 		req.log.debug("Received Jira GHE servers page request");
 
-		const servers = await GitHubServerApp.findForInstallationId(res.locals.installation.id) || [];
+		const allServers = await GitHubServerApp.findForInstallationId(res.locals.installation.id) || [];
+		const gheServers = chain(groupBy(allServers, "gitHubBaseUrl")).map((_, key) => ({ gitHubBaseUrl: key })).value();
 
 		res.render("jira-select-server.hbs", {
-			servers
+			servers: gheServers
 		});
 
 		req.log.debug("Jira GHE servers rendered successfully.");

--- a/src/routes/jira/server/jira-ghe-servers.ts
+++ b/src/routes/jira/server/jira-ghe-servers.ts
@@ -1,0 +1,22 @@
+import { NextFunction, Request, Response } from "express";
+import { GitHubServerApp } from "models/github-server-app";
+
+export const JiraGheServers = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+): Promise<void> => {
+	try {
+		req.log.debug("Received Jira GHE servers page request");
+
+		const servers = await GitHubServerApp.findForInstallationId(res.locals.installation.id) || [];
+
+		res.render("jira-select-server.hbs", {
+			servers
+		});
+
+		req.log.debug("Jira GHE servers rendered successfully.");
+	} catch (error) {
+		return next(new Error(`Failed to render Jira GHE servers page: ${error}`));
+	}
+};

--- a/src/routes/jira/server/jira-ghe-servers.ts
+++ b/src/routes/jira/server/jira-ghe-servers.ts
@@ -11,7 +11,7 @@ export const JiraGheServers = async (
 		req.log.debug("Received Jira GHE servers page request");
 
 		const allServers = await GitHubServerApp.findForInstallationId(res.locals.installation.id) || [];
-		const gheServers = chain(groupBy(allServers, "gitHubBaseUrl")).map((_, key) => ({ gitHubBaseUrl: key })).value();
+		const gheServers = chain(groupBy(allServers, "gitHubBaseUrl")).map((_, key) => ({ displayName: key })).value();
 
 		res.render("jira-select-server.hbs", {
 			servers: gheServers

--- a/static/js/jira-server-url.js
+++ b/static/js/jira-server-url.js
@@ -81,7 +81,7 @@ const verifyGitHubServerUrl = (gheServerURL) => {
 			},
 			function(data) {
 				if (data.success) {
-					const pagePath = data.appExists ? "github-list-apps-page" : "github-app-creation-page";
+					const pagePath = data.appExists ? "github-list-servers-page" : "github-app-creation-page";
 					AP.navigator.go(
 						"addonmodule",
 						{

--- a/static/js/select-server-table.js
+++ b/static/js/select-server-table.js
@@ -1,0 +1,4 @@
+$(".selectServer__addNew").click(function (event) {
+  event.preventDefault();
+  AP.navigator.go("addonmodule", {moduleKey: $(event.target).data("path")});
+});

--- a/test/snapshots/routes/jira/jira-atlassian-connect.test.ts.snap
+++ b/test/snapshots/routes/jira/jira-atlassian-connect.test.ts.snap
@@ -71,6 +71,19 @@ Object {
         },
         "url": "/jira/app-creation",
       },
+      Object {
+        "conditions": Array [
+          Object {
+            "condition": "user_is_admin",
+          },
+        ],
+        "key": "github-list-servers-page",
+        "location": "none",
+        "name": Object {
+          "value": "GitHub Enterprise Servers",
+        },
+        "url": "/jira/ghe-servers",
+      },
     ],
     "jiraBuildInfoProvider": Object {
       "homeUrl": "https://github.com/features/actions",

--- a/test/snapshots/routes/maintenance/maintenance-router.test.ts.snap
+++ b/test/snapshots/routes/maintenance/maintenance-router.test.ts.snap
@@ -71,6 +71,19 @@ Object {
         },
         "url": "/jira/app-creation",
       },
+      Object {
+        "conditions": Array [
+          Object {
+            "condition": "user_is_admin",
+          },
+        ],
+        "key": "github-list-servers-page",
+        "location": "none",
+        "name": Object {
+          "value": "GitHub Enterprise Servers",
+        },
+        "url": "/jira/ghe-servers",
+      },
     ],
     "jiraBuildInfoProvider": Object {
       "homeUrl": "https://github.com/features/actions",

--- a/views/jira-select-github-cloud-app.hbs
+++ b/views/jira-select-github-cloud-app.hbs
@@ -35,7 +35,7 @@
     />
     <div class="jiraSelectGitHubCloudApp">
       <header>
-         {{> navigation previousPageName="GitHub APplication Creation" }}
+         {{> navigation previousPageName="GitHub Application Creation" }}
       </header>
 
       <section class="jiraSelectGitHubCloudApp__content">

--- a/views/jira-select-github-cloud-app.hbs
+++ b/views/jira-select-github-cloud-app.hbs
@@ -48,15 +48,14 @@
             installationId=id
             contentImgURL="/public/assets/addon.svg"
             contentTitle="Applications in your server"
-            addNewText="Create new application"
-            addNewURL="#"
+            textForAddNew="Create new application"
+            pathNameForAddNew="github-app-creation-page"
             servers=servers
         }}
       </section>
 
     </div>
 
-    <script src="/public/js/jira-select-github-cloud-app.js" nonce="{{nonce}}"></script>
     <!-- Per https://blog.developer.atlassian.com/announcement-reminder-about-deprecation-of-xdm_e-usage-and-needing-to-load-all-js-from-the-cdn/ we are required to load this from this specific CDN -->
     <!-- DO NOT TOUCH!!! THIS IS NEEDED FOR CONNECT OR ELSE IT WILL CAUSE AN ERROR -->
     <script
@@ -69,5 +68,7 @@
       referrerpolicy="no-referrer"
       nonce="{{nonce}}"
     ></script>
+    <script src="/public/js/jira-select-github-cloud-app.js" nonce="{{nonce}}"></script>
+    <script src="/public/js/select-server-table.js" nonce="{{nonce}}"></script>
   </body>
 </html>

--- a/views/jira-select-server.hbs
+++ b/views/jira-select-server.hbs
@@ -35,7 +35,7 @@
     />
     <div class="jiraSelectServer">
       <header class="jiraSelectServer__header">
-         {{> navigation previousPageName="GitHub Enterprise Server app creation" }}
+         {{> navigation previousPathPage="github-select-version-page" previousPageName="GitHub Select Version" }}
       </header>
 
       <section class="jiraSelectServer__content">

--- a/views/jira-select-server.hbs
+++ b/views/jira-select-server.hbs
@@ -35,7 +35,7 @@
     />
     <div class="jiraSelectServer">
       <header class="jiraSelectServer__header">
-         {{> navigation previousPathPage="github-select-version-page" previousPageName="GitHub Select Version" }}
+         {{> navigation previousPathPage="github-server-url-page" previousPageName="GitHub Server Url" }}
       </header>
 
       <section class="jiraSelectServer__content">

--- a/views/jira-select-server.hbs
+++ b/views/jira-select-server.hbs
@@ -44,20 +44,19 @@
             header="Select a GitHub Server"
             subHeader="We found the following GitHub servers"
         }}
-        <!-- servers refer to the array of GHE apps/servers-->
+        <!-- servers refer to the array of GHE apps-->
         {{> select-server-table
             installationId=id
             contentImgURL="/public/assets/github-logo.svg"
             contentTitle="GitHub Enterprise Servers"
-            addNewText="Connect a new server"
-            addNewURL="#"
+            textForAddNew="Connect a new server"
+            pathNameForAddNew="github-server-url-page"
             servers=servers
         }}
       </section>
 
     </div>
 
-    <script src="/public/js/jira-select-server.js" nonce="{{nonce}}"></script>
     <!-- Per https://blog.developer.atlassian.com/announcement-reminder-about-deprecation-of-xdm_e-usage-and-needing-to-load-all-js-from-the-cdn/ we are required to load this from this specific CDN -->
     <!-- DO NOT TOUCH!!! THIS IS NEEDED FOR CONNECT OR ELSE IT WILL CAUSE AN ERROR -->
     <script
@@ -70,5 +69,7 @@
       referrerpolicy="no-referrer"
       nonce="{{nonce}}"
     ></script>
+    <script src="/public/js/jira-select-server.js" nonce="{{nonce}}"></script>
+    <script src="/public/js/select-server-table.js" nonce="{{nonce}}"></script>
   </body>
 </html>

--- a/views/jira-select-server.hbs
+++ b/views/jira-select-server.hbs
@@ -35,7 +35,7 @@
     />
     <div class="jiraSelectServer">
       <header class="jiraSelectServer__header">
-         {{> navigation previousPathPage="github-server-url-page" previousPageName="GitHub Server Url" }}
+         {{> navigation previousPagePath="github-server-url-page" previousPageName="GitHub Server Url" }}
       </header>
 
       <section class="jiraSelectServer__content">
@@ -69,6 +69,7 @@
       referrerpolicy="no-referrer"
       nonce="{{nonce}}"
     ></script>
+    <script src="/public/js/navigation.js" nonce="{{nonce}}"></script>
     <script src="/public/js/jira-select-server.js" nonce="{{nonce}}"></script>
     <script src="/public/js/select-server-table.js" nonce="{{nonce}}"></script>
   </body>

--- a/views/partials/select-server-table.hbs
+++ b/views/partials/select-server-table.hbs
@@ -13,8 +13,7 @@
   <div class="selectServer__list">
     {{#each servers as |server|}}
       <div class="selectServer__server">
-        <!--TODO: Update the URL by actual data-->
-        <div class="selectServer__serverURL">{{server.url}}</div>
+        <div class="selectServer__serverURL">{{server.gitHubBaseUrl}}</div>
         <button
           class="aui-button aui-button-label select-server"
           data-installation-id="{{installationId}}"

--- a/views/partials/select-server-table.hbs
+++ b/views/partials/select-server-table.hbs
@@ -4,16 +4,16 @@
       <img class="selectServer__contentImg" src="{{contentImgURL}}" alt="GitHub"/>
       <span class="selectServer__contentTitle">{{contentTitle}}</span>
     </div>
-    <a class="selectServer__addNew aui-button aui-button-subtle" href="{{addNewURL}}">
+    <a class="selectServer__addNew aui-button aui-button-subtle" data-path="{{pathNameForAddNew}}">
       <i class="aui-icon aui-iconfont-add"></i>
-      {{addNewText}}
+      {{textForAddNew}}
     </a>
   </div>
 
   <div class="selectServer__list">
     {{#each servers as |server|}}
       <div class="selectServer__server">
-        <div class="selectServer__serverURL">{{server.gitHubBaseUrl}}</div>
+        <div class="selectServer__serverURL">{{server.displayName}}</div>
         <button
           class="aui-button aui-button-label select-server"
           data-installation-id="{{installationId}}"


### PR DESCRIPTION
**What's in this PR?**
- New module added in app connector.
- New route and methods added to fetch the list of GHE servers for a JIRA instance.
- Fetching the actual list of GHE servers in the view.
- Added `pathNameForAddNew` for navigating back to jira-server-url page.

**Video**

https://user-images.githubusercontent.com/13076255/178638525-597c6512-a985-492b-b635-668062922aaa.mov
