### PR TITLE
create global to easily turn ghe_server on/off

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -88,3 +88,5 @@ export const isBlocked = async (installationId: number, logger: Logger): Promise
 export const shouldTagBackfillRequests = async (): Promise<boolean> => {
 	return booleanFlag(BooleanFlags.TAG_BACKFILL_REQUESTS, false);
 };
+
+export const GHE_SERVER_GLOBAL = false;

--- a/src/github/client/app-token-holder.ts
+++ b/src/github/client/app-token-holder.ts
@@ -4,7 +4,7 @@ import LRUCache from "lru-cache";
 import { InstallationId } from "./installation-id";
 import { keyLocator } from "~/src/github/client/key-locator";
 import { Subscription } from "~/src/models/subscription";
-import { booleanFlag, BooleanFlags } from "~/src/config/feature-flags";
+import { booleanFlag, BooleanFlags, GHE_SERVER_GLOBAL } from "~/src/config/feature-flags";
 import * as PrivateKey from "probot/lib/private-key";
 
 
@@ -62,7 +62,7 @@ export class AppTokenHolder {
 		if (!currentToken || currentToken.isAboutToExpire()) {
 			const subscription = await Subscription.findOneForGitHubInstallationId(appId.installationId);
 			let key;
-			if (await booleanFlag(BooleanFlags.GHE_SERVER, false, subscription?.jiraHost)) {
+			if (await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, subscription?.jiraHost)) {
 				key = await keyLocator(subscription?.gitHubAppId);
 			} else {
 				key = PrivateKey.findPrivateKey();

--- a/src/routes/jira/jira-get.ts
+++ b/src/routes/jira/jira-get.ts
@@ -7,7 +7,7 @@ import { statsd }  from "config/statsd";
 import { metricError } from "config/metric-names";
 import { AppInstallation, FailedAppInstallation } from "config/interfaces";
 import { createAppClient } from "utils/get-github-client-config";
-import { booleanFlag, BooleanFlags } from "config/feature-flags";
+import { booleanFlag, BooleanFlags, GHE_SERVER_GLOBAL } from "config/feature-flags";
 import { GitHubServerApp } from "models/github-server-app";
 import { sendAnalytics } from "utils/analytics-client";
 import { AnalyticsEventTypes, AnalyticsScreenEventsEnum } from "interfaces/common";
@@ -227,7 +227,7 @@ export const JiraGet = async (
 
 		req.log.debug("Received jira configuration page request");
 
-		if (await booleanFlag(BooleanFlags.GHE_SERVER, false, jiraHost)) {
+		if (await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)) {
 			await renderJiraCloudAndEnterpriseServer(res, req);
 		} else {
 			await renderJiraCloud(res, req);

--- a/src/util/get-github-client-config.ts
+++ b/src/util/get-github-client-config.ts
@@ -1,7 +1,7 @@
 import { GitHubServerApp } from "models/github-server-app";
 import { GitHubInstallationClient } from "../github/client/github-installation-client";
 import { getInstallationId } from "../github/client/installation-id";
-import { booleanFlag, BooleanFlags } from "config/feature-flags";
+import { booleanFlag, BooleanFlags, GHE_SERVER_GLOBAL } from "config/feature-flags";
 import { GitHubUserClient } from "../github/client/github-user-client";
 import Logger from "bunyan";
 import { GitHubAppClient } from "../github/client/github-app-client";
@@ -22,7 +22,7 @@ export interface GitHubClientConfig {
 
 export async function getGitHubApiUrl(jiraHost: string, gitHubAppId: number) {
 	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
-	return await booleanFlag(BooleanFlags.GHE_SERVER, false, jiraHost) && gitHubClientConfig
+	return await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost) && gitHubClientConfig
 		? `${gitHubClientConfig.baseUrl}`
 		: GITHUB_CLOUD_API_BASEURL;
 }
@@ -38,7 +38,7 @@ const getGitHubClientConfigFromAppId = async (gitHubAppId: number | undefined, j
 		};
 	}
 	// cloud config
-	const privateKey = await booleanFlag(BooleanFlags.GHE_SERVER, false, jiraHost)? await keyLocator(): PrivateKey.findPrivateKey();
+	const privateKey = await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)? await keyLocator(): PrivateKey.findPrivateKey();
 	if (!privateKey) {
 		throw new Error("Private key not found for github cloud");
 	}
@@ -52,7 +52,7 @@ const getGitHubClientConfigFromAppId = async (gitHubAppId: number | undefined, j
 
 export async function getGitHubHostname(jiraHost: string, gitHubAppId: number) {
 	const gitHubClientConfig = gitHubAppId && await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
-	return await booleanFlag(BooleanFlags.GHE_SERVER, false, jiraHost) && gitHubClientConfig
+	return await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost) && gitHubClientConfig
 		? gitHubClientConfig.hostname
 		: GITHUB_CLOUD_HOSTNAME;
 }
@@ -63,7 +63,7 @@ export async function getGitHubHostname(jiraHost: string, gitHubAppId: number) {
  */
 export async function createAppClient(logger: Logger, jiraHost: string, gitHubAppId: number | undefined): Promise<GitHubAppClient> {
 	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
-	return await booleanFlag(BooleanFlags.GHE_SERVER, false, jiraHost)
+	return await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)
 		? new GitHubAppClient(logger, gitHubClientConfig.baseUrl, gitHubClientConfig.appId.toString(), gitHubClientConfig.privateKey)
 		: new GitHubAppClient(logger);
 }
@@ -74,7 +74,7 @@ export async function createAppClient(logger: Logger, jiraHost: string, gitHubAp
  */
 export async function createInstallationClient(gitHubInstallationId: number, jiraHost: string, logger: Logger, gitHubAppId?: number | undefined): Promise<GitHubInstallationClient> {
 
-	if (await booleanFlag(BooleanFlags.GHE_SERVER, false, jiraHost)) {
+	if (await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)) {
 		const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
 		return new GitHubInstallationClient(getInstallationId(gitHubInstallationId, gitHubClientConfig.baseUrl, gitHubClientConfig.appId), logger, gitHubClientConfig.baseUrl);
 	} else {
@@ -87,7 +87,7 @@ export async function createInstallationClient(gitHubInstallationId: number, jir
  */
 export async function createUserClient(githubToken: string, jiraHost: string, logger: Logger, gitHubAppId: number | undefined): Promise<GitHubUserClient> {
 	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
-	return await booleanFlag(BooleanFlags.GHE_SERVER, false, jiraHost)
+	return await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)
 		? new GitHubUserClient(githubToken, logger, gitHubClientConfig.baseUrl)
 		: new GitHubUserClient(githubToken, logger);
 }


### PR DESCRIPTION
**What's in this PR?**
Added a ghe_server constant.

**Why**
So we can easily turn the GHE_SERVER flag on/off to test locally and there's no way to easily do this with our current ff setup.

**Whats Next?**
Update our ff config?
