### PR TITLE
SAI-12053 Removed feature flag controlling sending associated commits with deployments

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -25,7 +25,6 @@ export enum BooleanFlags {
 	USE_NEW_GITHUB_CLIENT_FOR_GET_REPO = "use-new-github-client-for-get-repo",
 	USE_NEW_GITHUB_CLIENT_FOR_INSTALLATION_API = "use-new-github-client-for-installation-api",
 	USE_NEW_GITHUB_CLIENT_FOR_REDIRECT = "use-new-github-client-for-redirect",
-	SEND_RELATED_COMMITS_WITH_DEPLOYMENT_ENTITIES = "send-related-commits-with-deployment-entities",
 	RETRY_ALL_ERRORS = "retry-all-errors",
 	GHE_SERVER = "ghe_server",
 	USE_REST_API_FOR_DISCOVERY = "use-rest-api-for-discovery",

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -23,7 +23,6 @@ export enum BooleanFlags {
 	REGEX_FIX = "regex-fix",
 	USE_NEW_GITHUB_CLIENT_FOR_GET_REPO = "use-new-github-client-for-get-repo",
 	USE_NEW_GITHUB_CLIENT_FOR_INSTALLATION_API = "use-new-github-client-for-installation-api",
-	USE_NEW_GITHUB_CLIENT_FOR_REDIRECT = "use-new-github-client-for-redirect",
 	RETRY_ALL_ERRORS = "retry-all-errors",
 	GHE_SERVER = "ghe_server",
 	USE_REST_API_FOR_DISCOVERY = "use-rest-api-for-discovery",

--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -202,17 +202,11 @@ export const transformDeployment = async (githubInstallationClient: GitHubInstal
 		);
 
 		const allCommitsMessages = extractMessagesFromCommitSummaries(commitSummaries);
-
-		const shouldSendCommitsWithDeploymentEntities = await booleanFlag(BooleanFlags.SEND_RELATED_COMMITS_WITH_DEPLOYMENT_ENTITIES, false, jiraHost);
-		if (shouldSendCommitsWithDeploymentEntities) {
-			associations = mapJiraIssueIdsAndCommitsToAssociationArray(
-				jiraIssueKeyParser(`${deployment.ref}\n${message}\n${allCommitsMessages}`),
-				payload.repository.id.toString(),
-				commitSummaries
-			);
-		} else {
-			issueKeys = jiraIssueKeyParser(`${deployment.ref}\n${message}\n${allCommitsMessages}`);
-		}
+		associations = mapJiraIssueIdsAndCommitsToAssociationArray(
+			jiraIssueKeyParser(`${deployment.ref}\n${message}\n${allCommitsMessages}`),
+			payload.repository.id.toString(),
+			commitSummaries
+		);
 	} else {
 		issueKeys = jiraIssueKeyParser(`${deployment.ref}\n${message}`);
 	}

--- a/src/transforms/transform-deployments.test.ts
+++ b/src/transforms/transform-deployments.test.ts
@@ -83,103 +83,6 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 	const { payload: { repository: { name: repoName, owner } } } = deployment_status;
 	const githubClient = new GitHubInstallationClient(getInstallationId(TEST_INSTALLATION_ID), getLogger("test"));
 
-	it("supports branch and merge workflows", async () => {
-
-		//If we use old GH Client we won't call the API because we pass already "authenticated" client to the test method
-		githubUserTokenNock(TEST_INSTALLATION_ID);
-		githubUserTokenNock(TEST_INSTALLATION_ID);
-		githubUserTokenNock(TEST_INSTALLATION_ID);
-		githubUserTokenNock(TEST_INSTALLATION_ID);
-
-		// Mocking all GitHub API Calls
-		// Get commit
-		githubNock.get(`/repos/${owner.login}/${repoName}/commits/${deployment_status.payload.deployment.sha}`)
-			.reply(200, {
-				...owner,
-				commit: {
-					message: "testing"
-				}
-			});
-
-		// List deployments
-		githubNock.get(`/repos/${owner.login}/${repoName}/deployments?environment=Production&per_page=10`)
-			.reply(200,
-				[
-					{
-						id: 1,
-						environment: "Production",
-						sha: "6e87a40179eb7ecf5094b9c8d690db727472d5bc"
-					}
-				]
-			);
-
-		// List deployments statuses
-		githubNock.get(`/repos/${owner.login}/${repoName}/deployments/1/statuses?per_page=100`)
-			.reply(200, [
-				{
-					id: 1,
-					state: "pending"
-				},
-				{
-					id: 2,
-					state: "success"
-				}
-			]);
-
-		// Compare commits
-		githubNock.get(`/repos/${owner.login}/${repoName}/compare/6e87a40179eb7ecf5094b9c8d690db727472d5bc...${deployment_status.payload.deployment.sha}`)
-			.reply(200, {
-				commits: [
-					{
-						commit: {
-							message: "ABC-1"
-						},
-						sha: "6e87a40179eb7ecf5094b9c8d690db727472d5bc1"
-					},
-					{
-						commit: {
-							message: "ABC-2"
-						},
-						sha: "6e87a40179eb7ecf5094b9c8d690db727472d5bc2"
-					}
-				]
-			}
-			);
-
-
-		when(booleanFlag).calledWith(
-			BooleanFlags.SUPPORT_BRANCH_AND_MERGE_WORKFLOWS_FOR_DEPLOYMENTS,
-			expect.anything(),
-			expect.anything()
-		).mockResolvedValue(true);
-
-		const jiraPayload = await transformDeployment(githubClient, deployment_status.payload as any, "testing.atlassian.net", getLogger("deploymentLogger"));
-
-		expect(jiraPayload).toMatchObject({
-			deployments: [{
-				schemaVersion: "1.0",
-				deploymentSequenceNumber: 1234,
-				updateSequenceNumber: 123456,
-				issueKeys: ["ABC-1", "ABC-2"],
-				displayName: "deploy",
-				url: "test-repo-url/commit/885bee1-commit-id-1c458/checks",
-				description: "deploy",
-				lastUpdated: new Date("2021-06-28T12:15:18.000Z"),
-				state: "successful",
-				pipeline: {
-					id: "deploy",
-					displayName: "deploy",
-					url: "test-repo-url/commit/885bee1-commit-id-1c458/checks"
-				},
-				environment: {
-					id: "Production",
-					displayName: "Production",
-					type: "production"
-				}
-			}]
-		});
-	});
-
 	it(`supports branch and merge workflows, sending related commits in deployment`, async () => {
 
 		//If we use old GH Client we won't call the API because we pass already "authenticated" client to the test method
@@ -246,12 +149,6 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 
 		when(booleanFlag).calledWith(
 			BooleanFlags.SUPPORT_BRANCH_AND_MERGE_WORKFLOWS_FOR_DEPLOYMENTS,
-			expect.anything(),
-			expect.anything()
-		).mockResolvedValue(true);
-
-		when(booleanFlag).calledWith(
-			BooleanFlags.SEND_RELATED_COMMITS_WITH_DEPLOYMENT_ENTITIES,
 			expect.anything(),
 			expect.anything()
 		).mockResolvedValue(true);
@@ -364,12 +261,6 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 
 		when(booleanFlag).calledWith(
 			BooleanFlags.SUPPORT_BRANCH_AND_MERGE_WORKFLOWS_FOR_DEPLOYMENTS,
-			expect.anything(),
-			expect.anything()
-		).mockResolvedValue(true);
-
-		when(booleanFlag).calledWith(
-			BooleanFlags.SEND_RELATED_COMMITS_WITH_DEPLOYMENT_ENTITIES,
 			expect.anything(),
 			expect.anything()
 		).mockResolvedValue(true);


### PR DESCRIPTION
**What's in this PR?**
- removed FF
- feature for sending related commits with deployments is now enabled permanently

**Why**
- the feature has been rolled out 100% in production

**How has this been tested?**  
- unit tests