### PR TITLE
ARC 1555 - JWT wrong QSH for encoded URLs in path

### DIFF
--- a/src/jira/util/jwt.test.ts
+++ b/src/jira/util/jwt.test.ts
@@ -378,5 +378,13 @@ describe("jwt", () => {
 			expect(res.status).toHaveBeenCalledWith(401);
 			expect(next).toBeCalledTimes(0);
 		});
+
+		it("should return 200 with encoded URI in the path", async () => {
+			const req = buildRequestWithJwt("629dd55929f23ea619f465d40e02b394f57acfc6deeecd2024428f9c31f8b55c");
+			req.path = encodeURIComponent("https://whatever.fake");
+			await verifyAsymmetricJwtTokenMiddleware(req, res, next);
+			expect(res.status).toHaveBeenCalledTimes(0);
+			expect(next).toBeCalledTimes(1);
+		});
 	});
 });

--- a/src/jira/util/jwt.ts
+++ b/src/jira/util/jwt.ts
@@ -81,7 +81,16 @@ function decodeAsymmetricToken(token: string, publicKey: string, noVerify: boole
 
 function verifyQsh(qsh: string, req: Request): boolean {
 	// to get full path from express request, we need to add baseUrl with path
-	const requestInAtlassianJwtFormat = { ...req, pathname: req.baseUrl + req.path };
+	/**
+	 * TODO: Remove `decodeURIComponent` later
+	 * This has been added here as a temporarily until the `qsh` bug is fixed
+	 *
+	 * Bug: This method `createQueryStringHash` doesn't handle the decoded URI strings passed along the path
+	 * For e.g. If we pass a string `http%3A%2F%2Fabc.com`, it doesn't encode it to `http://abc.com`,
+	 * but uses the original string, which returns a different `qsh` value.
+	 * Because of this reason, if we have any decoded URI in the request path, then it always fails with an error `Wrong qsh`
+	 */
+	const requestInAtlassianJwtFormat = { ...req, pathname: req.baseUrl + decodeURIComponent(req.path) };
 	let expectedHash = createQueryStringHash(requestInAtlassianJwtFormat, false, BASE_URL);
 	const signatureHashVerified = qsh === expectedHash;
 


### PR DESCRIPTION
**What's in this PR?**
- The encoded URLs in the path are decoded before being passed through `createQueryStringHash`.
- Test case added

**Why**
- In our connect-app, when the user has an encoded URI in the request path, the request fails with an error `wrong qsh`. 

**Affected issues**  
- ARC-1519

**How has this been tested?**  
- In local environment
- Test case
