### PR TITLE
replace ternary operator with if/else to avoid logging issues

### DIFF
--- a/src/github/client/github-client-interceptors.ts
+++ b/src/github/client/github-client-interceptors.ts
@@ -127,7 +127,12 @@ export const handleFailedRequest = (logger: Logger) =>
 			}
 			const isWarning = status && (status >= 300 && status < 500 && status !== 400);
 
-			(isWarning ? logger.warn : logger.error)(errorMessage);
+			if (isWarning){
+				logger.warn(errorMessage);
+			} else {
+				logger.error(errorMessage);
+			}
+
 			return Promise.reject(new GithubClientError(errorMessage, status, error));
 		}
 


### PR DESCRIPTION
There was an issue using logging inside a ternary in `axios.ts`, so I'm fixing it in the GitHub client interceptors as well.
