### PR TITLE
Reverting repositoryId change on deployment fix

### DIFF
--- a/src/github/client/github-queries.ts
+++ b/src/github/client/github-queries.ts
@@ -351,6 +351,7 @@ export const getDeploymentsQuery = `query ($owner: String!, $repo: String!, $per
         cursor
         node {
           repository {
+            id: databaseId
             node_id: id
             name
             owner {

--- a/src/github/deployment.test.ts
+++ b/src/github/deployment.test.ts
@@ -149,11 +149,11 @@ describe("Deployment Webhook", () => {
 									"values": [
 										{
 											"commitHash": "a84d88e7554fc1fa21bcbc4efae3c782a70d2b9d",
-											"repositoryId": "MDEwOkRlcGxveW1lbnQxNDU5ODg3NDY"
+											"repositoryId": "65"
 										},
 										{
 											"commitHash": "f95f852bd8fca8fcc58a9a2d6c842781e32a215e",
-											"repositoryId": "MDEwOkRlcGxveW1lbnQxNDU5ODg3NDY"
+											"repositoryId": "65"
 										}
 									]
 								}

--- a/src/sync/deployment.test.ts
+++ b/src/sync/deployment.test.ts
@@ -207,11 +207,11 @@ describe("sync/deployments", () => {
 					"values": [
 						{
 							"commitHash": "a84d88e7554fc1fa21bcbc4efae3c782a70d2b9d",
-							"repositoryId": "AyMi0wMi0wM1QyMjo0NT"
+							"repositoryId": "19"
 						},
 						{
 							"commitHash": "51e16759cdac67b0d2a94e0674c9603b75a840f6",
-							"repositoryId": "AyMi0wMi0wM1QyMjo0NT"
+							"repositoryId": "19"
 						}
 					]
 				}]
@@ -339,11 +339,11 @@ describe("sync/deployments", () => {
 						values: [
 							{
 								commitHash: "a84d88e7554fc1fa21bcbc4efae3c782a70d2b9d",
-								repositoryId: "pK0MjAyMi0wMi0wM1QyMj"
+								repositoryId: "24"
 							},
 							{
 								commitHash: "51e16759cdac67b0d2a94e0674c9603b75a840f6",
-								repositoryId: "pK0MjAyMi0wMi0wM1QyMj"
+								repositoryId: "24"
 							}
 						]
 					}
@@ -378,11 +378,11 @@ describe("sync/deployments", () => {
 						values: [
 							{
 								commitHash: "a84d88e7554fc1fa21bcbc4efae3c782a70d2b9d",
-								repositoryId: "pK0MjAyMi0wMi0wM1QyMj"
+								repositoryId: "42"
 							},
 							{
 								commitHash: "7544f2fec0321a32d5effd421682463c2ebd5018",
-								repositoryId: "pK0MjAyMi0wMi0wM1QyMj"
+								repositoryId: "42"
 							}
 						]
 					}

--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -190,7 +190,7 @@ export const transformDeployment = async (githubInstallationClient: GitHubInstal
 	const allCommitsMessages = extractMessagesFromCommitSummaries(commitSummaries);
 	const associations = mapJiraIssueIdsAndCommitsToAssociationArray(
 		jiraIssueKeyParser(`${deployment.ref}\n${message}\n${allCommitsMessages}`),
-		payload.repository.node_id,
+		payload.repository.id.toString(),
 		commitSummaries
 	);
 

--- a/src/transforms/transform-deployments.test.ts
+++ b/src/transforms/transform-deployments.test.ts
@@ -176,11 +176,11 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 						values: [
 							{
 								commitHash: "6e87a40179eb7ecf5094b9c8d690db727472d5bc1",
-								repositoryId: "MDEwOkRlcGxveW1lbnQxNDU5ODg3NDY"
+								repositoryId: "65"
 							},
 							{
 								commitHash: "6e87a40179eb7ecf5094b9c8d690db727472d5bc2",
-								repositoryId: "MDEwOkRlcGxveW1lbnQxNDU5ODg3NDY"
+								repositoryId: "65"
 							}
 						]
 					}

--- a/test/fixtures/api/graphql/deployment-nodes-mixed.json
+++ b/test/fixtures/api/graphql/deployment-nodes-mixed.json
@@ -7,6 +7,7 @@
             "cursor": "Y3Vyc29yOnYyOpK0MjAyMi0wMi0wM1QyMjo0NTowM1rOHdDZeg==",
             "node": {
               "repository": {
+								"id": 24,
 								"node_id": "pK0MjAyMi0wMi0wM1QyMj",
                 "name": "test-repo-name",
                 "owner": {
@@ -35,6 +36,7 @@
             "cursor": "Y3Vyc29yOnYyOpK0MjAyMi0wMi0wM1QyMjo0NTowM1rOHdDZeg==",
             "node": {
               "repository": {
+								"id": 42,
 								"node_id": "pK0MjAyMi0wMi0wM1QyMj",
                 "name": "test-repo-name",
                 "owner": {

--- a/test/fixtures/api/graphql/deployment-nodes.json
+++ b/test/fixtures/api/graphql/deployment-nodes.json
@@ -7,6 +7,7 @@
             "cursor": "Y3Vyc29yOnYyOpK0MjAyMi0wMi0wM1QyMjo0NTowM1rOHdDZeg==",
             "node": {
               "repository": {
+								"id": 19,
 								"node_id": "AyMi0wMi0wM1QyMjo0NT",
                 "name": "test-repo-name",
                 "owner": {

--- a/test/fixtures/deployment_status-basic.json
+++ b/test/fixtures/deployment_status-basic.json
@@ -33,6 +33,7 @@
 		},
 		"action": "created",
 		"repository": {
+			"id": 65,
 			"name": "test-repo-name",
 			"node_id": "MDEwOkRlcGxveW1lbnQxNDU5ODg3NDY",
 			"html_url": "test-repo-url",


### PR DESCRIPTION
**What's in this PR?**
reverting `repositoryId` to use `repository.id` instead of `repository.node_id`

**Why**
Because `node_id` has certain special characters that data depot doesn't allow.  We sometimes see the error `Id must match the pattern '[A-Za-z0-9\-._~]+` depending on the the repository which means that the deployment call to jira will fail and won't show for the customer. We've decided (arc and sayans) that this is the quickest simplest fix for now until the sayans change that id validation to be more broad for our purposes.

**Added feature flags**
none

**Affected issues**  
HOT-99909

**How has this been tested?**  
unit tests

**Whats Next?**
Deploy it, do another PR that reverts this change waiting for the sayans to fix data depot validation.