### PR TITLE
Adding yarnrc for defaulting ignore-optional on yarn install

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--install.ignore-optional true


### PR DESCRIPTION
**What's in this PR?**
Defaulting `yarn install` to ignore optional dependencies

**Why**
Because it was annoying of writing `yarn install --ignore-optional` every time.

**Added feature flags**
None

**Affected issues**  
_Jira Issues_

**How has this been tested?**  
`yarn install` while not connected to VPN should not break

**Whats Next?**
Profit.