### PR TITLE
ARC-1546 - GHE UI - Lose the back button in the GH cloud connect page(child window)

### DIFF
--- a/static/css/global.css
+++ b/static/css/global.css
@@ -214,6 +214,10 @@ a:focus {
   align-items: center;
 }
 
+.navigation.no-back-btn {
+  justify-content: flex-end;
+}
+
 .navigation__backButton__container {
   background: #fff;
   border: none;

--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -2,11 +2,8 @@
 $(".go-back").click(function (event) {
   event.preventDefault();
   const previousPagePath = $(event.target).data("previous-page-path");
-  const closeOnBack = $(event.target).data("close-on-back");
 
-  if (closeOnBack) {
-    window.close();
-  } else if (previousPagePath) {
+  if (previousPagePath) {
     AP.navigator.go("addonmodule", {moduleKey: previousPagePath});
   } else {
     history.back();

--- a/views/github-configuration.hbs
+++ b/views/github-configuration.hbs
@@ -31,7 +31,7 @@
   value="{{clientKey}}"
 />
 
-{{> navigation previousPageName="Jira Configuration" closeOnBack="true" }}
+{{> navigation previousPageName="Jira Configuration" hideBackButton=true }}
 
 <section class="gitHubConfiguration">
   <div class="headerImage">

--- a/views/partials/navigation.hbs
+++ b/views/partials/navigation.hbs
@@ -1,11 +1,12 @@
-<nav class="navigation">
-    <button class="navigation__backButton__container navigation__link go-back">
-        <img src="/public/assets/arrow-left.svg"
-             alt="Go back to {{previousPageName}}"
-             data-previous-page-path="{{previousPagePath}}"
-             data-close-on-back="{{closeOnBack}}"
-        />
-    </button>
+<nav class="navigation {{#if hideBackButton}}no-back-btn{{/if}}">
+    {{#unless hideBackButton}}
+        <button class="navigation__backButton__container navigation__link go-back">
+            <img src="/public/assets/arrow-left.svg"
+                 alt="Go back to {{previousPageName}}"
+                 data-previous-page-path="{{previousPagePath}}"
+            />
+        </button>
+    {{/unless}}
     <a href="https://support.atlassian.com/jira-cloud-administration/docs/integrate-with-jenkins" class="navigation__help__container navigation__link">
         <img class="navigation__icon" src="/public/assets/question.svg" alt="https://support.atlassian.com/jira-cloud-administration/docs/integrate-with-jenkins" />
         <p class="navigation__help__message">Help</p>


### PR DESCRIPTION
**What's in this PR?**
- The back button in the Github Configuration/Connect Page, which is opened as a child window, was removed.
- The attribute `closeOnBack` was removed and a new attribute `hideBackButton` was added in partial `navigation`.


**Why**
- [Outcome based on this discussion ](https://atlassian.slack.com/archives/C039YPCGCSG/p1658711208126409)

**How has this been tested?**  
- In local dev environment
- In Staging environment