### PR TITLE
gArc 1515 share GitHub server app middleware

### DIFF
--- a/src/middleware/github-server-app-middleware.test.ts
+++ b/src/middleware/github-server-app-middleware.test.ts
@@ -28,7 +28,7 @@ describe("github-server-app-middleware", () => {
 	it("should call next() when no gitHupAppId is provided",  async() => {
 		req = {
 			log: getLogger("request"),
-			params: {
+			query: {
 				id: undefined
 			}
 		};
@@ -40,7 +40,7 @@ describe("github-server-app-middleware", () => {
 	it("should throw an error if an id is provided but no GitHub server app is found", async () => {
 		req = {
 			log: getLogger("request"),
-			params: {
+			query: {
 				id: 3
 			}
 		};
@@ -53,7 +53,7 @@ describe("github-server-app-middleware", () => {
 	it("should throw an error if an id is provided and a GitHub server app is found but the installation id doesn't match",  async() => {
 		req = {
 			log: getLogger("request"),
-			params: {
+			query: {
 				id: 3
 			}
 		};
@@ -87,7 +87,7 @@ describe("github-server-app-middleware", () => {
 	it("should call next() when GH app is found and installation id matches", async () => {
 		req = {
 			log: getLogger("request"),
-			params: {
+			query: {
 				id: 3
 			}
 		};

--- a/src/middleware/github-server-app-middleware.ts
+++ b/src/middleware/github-server-app-middleware.ts
@@ -6,33 +6,27 @@ export const GithubServerAppMiddleware = async (req: Request, res: Response, nex
 	const { jiraHost } = res.locals;
 	const { ghaid: id } = req.query;
 
-	if (!id) return next();
+	if (id) {
+		req.log.debug(`Retrieving GitHub app with id ${id}`);
+		const gitHubServerApp = await GitHubServerApp.getForGitHubServerAppId(Number(id));
 
-	//TODO: ARC-1515 fix it to parse uuid xxx-xxx-xxx
-	const isNonRecognizableId = isNaN(parseInt(id as string));
-	if (isNonRecognizableId) {
-		console.log("wrong path, just return;");
-		next();
-		return;
+		if (!gitHubServerApp) {
+			req.log.error({ id, jiraHost }, "No GitHub app found for provided id.");
+			throw new Error("No GitHub app found for provided id.");
+		}
+
+		const installation = await Installation.findByPk(gitHubServerApp.installationId);
+
+		if (installation?.jiraHost !== jiraHost) {
+			req.log.error({ id, jiraHost }, "Jira hosts do not match");
+			throw new Error("Jira hosts do not match.");
+		}
+
+		req.log.info("Found GitHub server app for installation");
+		res.locals.gitHubAppId = id;
+		return next();
 	}
 
-	req.log.debug(`Retrieving GitHub app with id ${id}`);
-	const gitHubServerApp = await GitHubServerApp.getForGitHubServerAppId(Number(id));
-
-	if (!gitHubServerApp) {
-		req.log.error({ id, jiraHost }, "No GitHub app found for provided id.");
-		throw new Error("No GitHub app found for provided id.");
-	}
-
-	const installation = await Installation.findByPk(gitHubServerApp.installationId);
-
-	if (installation?.jiraHost !== jiraHost) {
-		req.log.error({ id, jiraHost }, "Jira hosts do not match");
-		throw new Error("Jira hosts do not match.");
-	}
-
-	req.log.info("Found GitHub server app for installation");
-	res.locals.gitHubAppId = Number(id);
-	return next();
-
+	next();
 };
+

--- a/src/middleware/github-server-app-middleware.ts
+++ b/src/middleware/github-server-app-middleware.ts
@@ -4,11 +4,17 @@ import { Installation } from "models/installation";
 
 export const GithubServerAppMiddleware = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
 	const { jiraHost } = res.locals;
-	const { ghaid: id } = req.query;
+	const { id: idStr } = req.query;
+	const id = parseInt(idStr as string);
+
+	if (id && isNaN(id)) {
+		req.log.warn({ id, jiraHost }, "Provided id found but not a number " + id);
+		throw new Error("Provided id found but not a number " + id);
+	}
 
 	if (id) {
 		req.log.debug(`Retrieving GitHub app with id ${id}`);
-		const gitHubServerApp = await GitHubServerApp.getForGitHubServerAppId(Number(id));
+		const gitHubServerApp = await GitHubServerApp.getForGitHubServerAppId(id);
 
 		if (!gitHubServerApp) {
 			req.log.error({ id, jiraHost }, "No GitHub app found for provided id.");

--- a/src/middleware/github-server-app-middleware.ts
+++ b/src/middleware/github-server-app-middleware.ts
@@ -4,17 +4,15 @@ import { Installation } from "models/installation";
 
 export const GithubServerAppMiddleware = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
 	const { jiraHost } = res.locals;
-	const { gitHubAppId: id} = req.params;
+	const { ghaid: id } = req.query;
 
-	console.log('----- check id path ----', {id, path: req.path});
-
-	if(!id) return next();
+	if (!id) return next();
 
 	//TODO: ARC-1515 fix it to parse uuid xxx-xxx-xxx
-	const isNonRecognizableId = isNaN(parseInt(id));
-	if(isNonRecognizableId) {
-		console.log('wrong path, just return;');
-		next('route');
+	const isNonRecognizableId = isNaN(parseInt(id as string));
+	if (isNonRecognizableId) {
+		console.log("wrong path, just return;");
+		next();
 		return;
 	}
 

--- a/src/middleware/github-server-app-middleware.ts
+++ b/src/middleware/github-server-app-middleware.ts
@@ -4,26 +4,26 @@ import { Installation } from "models/installation";
 
 export const GithubServerAppMiddleware = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
 	const { jiraHost } = res.locals;
-	const { id } = req.params;
+	const { gitHubServerAppUUID } = req.params;
 
-	if (id) {
-		req.log.debug(`Retrieving GitHub app with id ${id}`);
-		const gitHubServerApp = await GitHubServerApp.getForGitHubServerAppId(Number(id));
+	if (gitHubServerAppUUID) {
+		req.log.debug(`Retrieving GitHub app with id ${gitHubServerAppUUID}`);
+		const gitHubServerApp = await GitHubServerApp.getForGitHubServerAppId(Number(gitHubServerAppUUID));
 
 		if (!gitHubServerApp) {
-			req.log.error({ id, jiraHost }, "No GitHub app found for provided id.");
+			req.log.error({ gitHubServerAppUUID, jiraHost }, "No GitHub app found for provided id.");
 			throw new Error("No GitHub app found for provided id.");
 		}
 
 		const installation = await Installation.findByPk(gitHubServerApp.installationId);
 
 		if (installation?.jiraHost !== jiraHost) {
-			req.log.error({ id, jiraHost }, "Jira hosts do not match");
+			req.log.error({ gitHubServerAppUUID, jiraHost }, "Jira hosts do not match");
 			throw new Error("Jira hosts do not match.");
 		}
 
 		req.log.info("Found GitHub server app for installation");
-		res.locals.gitHubAppId = id;
+		res.locals.gitHubAppId = gitHubServerAppUUID;
 		return next();
 	}
 

--- a/src/routes/github/configuration/github-configuration-router.ts
+++ b/src/routes/github/configuration/github-configuration-router.ts
@@ -3,7 +3,6 @@ import { GithubConfigurationGet } from "./github-configuration-get";
 import { GithubConfigurationPost } from "./github-configuration-post";
 
 export const GithubConfigurationRouter = Router();
-
 GithubConfigurationRouter.route("/")
 	.get(GithubConfigurationGet)
 	.post(GithubConfigurationPost);

--- a/src/routes/github/configuration/github-configuration-router.ts
+++ b/src/routes/github/configuration/github-configuration-router.ts
@@ -1,11 +1,9 @@
 import { Router } from "express";
 import { GithubConfigurationGet } from "./github-configuration-get";
 import { GithubConfigurationPost } from "./github-configuration-post";
-import { GithubServerAppMiddleware } from "middleware/github-server-app-middleware";
 
 export const GithubConfigurationRouter = Router();
 
-GithubConfigurationRouter.route("/:id?")
-	.all(GithubServerAppMiddleware)
+GithubConfigurationRouter.route("/")
 	.get(GithubConfigurationGet)
 	.post(GithubConfigurationPost);

--- a/src/routes/github/github-oauth-router.ts
+++ b/src/routes/github/github-oauth-router.ts
@@ -8,7 +8,7 @@ import { Tracer } from "config/tracer";
 import { envVars } from "config/env";
 import { GithubAPI } from "config/github-api";
 import { Errors } from "config/errors";
-import { getGitHubHostname, getGitHubApiUrl } from "~/src/util/get-github-client-config";
+import { getGitHubHostname, getGitHubApiUrl } from "utils/get-github-client-config";
 import { createHashWithSharedSecret } from "utils/encryption";
 
 const logger = getLogger("github-oauth");
@@ -139,8 +139,9 @@ export const GithubAuthMiddleware = async (req: Request, res: Response, next: Ne
 			throw "Missing github token";
 		}
 		req.log.debug("found github token in session. validating token with API.");
-
+console.log('-------------------------', {jiraHost, gitHubAppId});
 		const url = await getGitHubApiUrl(jiraHost, gitHubAppId);
+console.log('-------------------------', {url});
 
 		await axios.get(url, {
 			headers: {

--- a/src/routes/github/github-oauth-router.ts
+++ b/src/routes/github/github-oauth-router.ts
@@ -170,5 +170,6 @@ export const GithubAuthMiddleware = async (req: Request, res: Response, next: Ne
 // IMPORTANT: We need to keep the login/callback/middleware functions
 // in the same file as they reference each other
 export const GithubOAuthRouter = Router();
+//TODO: ARC-1515 confirm this is not used at all.
 GithubOAuthRouter.get("/login", GithubOAuthLoginGet);
 GithubOAuthRouter.get(callbackPath, GithubOAuthCallbackGet);

--- a/src/routes/github/github-oauth-router.ts
+++ b/src/routes/github/github-oauth-router.ts
@@ -139,9 +139,7 @@ export const GithubAuthMiddleware = async (req: Request, res: Response, next: Ne
 			throw "Missing github token";
 		}
 		req.log.debug("found github token in session. validating token with API.");
-console.log('-------------------------', {jiraHost, gitHubAppId});
 		const url = await getGitHubApiUrl(jiraHost, gitHubAppId);
-console.log('-------------------------', {url});
 
 		await axios.get(url, {
 			headers: {
@@ -150,7 +148,6 @@ console.log('-------------------------', {url});
 		});
 
 		req.log.debug(`Github token is valid, continuing...`);
-
 		// Everything's good, set it to res.locals
 		res.locals.githubToken = githubToken;
 		// TODO: Not a great place to put this, but it'll do for now

--- a/src/routes/github/github-oauth-router.ts
+++ b/src/routes/github/github-oauth-router.ts
@@ -139,6 +139,7 @@ export const GithubAuthMiddleware = async (req: Request, res: Response, next: Ne
 			throw "Missing github token";
 		}
 		req.log.debug("found github token in session. validating token with API.");
+
 		const url = await getGitHubApiUrl(jiraHost, gitHubAppId);
 
 		await axios.get(url, {
@@ -148,6 +149,7 @@ export const GithubAuthMiddleware = async (req: Request, res: Response, next: Ne
 		});
 
 		req.log.debug(`Github token is valid, continuing...`);
+
 		// Everything's good, set it to res.locals
 		res.locals.githubToken = githubToken;
 		// TODO: Not a great place to put this, but it'll do for now

--- a/src/routes/github/github-router.test.ts
+++ b/src/routes/github/github-router.test.ts
@@ -1,32 +1,27 @@
-import express, {Application} from "express";
+import express, { Application } from "express";
 import supertest from "supertest";
-import {GithubRouter} from "./github-router";
-import {getLogger} from "config/logger";
-import {when} from "jest-when";
-import {GithubConfigurationGet} from "./configuration/github-configuration-get";
-import {getGitHubApiUrl} from "utils/get-github-client-config";
+import { GithubRouter } from "./github-router";
+import { getLogger } from "config/logger";
+import { when } from "jest-when";
+import { GithubConfigurationGet } from "./configuration/github-configuration-get";
+import { getGitHubApiUrl } from "utils/get-github-client-config";
 import axios from "axios";
-import {GitHubServerApp} from "models/github-server-app";
-import {Installation} from "models/installation";
-import {v4 as v4uuid} from 'uuid';
+import { GitHubServerApp } from "models/github-server-app";
+import { Installation } from "models/installation";
+import { v4 as v4uuid } from "uuid";
 
-jest.mock("./configuration/github-configuration-get", () => ({
-	GithubConfigurationGet: jest.fn(async (_req: any, _res: any, next: any) => {next();})
-}));
+jest.mock("./configuration/github-configuration-get");
 jest.mock("utils/get-github-client-config");
-jest.mock("axios", () => ({
-	get: jest.fn(),
-	create: jest.fn()
-}));
+jest.mock("axios", () => ({ get: jest.fn(), create: jest.fn() }));
 jest.mock("models/github-server-app");
 jest.mock("models/Installation");
 
 const JIRA_HOST = "https://gh4j.test.atlassian.net";
-const VALID_TOKEN = 'valid-token';
+const VALID_TOKEN = "valid-token";
 const GITHUB_SERVER_APP_UUID: string = v4uuid();
 const GITHUB_SERVER_APP_ID = 789;
 const GITHUB_SERVER_APP_URL = "https://default.internal.github.atlassian.net";
-const JIRA_INSTALLATION_ID: number = 444444;
+const JIRA_INSTALLATION_ID = 444444;
 
 const getGitHubServerAppModel = (): GitHubServerApp => {
 	return {
@@ -34,75 +29,79 @@ const getGitHubServerAppModel = (): GitHubServerApp => {
 		uuid: GITHUB_SERVER_APP_UUID,
 		appId: GITHUB_SERVER_APP_ID,
 		gitHubBaseUrl: GITHUB_SERVER_APP_URL,
-		gitHubClientId: 'client-id',
-		gitHubClientSecret: 'client-secret',
-		webhookSecret: 'webhook-secret',
-		privateKey: 'private-key',
-		gitHubAppName: 'test-app-name',
+		gitHubClientId: "client-id",
+		gitHubClientSecret: "client-secret",
+		webhookSecret: "webhook-secret",
+		privateKey: "private-key",
+		gitHubAppName: "test-app-name",
 		installationId: JIRA_INSTALLATION_ID,
 		updatedAt: new Date(),
 		createdAt: new Date()
 	} as GitHubServerApp;
-}
+};
 
 const getServerApptInstallationModel = (): Installation => {
 	return {
 		id: JIRA_INSTALLATION_ID,
 		jiraHost: JIRA_HOST,
-		secrets: 'secrets',
-		sharedSecret: 'sharedSecret',
-		encryptedSharedSecret: 'encryptedSharedSecret',
-		clientKey: 'clientKey',
+		secrets: "secrets",
+		sharedSecret: "sharedSecret",
+		encryptedSharedSecret: "encryptedSharedSecret",
+		clientKey: "clientKey",
 		updatedAt: new Date(),
 		createdAt: new Date(),
 		githubAppId: GITHUB_SERVER_APP_ID
 	} as Installation;
-}
+};
 
 const mockPrerequistApp = () => {
 	const app = express();
 	app.use((req, res, next) => {
-		req.session = {githubToken: VALID_TOKEN};
-		res.locals = {jiraHost: JIRA_HOST};
+		req.session = { githubToken: VALID_TOKEN };
+		res.locals = { jiraHost: JIRA_HOST };
 		req.log = getLogger("test");
 		next();
 	});
 	return app;
-}
+};
+
+const mockConfigurationGetProceed = ()=>{
+	jest.mocked(GithubConfigurationGet).mockClear();
+	jest.mocked(GithubConfigurationGet).mockImplementation(async (_req, _res, next) => {next();});
+};
 
 const mockGetGitHubApiUrl = () => {
 	when(getGitHubApiUrl)
 		.calledWith(JIRA_HOST, GITHUB_SERVER_APP_ID)
 		.mockResolvedValue(GITHUB_SERVER_APP_URL);
-}
+};
 
 const mockGetForGitHubServerAppId = () => {
 	when(GitHubServerApp.getForGitHubServerAppId)
 		.calledWith(GITHUB_SERVER_APP_ID)
 		.mockResolvedValue(getGitHubServerAppModel());
-}
+};
 
 const mockAxiosPingURL = () => {
 	when(axios.get)
 		.calledWith(JIRA_HOST)
 		.mockResolvedValue(undefined);
-}
+};
 
 const mockInstallationFindByPK = () => {
 	when(Installation.findByPk)
 		.calledWith(JIRA_INSTALLATION_ID as any)
 		.mockResolvedValue(getServerApptInstallationModel());
-}
+};
 
 describe("GitHub router", () => {
-	beforeEach(()=>{
-	});
 	describe("Common route utilities", () => {
-		describe.only("Cloud scenario", ()=>{
+		describe("Cloud scenario", ()=>{
 			let app: Application;
 			beforeEach(() => {
 				app = mockPrerequistApp();
 				app.use("/github", GithubRouter);
+				mockConfigurationGetProceed();
 			});
 			it("should skip uuid when absent", async () => {
 				await supertest(app).get(`/github/configuration`);
@@ -114,7 +113,7 @@ describe("GitHub router", () => {
 							jiraHost: JIRA_HOST
 						})
 					}),
-					expect.anything(),
+					expect.anything()
 				);
 			});
 		});
@@ -127,9 +126,10 @@ describe("GitHub router", () => {
 				mockGetForGitHubServerAppId();
 				mockAxiosPingURL();
 				mockInstallationFindByPK();
+				mockConfigurationGetProceed();
 			});
 			it("should extract uuid when present", async () => {
-				await supertest(app).get(`/github/appid-${GITHUB_SERVER_APP_ID}/configuration`);
+				await supertest(app).get(`/github/configuration?ghaid=${GITHUB_SERVER_APP_ID}`);
 				expect(GithubConfigurationGet).toBeCalledWith(
 					expect.anything(), //not matching req
 					expect.objectContaining({ //matching res locals
@@ -139,7 +139,7 @@ describe("GitHub router", () => {
 							jiraHost: JIRA_HOST
 						})
 					}),
-					expect.anything(),
+					expect.anything()
 				);
 			});
 		});

--- a/src/routes/github/github-router.test.ts
+++ b/src/routes/github/github-router.test.ts
@@ -1,28 +1,32 @@
 import express, {Application} from "express";
 import supertest from "supertest";
-import { GithubRouter } from "./github-router";
-import { getLogger } from "config/logger";
-import { when } from  "jest-when";
+import {GithubRouter} from "./github-router";
+import {getLogger} from "config/logger";
+import {when} from "jest-when";
 import {GithubConfigurationGet} from "./configuration/github-configuration-get";
-import { getGitHubApiUrl } from "utils/get-github-client-config";
+import {getGitHubApiUrl} from "utils/get-github-client-config";
 import axios from "axios";
-import { GitHubServerApp } from "models/github-server-app";
-import { v4 as v4uuid } from 'uuid';
+import {GitHubServerApp} from "models/github-server-app";
+import {Installation} from "models/installation";
+import {v4 as v4uuid} from 'uuid';
 
-jest.mock("./configuration/github-configuration-get");
+jest.mock("./configuration/github-configuration-get", () => ({
+	GithubConfigurationGet: jest.fn(async (_req: any, _res: any, next: any) => {next();})
+}));
 jest.mock("utils/get-github-client-config");
 jest.mock("axios", () => ({
 	get: jest.fn(),
 	create: jest.fn()
 }));
 jest.mock("models/github-server-app");
-console.log('', {axios });
+jest.mock("models/Installation");
 
-const DEFAULT_JIRA_HOST = "https://gh4j.test.atlassian.net";
+const JIRA_HOST = "https://gh4j.test.atlassian.net";
 const VALID_TOKEN = 'valid-token';
 const GITHUB_SERVER_APP_UUID: string = v4uuid();
 const GITHUB_SERVER_APP_ID = 789;
 const GITHUB_SERVER_APP_URL = "https://default.internal.github.atlassian.net";
+const JIRA_INSTALLATION_ID: number = 444444;
 
 const getGitHubServerAppModel = (): GitHubServerApp => {
 	return {
@@ -35,35 +39,108 @@ const getGitHubServerAppModel = (): GitHubServerApp => {
 		webhookSecret: 'webhook-secret',
 		privateKey: 'private-key',
 		gitHubAppName: 'test-app-name',
-		installationId: 123456,
+		installationId: JIRA_INSTALLATION_ID,
 		updatedAt: new Date(),
 		createdAt: new Date()
 	} as GitHubServerApp;
 }
 
+const getServerApptInstallationModel = (): Installation => {
+	return {
+		id: JIRA_INSTALLATION_ID,
+		jiraHost: JIRA_HOST,
+		secrets: 'secrets',
+		sharedSecret: 'sharedSecret',
+		encryptedSharedSecret: 'encryptedSharedSecret',
+		clientKey: 'clientKey',
+		updatedAt: new Date(),
+		createdAt: new Date(),
+		githubAppId: GITHUB_SERVER_APP_ID
+	} as Installation;
+}
+
+const mockPrerequistApp = () => {
+	const app = express();
+	app.use((req, res, next) => {
+		req.session = {githubToken: VALID_TOKEN};
+		res.locals = {jiraHost: JIRA_HOST};
+		req.log = getLogger("test");
+		next();
+	});
+	return app;
+}
+
+const mockGetGitHubApiUrl = () => {
+	when(getGitHubApiUrl)
+		.calledWith(JIRA_HOST, GITHUB_SERVER_APP_ID)
+		.mockResolvedValue(GITHUB_SERVER_APP_URL);
+}
+
+const mockGetForGitHubServerAppId = () => {
+	when(GitHubServerApp.getForGitHubServerAppId)
+		.calledWith(GITHUB_SERVER_APP_ID)
+		.mockResolvedValue(getGitHubServerAppModel());
+}
+
+const mockAxiosPingURL = () => {
+	when(axios.get)
+		.calledWith(JIRA_HOST)
+		.mockResolvedValue(undefined);
+}
+
+const mockInstallationFindByPK = () => {
+	when(Installation.findByPk)
+		.calledWith(JIRA_INSTALLATION_ID as any)
+		.mockResolvedValue(getServerApptInstallationModel());
+}
+
 describe("GitHub router", () => {
+	beforeEach(()=>{
+	});
 	describe("Common route utilities", () => {
+		describe("Cloud scenario", ()=>{
+			let app: Application;
+			beforeEach(() => {
+				app = mockPrerequistApp();
+				app.use("/github-cloud", GithubRouter);
+			});
+			it("should skip uuid when absent", async () => {
+				await supertest(app).get(`/github-cloud/configuration`);
+				expect(GithubConfigurationGet).toBeCalledWith(
+					expect.anything(), //not matching req
+					expect.objectContaining({ //matching res locals
+						locals: expect.objectContaining({
+							githubToken: VALID_TOKEN,
+							jiraHost: JIRA_HOST
+						})
+					}),
+					expect.anything(),
+				);
+			});
+		});
 		describe("GitHubServer", () => {
 			let app: Application;
 			beforeEach(() => {
-				app = express();
-				app.use((req, res, next)=>{
-					req.session = { githubToken: VALID_TOKEN };
-					res.locals = {jiraHost: DEFAULT_JIRA_HOST};
-					req.log = getLogger("test");
-					next();
-				});
-				app.use("/github", GithubRouter);
-				when(getGitHubApiUrl)
-					.calledWith(DEFAULT_JIRA_HOST, GITHUB_SERVER_APP_UUID)
-					.mockResolvedValue(GITHUB_SERVER_APP_URL);
-				when(GitHubServerApp.getForGitHubServerAppId)
-					.calledWith(GITHUB_SERVER_APP_UUID)
-					.mockResolvedValue(getGitHubServerAppModel());
+				app = mockPrerequistApp();
+				app.use("/github-server", GithubRouter);
+				mockGetGitHubApiUrl();
+				mockGetForGitHubServerAppId();
+				mockAxiosPingURL();
+				mockInstallationFindByPK();
 			});
 			it("should extract uuid when present", async () => {
-				await supertest(app).get(`/github/${GITHUB_SERVER_APP_UUID}/configuration`);
-				expect(GithubConfigurationGet).toBeCalledWith();
+				await supertest(app).get(`/github-server/${GITHUB_SERVER_APP_ID}/configuration`);
+				expect(GithubConfigurationGet).toBeCalledWith(
+					expect.anything(), //not matching req
+					expect.objectContaining({ //matching res locals
+						locals: expect.objectContaining({
+							gitHubAppId: GITHUB_SERVER_APP_ID,
+							githubToken: VALID_TOKEN,
+							jiraHost: JIRA_HOST
+						})
+					}),
+					expect.anything(),
+				);
 			});
 		});
 	});

--- a/src/routes/github/github-router.test.ts
+++ b/src/routes/github/github-router.test.ts
@@ -1,0 +1,70 @@
+import express, {Application} from "express";
+import supertest from "supertest";
+import { GithubRouter } from "./github-router";
+import { getLogger } from "config/logger";
+import { when } from  "jest-when";
+import {GithubConfigurationGet} from "./configuration/github-configuration-get";
+import { getGitHubApiUrl } from "utils/get-github-client-config";
+import axios from "axios";
+import { GitHubServerApp } from "models/github-server-app";
+import { v4 as v4uuid } from 'uuid';
+
+jest.mock("./configuration/github-configuration-get");
+jest.mock("utils/get-github-client-config");
+jest.mock("axios", () => ({
+	get: jest.fn(),
+	create: jest.fn()
+}));
+jest.mock("models/github-server-app");
+console.log('', {axios });
+
+const DEFAULT_JIRA_HOST = "https://gh4j.test.atlassian.net";
+const VALID_TOKEN = 'valid-token';
+const GITHUB_SERVER_APP_UUID: string = v4uuid();
+const GITHUB_SERVER_APP_ID = 789;
+const GITHUB_SERVER_APP_URL = "https://default.internal.github.atlassian.net";
+
+const getGitHubServerAppModel = (): GitHubServerApp => {
+	return {
+		id: 1,
+		uuid: GITHUB_SERVER_APP_UUID,
+		appId: GITHUB_SERVER_APP_ID,
+		gitHubBaseUrl: GITHUB_SERVER_APP_URL,
+		gitHubClientId: 'client-id',
+		gitHubClientSecret: 'client-secret',
+		webhookSecret: 'webhook-secret',
+		privateKey: 'private-key',
+		gitHubAppName: 'test-app-name',
+		installationId: 123456,
+		updatedAt: new Date(),
+		createdAt: new Date()
+	} as GitHubServerApp;
+}
+
+describe("GitHub router", () => {
+	describe("Common route utilities", () => {
+		describe("GitHubServer", () => {
+			let app: Application;
+			beforeEach(() => {
+				app = express();
+				app.use((req, res, next)=>{
+					req.session = { githubToken: VALID_TOKEN };
+					res.locals = {jiraHost: DEFAULT_JIRA_HOST};
+					req.log = getLogger("test");
+					next();
+				});
+				app.use("/github", GithubRouter);
+				when(getGitHubApiUrl)
+					.calledWith(DEFAULT_JIRA_HOST, GITHUB_SERVER_APP_UUID)
+					.mockResolvedValue(GITHUB_SERVER_APP_URL);
+				when(GitHubServerApp.getForGitHubServerAppId)
+					.calledWith(GITHUB_SERVER_APP_UUID)
+					.mockResolvedValue(getGitHubServerAppModel());
+			});
+			it("should extract uuid when present", async () => {
+				await supertest(app).get(`/github/${GITHUB_SERVER_APP_UUID}/configuration`);
+				expect(GithubConfigurationGet).toBeCalledWith();
+			});
+		});
+	});
+});

--- a/src/routes/github/github-router.test.ts
+++ b/src/routes/github/github-router.test.ts
@@ -65,11 +65,6 @@ const mockPrerequistApp = () => {
 	return app;
 };
 
-const mockConfigurationGetProceed = ()=>{
-	jest.mocked(GithubConfigurationGet).mockClear();
-	jest.mocked(GithubConfigurationGet).mockImplementation(async (_req, _res, next) => {next();});
-};
-
 const mockGetGitHubApiUrl = () => {
 	when(getGitHubApiUrl)
 		.calledWith(JIRA_HOST, GITHUB_SERVER_APP_ID)
@@ -92,6 +87,13 @@ const mockInstallationFindByPK = () => {
 	when(Installation.findByPk)
 		.calledWith(JIRA_INSTALLATION_ID as any)
 		.mockResolvedValue(getServerApptInstallationModel());
+};
+
+const mockConfigurationGetProceed = ()=>{
+	jest.mocked(GithubConfigurationGet).mockClear();
+	jest.mocked(GithubConfigurationGet).mockImplementation(async (_req, _res, next) => {
+		next();
+	});
 };
 
 describe("GitHub router", () => {
@@ -129,7 +131,7 @@ describe("GitHub router", () => {
 				mockConfigurationGetProceed();
 			});
 			it("should extract uuid when present", async () => {
-				await supertest(app).get(`/github/configuration?ghaid=${GITHUB_SERVER_APP_ID}`);
+				await supertest(app).get(`/github/configuration?id=${GITHUB_SERVER_APP_ID}`);
 				expect(GithubConfigurationGet).toBeCalledWith(
 					expect.anything(), //not matching req
 					expect.objectContaining({ //matching res locals

--- a/src/routes/github/github-router.test.ts
+++ b/src/routes/github/github-router.test.ts
@@ -14,7 +14,7 @@ jest.mock("./configuration/github-configuration-get");
 jest.mock("utils/get-github-client-config");
 jest.mock("axios", () => ({ get: jest.fn(), create: jest.fn() }));
 jest.mock("models/github-server-app");
-jest.mock("models/Installation");
+jest.mock("models/installation");
 
 const JIRA_HOST = "https://gh4j.test.atlassian.net";
 const VALID_TOKEN = "valid-token";

--- a/src/routes/github/github-router.test.ts
+++ b/src/routes/github/github-router.test.ts
@@ -98,14 +98,14 @@ describe("GitHub router", () => {
 	beforeEach(()=>{
 	});
 	describe("Common route utilities", () => {
-		describe("Cloud scenario", ()=>{
+		describe.only("Cloud scenario", ()=>{
 			let app: Application;
 			beforeEach(() => {
 				app = mockPrerequistApp();
-				app.use("/github-cloud", GithubRouter);
+				app.use("/github", GithubRouter);
 			});
 			it("should skip uuid when absent", async () => {
-				await supertest(app).get(`/github-cloud/configuration`);
+				await supertest(app).get(`/github/configuration`);
 				expect(GithubConfigurationGet).toBeCalledWith(
 					expect.anything(), //not matching req
 					expect.objectContaining({ //matching res locals
@@ -122,14 +122,14 @@ describe("GitHub router", () => {
 			let app: Application;
 			beforeEach(() => {
 				app = mockPrerequistApp();
-				app.use("/github-server", GithubRouter);
+				app.use("/github", GithubRouter);
 				mockGetGitHubApiUrl();
 				mockGetForGitHubServerAppId();
 				mockAxiosPingURL();
 				mockInstallationFindByPK();
 			});
 			it("should extract uuid when present", async () => {
-				await supertest(app).get(`/github-server/${GITHUB_SERVER_APP_ID}/configuration`);
+				await supertest(app).get(`/github/appid-${GITHUB_SERVER_APP_ID}/configuration`);
 				expect(GithubConfigurationGet).toBeCalledWith(
 					expect.anything(), //not matching req
 					expect.objectContaining({ //matching res locals

--- a/src/routes/github/github-router.ts
+++ b/src/routes/github/github-router.ts
@@ -1,13 +1,13 @@
-import {Router} from "express";
-import {GithubAuthMiddleware, GithubOAuthRouter} from "./github-oauth-router";
-import {csrfMiddleware} from "middleware/csrf-middleware";
-import {GithubSubscriptionRouter} from "./subscription/github-subscription-router";
-import {GithubSetupRouter} from "routes/github/setup/github-setup-router";
-import {GithubConfigurationRouter} from "routes/github/configuration/github-configuration-router";
-import {returnOnValidationError} from "../api/api-utils";
-import {header} from "express-validator";
-import {WebhookReceiverPost} from "./webhook/webhook-receiver-post";
-import {GithubServerAppMiddleware} from "middleware/github-server-app-middleware";
+import { Router } from "express";
+import { GithubAuthMiddleware, GithubOAuthRouter } from "./github-oauth-router";
+import { csrfMiddleware } from "middleware/csrf-middleware";
+import { GithubSubscriptionRouter } from "./subscription/github-subscription-router";
+import { GithubSetupRouter } from "routes/github/setup/github-setup-router";
+import { GithubConfigurationRouter } from "routes/github/configuration/github-configuration-router";
+import { returnOnValidationError } from "../api/api-utils";
+import { header } from "express-validator";
+import { WebhookReceiverPost } from "./webhook/webhook-receiver-post";
+import { GithubServerAppMiddleware } from "middleware/github-server-app-middleware";
 
 export const GithubRouter = Router();
 
@@ -36,9 +36,3 @@ GithubRouter.use("/configuration", GithubConfigurationRouter);
 // TODO: remove optional "s" once we change the frontend to use the proper delete method
 GithubRouter.use("/subscriptions?", GithubSubscriptionRouter);
 
-/*
- *
- *	/github (From Root Router)
- *
- *
- */

--- a/src/routes/github/github-router.ts
+++ b/src/routes/github/github-router.ts
@@ -11,32 +11,34 @@ import {GithubServerAppMiddleware} from "middleware/github-server-app-middleware
 
 export const GithubRouter = Router();
 
-//Having an sub route  to extract optional :gitHubAppId for GitHub Server App
-//TODO: ARC-1515 chagne this to uuid instead of github app id
-const GithubRouterWithUUID = Router({mergeParams: true});
-GithubRouter.use("/appid-:gitHubAppId?", GithubRouterWithUUID);
 //Have an cover all middleware to extract the optional gitHubAppId
-GithubRouterWithUUID.use(GithubServerAppMiddleware);
+GithubRouter.use(GithubServerAppMiddleware);
 
 // OAuth Routes
-GithubRouterWithUUID.use(GithubOAuthRouter);
+GithubRouter.use(GithubOAuthRouter);
 
 // Webhook Route
-GithubRouterWithUUID.post("/webhooks/:uuid",
+GithubRouter.post("/webhooks/:uuid",
 	header(["x-github-event", "x-hub-signature-256", "x-github-delivery"]).exists(),
 	returnOnValidationError,
 	WebhookReceiverPost);
 
 // CSRF Protection Middleware for all following routes
-GithubRouterWithUUID.use(csrfMiddleware);
+GithubRouter.use(csrfMiddleware);
 
-GithubRouterWithUUID.use("/setup", GithubSetupRouter);
+GithubRouter.use("/setup", GithubSetupRouter);
 
 // All following routes need Github Auth
-GithubRouterWithUUID.use(GithubAuthMiddleware);
+GithubRouter.use(GithubAuthMiddleware);
 
-GithubRouterWithUUID.use("/configuration", GithubConfigurationRouter);
+GithubRouter.use("/configuration", GithubConfigurationRouter);
 
 // TODO: remove optional "s" once we change the frontend to use the proper delete method
-GithubRouterWithUUID.use("/subscriptions?", GithubSubscriptionRouter);
+GithubRouter.use("/subscriptions?", GithubSubscriptionRouter);
 
+/*
+ *
+ *	/github (From Root Router)
+ *
+ *
+ */

--- a/src/util/get-github-client-config.ts
+++ b/src/util/get-github-client-config.ts
@@ -19,8 +19,8 @@ export interface GitHubClientConfig {
 
 const logger = getLogger("get-github-client-config");
 
-export async function getGitHubApiUrl(jiraHost: string, gitHubAppId: number) {
-	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId);
+export async function getGitHubApiUrl(jiraHost: string, gitHubAppUUDId: string | undefined) {
+	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppUUDId);
 	return await booleanFlag(BooleanFlags.GHE_SERVER, false, jiraHost) && gitHubClientConfig
 		? `${gitHubClientConfig.baseUrl}`
 		: GITHUB_CLOUD_API_BASEURL;
@@ -32,8 +32,8 @@ const getGitHubClientConfigFromGitHubInstallationId = async (gitHubInstallationI
 	return getGitHubClientConfigFromAppId(gitHubAppId);
 };
 
-const getGitHubClientConfigFromAppId = async (gitHubAppId: number | undefined): Promise<GitHubClientConfig> => {
-	const gitHubServerApp = gitHubAppId && await GitHubServerApp.getForGitHubServerAppId(gitHubAppId);
+const getGitHubClientConfigFromAppId = async (gitHubAppUUIDId: string | undefined): Promise<GitHubClientConfig> => {
+	const gitHubServerApp = gitHubAppUUIDId && await GitHubServerApp.getForGitHubServerAppId(gitHubAppUUIDId);
 	const gitHubCloudUrls = {
 		hostname: GITHUB_CLOUD_HOSTNAME,
 		baseUrl: GITHUB_CLOUD_API_BASEURL

--- a/src/util/get-github-client-config.ts
+++ b/src/util/get-github-client-config.ts
@@ -19,8 +19,8 @@ export interface GitHubClientConfig {
 
 const logger = getLogger("get-github-client-config");
 
-export async function getGitHubApiUrl(jiraHost: string, gitHubAppUUDId: string | undefined) {
-	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppUUDId);
+export async function getGitHubApiUrl(jiraHost: string, gitHubAppId: number) {
+	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId);
 	return await booleanFlag(BooleanFlags.GHE_SERVER, false, jiraHost) && gitHubClientConfig
 		? `${gitHubClientConfig.baseUrl}`
 		: GITHUB_CLOUD_API_BASEURL;
@@ -32,8 +32,8 @@ const getGitHubClientConfigFromGitHubInstallationId = async (gitHubInstallationI
 	return getGitHubClientConfigFromAppId(gitHubAppId);
 };
 
-const getGitHubClientConfigFromAppId = async (gitHubAppUUIDId: string | undefined): Promise<GitHubClientConfig> => {
-	const gitHubServerApp = gitHubAppUUIDId && await GitHubServerApp.getForGitHubServerAppId(gitHubAppUUIDId);
+const getGitHubClientConfigFromAppId = async (gitHubAppId: number | undefined): Promise<GitHubClientConfig> => {
+	const gitHubServerApp = gitHubAppId && await GitHubServerApp.getForGitHubServerAppId(gitHubAppId);
 	const gitHubCloudUrls = {
 		hostname: GITHUB_CLOUD_HOSTNAME,
 		baseUrl: GITHUB_CLOUD_API_BASEURL


### PR DESCRIPTION
**What's in this PR?**
Move the GithubServerAppMiddleware to above to support GHE use case.

**Why**
Many github routes need the gitHubAppId (for now), need to use a shared route

**Added feature flags**
N/A

**Affected issues**  
ARC-1515

**How has this been tested?**  
Unit test.

**Whats Next?**
1. Figure out how to make use of it in the frontend and create PR.
2. Refactor once db schema is done, to use uuid instead of app id.