### PR TITLE
ARC-1354 fix starting dependencies of cryptor.

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -26,6 +26,8 @@ compose:
     links:
       - pgbouncer
       - cryptor
+    depends_on:
+      - cryptor
   cryptor:
     image: docker.atl-paas.net/sox/cryptor-sidecar-application
     tag: 1.1-stable-release


### PR DESCRIPTION
**What's in this PR?**
Add depends_on for cryptor to the app itself.

**Why**
It seems the worker start consuming sqs before cryptor sidecar is ready. Having this "depends_on" will "ease" the problem.

**Added feature flags**
N/A

**Affected issues**  
ARC-1354

**How has this been tested?**  
ddev

**Whats Next?**
Check whether it works over each deployments. If no, may need to add more sophisticated checking for cryptor.
