### PR TITLE
ARC-1563 delete app and navigate to form on edit

### DIFF
--- a/src/models/github-server-app.ts
+++ b/src/models/github-server-app.ts
@@ -97,7 +97,7 @@ export class GitHubServerApp extends EncryptedModel {
 	 * @param installationId
 	 * @returns {GitHubServerApp[]}
 	 */
-	static getAllForGitHubBaseUrlAndInstallationId(
+	static async getAllForGitHubBaseUrlAndInstallationId(
 		gitHubBaseUrl: string,
 		installationId: number
 	): Promise<GitHubServerApp[]> {

--- a/src/models/github-server-app.ts
+++ b/src/models/github-server-app.ts
@@ -97,14 +97,10 @@ export class GitHubServerApp extends EncryptedModel {
 	 * @param installationId
 	 * @returns {GitHubServerApp[]}
 	 */
-	static async getAllForGitHubBaseUrl(
+	static getAllForGitHubBaseUrlAndInstallationId(
 		gitHubBaseUrl: string,
 		installationId: number
-	): Promise<GitHubServerApp[] | null> {
-		if (!gitHubBaseUrl || !installationId) {
-			return null;
-		}
-
+	): Promise<GitHubServerApp[]> {
 		return this.findAll({
 			where: {
 				gitHubBaseUrl,
@@ -159,6 +155,12 @@ export class GitHubServerApp extends EncryptedModel {
 		});
 
 		return gitHubServerApp;
+	}
+
+	static async uninstall(uuid: string): Promise<void> {
+		await this.destroy({
+			where: { uuid }
+		});
 	}
 
 	/**

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-delete.test.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-delete.test.ts
@@ -1,0 +1,86 @@
+import { GitHubServerApp } from "models/github-server-app";
+import { JiraConnectEnterpriseAppDelete } from "routes/jira/connect/enterprise/app/jira-connect-enterprise-app-delete";
+
+describe("DELETE /jira/connect/enterprise/app/:uuid", () => {
+	const gitHubBaseUrl = "http://myinternalinstance.com";
+	const installationId = 72;
+	const appOneUuid = "c97806fc-c433-4ad5-b569-bf5191590be2";
+	const appTwoUuid = "9eaf28d5-fe18-42d8-a76d-eba80adc2295";
+
+	const mockRequest = (uuid: string): any => ({
+		log: {
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+			debug: jest.fn()
+		},
+		query: {},
+		body: { uuid },
+		csrfToken: jest.fn().mockReturnValue({})
+	});
+
+	const mockResponse = (): any => {
+		const response = {
+			locals: {},
+			render: jest.fn().mockReturnValue({}),
+			status: jest.fn(),
+			send: jest.fn().mockReturnValue({})
+		};
+		response.status = response.status.mockReturnValue(response);
+
+		return response;
+	};
+
+	beforeEach(async () => {
+		await GitHubServerApp.create({
+			uuid: appOneUuid,
+			appId: 1,
+			gitHubAppName: "my awesome app",
+			gitHubBaseUrl,
+			gitHubClientId: "lvl.1n23j12389wndd",
+			gitHubClientSecret: "secret",
+			webhookSecret: "anothersecret",
+			privateKey: "privatekey",
+			installationId
+		});
+		await GitHubServerApp.create({
+			uuid: "9eaf28d5-fe18-42d8-a76d-eba80adc2295",
+			appId: 2,
+			gitHubAppName: "my awesome app",
+			gitHubBaseUrl,
+			gitHubClientId: "lvl.1n23j12389wndd",
+			gitHubClientSecret: "secret",
+			webhookSecret: "anothersecret",
+			privateKey: "privatekey",
+			installationId
+		});
+	});
+
+	it("should delete GitHub app when uuid is found", async () => {
+		const records = await GitHubServerApp.getAllForGitHubBaseUrlAndInstallationId(gitHubBaseUrl, installationId);
+		expect(records.length).toBe(2);
+
+		await GitHubServerApp.uninstall(appOneUuid);
+
+		const appOne = await GitHubServerApp.findForUuid(appOneUuid);
+		expect(appOne).toBeNull();
+		const appTwo = await GitHubServerApp.findForUuid(appTwoUuid);
+		expect(appTwo).not.toBeNull();
+	});
+
+	it("should send a successful response when app is deleted", async () => {
+		const response = mockResponse();
+		await JiraConnectEnterpriseAppDelete(mockRequest("95980446-16e1-11ed-861d-0242ac120002"), response, jest.fn());
+
+		expect(response.status).toHaveBeenCalledWith(200);
+		expect(response.send).toHaveBeenCalledWith({ success: true });
+	});
+
+	it("should send a failure response when unable to delete app", async () => {
+		const response = mockResponse();
+		await JiraConnectEnterpriseAppDelete(mockRequest("this is not a uuid"), response, jest.fn());
+
+		expect(response.status).toHaveBeenCalledWith(200);
+		expect(response.send).toHaveBeenCalledWith({ success: false, message: "Failed to delete GitHub App." });
+	});
+});

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-delete.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-delete.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from "express";
+import { GitHubServerApp } from "~/src/models/github-server-app";
 
 export const JiraConnectEnterpriseAppDelete = async (
 	req: Request,
@@ -8,10 +9,12 @@ export const JiraConnectEnterpriseAppDelete = async (
 	try {
 		req.log.debug("Received Jira Connect Enterprise App DELETE request");
 
-		// TODO: Add logic for deleting apps
+		await GitHubServerApp.uninstall(req.body.uuid);
 
-		req.log.debug("Jira Connect Enterprise App deleted successfully.", res.locals);
+		res.status(200).send({ success: true });
+		req.log.debug("Jira Connect Enterprise App deleted successfully.");
 	} catch (error) {
+		res.status(200).send({ success: false, message: "Failed to delete GitHub App." });
 		return next(new Error(`Failed to render Jira Connect Enterprise App DELETE request : ${error}`));
 	}
 };

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-router.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-router.ts
@@ -13,4 +13,4 @@ JiraConnectEnterpriseAppRouter.post("/", JiraContextJwtTokenMiddleware, JiraConn
 JiraConnectEnterpriseAppRouter.route("/:uuid")
 	.get(csrfMiddleware, JiraJwtTokenMiddleware, JiraConnectEnterpriseAppCreateOrEdit)
 	.put(csrfMiddleware, JiraContextJwtTokenMiddleware, JiraConnectEnterpriseAppPut)
-	.delete(csrfMiddleware, JiraContextJwtTokenMiddleware, JiraConnectEnterpriseAppDelete);
+	.delete(JiraContextJwtTokenMiddleware, JiraConnectEnterpriseAppDelete);

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.ts
@@ -58,9 +58,9 @@ export const JiraConnectEnterprisePost = async (
 	const jiraHost = res.locals.jiraHost;
 
 	try {
-		const gitHubServerApps = await GitHubServerApp.getAllForGitHubBaseUrl(gheServerURL, installationId);
+		const gitHubServerApps = await GitHubServerApp.getAllForGitHubBaseUrlAndInstallationId(gheServerURL, installationId);
 
-		if (gitHubServerApps?.length) {
+		if (gitHubServerApps?.length > 0) {
 			req.log.debug(`GitHub apps found for url: ${gheServerURL}. Redirecting to Jira list apps page.`);
 			res.status(200).send({ success: true, appExists: true });
 			return;

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.ts
@@ -60,7 +60,7 @@ export const JiraConnectEnterprisePost = async (
 	try {
 		const gitHubServerApps = await GitHubServerApp.getAllForGitHubBaseUrlAndInstallationId(gheServerURL, installationId);
 
-		if (gitHubServerApps?.length > 0) {
+		if (gitHubServerApps?.length) {
 			req.log.debug(`GitHub apps found for url: ${gheServerURL}. Redirecting to Jira list apps page.`);
 			res.status(200).send({ success: true, appExists: true });
 			return;

--- a/src/routes/jira/connect/enterprise/server_app/jira-connect-enterprise-server-app-get.ts
+++ b/src/routes/jira/connect/enterprise/server_app/jira-connect-enterprise-server-app-get.ts
@@ -18,7 +18,7 @@ export const JiraConnectEnterpriseServerAppGet = async (
 
 		const gheServers = await GitHubServerApp.getAllForGitHubBaseUrlAndInstallationId(decodeURIComponent(baseUrl), res.locals.installation.id);
 
-		if (!isNew && gheServers?.length > 0) {
+		if (!isNew && gheServers?.length) {
 			// `identifier` is the githubAppName for the GH server app
 			const serverApps = gheServers.map(server => ({ identifier: server.gitHubAppName }));
 

--- a/src/routes/jira/connect/enterprise/server_app/jira-connect-enterprise-server-app-get.ts
+++ b/src/routes/jira/connect/enterprise/server_app/jira-connect-enterprise-server-app-get.ts
@@ -16,9 +16,9 @@ export const JiraConnectEnterpriseServerAppGet = async (
 			throw new Error("No server URL passed!");
 		}
 
-		const gheServers = await GitHubServerApp.getAllForGitHubBaseUrl(decodeURIComponent(baseUrl), res.locals.installation.id);
+		const gheServers = await GitHubServerApp.getAllForGitHubBaseUrlAndInstallationId(decodeURIComponent(baseUrl), res.locals.installation.id);
 
-		if (!isNew && gheServers?.length) {
+		if (!isNew && gheServers?.length > 0) {
 			// `identifier` is the githubAppName for the GH server app
 			const serverApps = gheServers.map(server => ({ identifier: server.gitHubAppName }));
 

--- a/static/css/jira-configuration-new.css
+++ b/static/css/jira-configuration-new.css
@@ -1,131 +1,131 @@
 .jiraConfiguration {
-  box-sizing: border-box;
-  height: 100vh;
-  padding: 3.5em 4.5em;
+    box-sizing: border-box;
+    height: 100vh;
+    padding: 3.5em 4.5em;
 }
 
 .jiraConfiguration__header {
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 2em;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 2em;
 }
 
 .jiraConfiguration__header__title {
-  font-weight: 500;
+    font-weight: 500;
 }
 
 .jiraConfiguration__header__title__cta {
-  font-size: 1rem;
-  font-weight: normal;
-  padding: 0 1em;
+    font-size: 1rem;
+    font-weight: normal;
+    padding: 0 1em;
 }
 
 .jiraConfiguration__content__list {
-  margin: 0.5em auto;
-  padding-left: 2em;
+    margin: 0.5em auto;
+    padding-left: 2em;
 }
 
 .jiraConfiguration_content {
-  margin-top: 2em;
+    margin-top: 2em;
 }
 
 .jiraConfiguration__syncRetryModal__headerContainer {
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 1.2em;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 1.2em;
 }
 
 .jiraConfiguration__syncRetryModal__header {
-  font-size: 20px;
+    font-size: 20px;
 }
 
 .jiraConfiguration__syncRetryModal__closeBtn {
-  cursor: pointer;
-  font-size: 20px;
+    cursor: pointer;
+    font-size: 20px;
 }
 
 .jiraConfiguration__syncRetryModal__table {
-  border-collapse: separate;
-  border-spacing: 0 15px;
+    border-collapse: separate;
+    border-spacing: 0 15px;
 }
 
 .jiraConfiguration__syncRetryModal__tableBody {
-  border-bottom: none;
+    border-bottom: none;
 }
 
 .jiraConfiguration__syncRetryModal__tableRow {
-  margin-bottom: 1em;
+    margin-bottom: 1em;
 }
 
 .jiraConfiguration__syncRetryModal__syncStatus__type {
-  display: flex;
-  text-transform: uppercase;
-  width: 9em;
+    display: flex;
+    text-transform: uppercase;
+    width: 9em;
 }
 
 .jiraConfiguration__syncRetryModal__syncStatus__details {
-  font-size: 1rem;
-  line-height: 1.6;
+    font-size: 1rem;
+    line-height: 1.6;
 }
 
 .jiraConfiguration__restartBackfillModal__header__container {
-  margin-bottom: 1.3em;
+    margin-bottom: 1.3em;
 }
 
 .jiraConfiguration__restartBackfillModal__header__content {
-  color: #344563;
-  font-size: 1.01rem;
-  margin-bottom: 1.2em;
+    color: #344563;
+    font-size: 1.01rem;
+    margin-bottom: 1.2em;
 }
 
 .jiraConfiguration__restartBackfillModal__date {
-  padding: 0.2em;
-  min-height: 40px;
-  width: 100%;
+    padding: 0.2em;
+    min-height: 40px;
+    width: 100%;
 }
 
 .jiraConfiguration__restartBackfillModal__required {
-  color: #bf2600;
+    color: #bf2600;
 }
 
 .jiraConfiguration__restartBackfillModal__actions {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 1em;
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 1em;
 }
 
 .jiraConfiguration__tableContainer {
-  padding: 0 0 1em;
+    padding: 0 0 1em;
 }
 
 .jiraConfiguration__tableContainer > .jiraConfiguration__table {
-  color: #172b4d;
-  table-layout: fixed;
-  width: 100%;
+    color: #172b4d;
+    table-layout: fixed;
+    width: 100%;
 }
 
 .jiraConfiguration__table__head {
-  color: #6b778c;
-  font-size: 0.8rem;
+    color: #6b778c;
+    font-size: 0.8rem;
 }
 
 .jiraConfiguration__table__head_row > .jiraConfiguration__table__head__title {
-  font-weight: normal;
-  padding: 0.3em 0;
+    font-weight: normal;
+    padding: 0.3em 0;
 }
 
 .jiraConfiguration__table__head__title:not(:last-child) {
-  width: 30%;
+    width: 30%;
 }
 
 .jiraConfiguration__table__head_row
 > .jiraConfiguration__table__head__title:last-child {
-  padding-right: 1em;
-  text-align: right;
+    padding-right: 1em;
+    text-align: right;
 }
 
 .jiraConfiguration__table__infoIcon {
-  cursor: pointer;
+    cursor: pointer;
 }
 
 .jiraConfiguration__table__body
@@ -134,216 +134,220 @@
 .jiraConfiguration__table__body
 > .jiraConfiguration__table__row
 > .jiraConfiguration__table__cell__settings {
-  border-bottom: none;
-  border-top: none;
-  padding: 0.8em 0;
+    border-bottom: none;
+    border-top: none;
+    padding: 0.8em 0;
 }
 
 .jiraConfiguration__retryContainer, .jiraConfiguration__retryContainer {
-  font-size: 1.5rem;
-  position: relative;
+    font-size: 1.5rem;
+    position: relative;
 }
 
 .jiraConfiguration__retry {
-  cursor: pointer;
-  font-weight: normal;
-  margin-left: 0.2em;
-  margin: 0.2em auto auto 0.5em;
-  font-size: 1.2rem;
-  position: absolute;
-  transform: scaleX(-1) rotate(30deg);
-  background: inherit;
-  border: none;
+    cursor: pointer;
+    font-weight: normal;
+    margin-left: 0.2em;
+    margin: 0.2em auto auto 0.5em;
+    font-size: 1.2rem;
+    position: absolute;
+    transform: scaleX(-1) rotate(30deg);
+    background: inherit;
+    border: none;
 }
 
 .jiraConfiguration__retryMsg {
-  background-color: #172b4d;
-  border-radius: 3px;
-  color: #fff;
-  display: none;
-  font-size: 1rem;
-  left: -0.8em;
-  padding: 0.3em;
-  position: absolute;
-  top: -2em;
+    background-color: #172b4d;
+    border-radius: 3px;
+    color: #fff;
+    display: none;
+    font-size: 1rem;
+    left: -0.8em;
+    padding: 0.3em;
+    position: absolute;
+    top: -2em;
 }
 
 .jiraConfiguration__retry:hover ~ .jiraConfiguration__retryMsg {
-  display: block;
+    display: block;
 }
 
 .jiraConfiguration__syncWarning {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-left: 8px;
-  position: relative;
-  cursor: pointer;
-  border-radius: 2px;
-  padding: 0.2rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-left: 8px;
+    position: relative;
+    cursor: pointer;
+    border-radius: 2px;
+    padding: 0.2rem;
 }
 
 /* Hit box */
 .jiraConfiguration__syncWarning:before {
-  content: '';
-  padding: 1.25em;
-  position: absolute;
+    content: '';
+    padding: 1.25em;
+    position: absolute;
 }
 
 .jiraConfiguration__syncWarning:hover {
-  background: #0914E208;
+    background: #0914E208;
 }
 
 .warning-popup {
-  display: block;
-  box-sizing: border-box;
-  z-index: 400;
-  flex: 1 1 auto;
-  background-color: var(--ds-surface-overlay, #FFFFFF);
-  border-radius: 3px;
-  box-shadow: var(--ds-shadow-overlay, 0 4px 8px -2px rgba(9, 30, 66, 0.25), 0 0 1px rgba(9, 30, 66, 0.31));
-  overflow: auto;
+    display: block;
+    box-sizing: border-box;
+    z-index: 400;
+    flex: 1 1 auto;
+    background-color: var(--ds-surface-overlay, #FFFFFF);
+    border-radius: 3px;
+    box-shadow: var(--ds-shadow-overlay, 0 4px 8px -2px rgba(9, 30, 66, 0.25), 0 0 1px rgba(9, 30, 66, 0.31));
+    overflow: auto;
 }
 
 .warning-popup div {
-  padding: 15px;
-  line-height: 20px;
+    padding: 15px;
+    line-height: 20px;
 }
 
 .jiraConfiguration__syncWarningMessage {
-  border-radius: 3px;
-  display: none;
-  font-size: 1rem;
-  left: -15em;
-  right: -15em;
-  padding: 0.3em;
-  position: absolute;
-  top: -7.5em;
+    border-radius: 3px;
+    display: none;
+    font-size: 1rem;
+    left: -15em;
+    right: -15em;
+    padding: 0.3em;
+    position: absolute;
+    top: -7.5em;
 }
 
 .jiraConfiguration__syncWarning:hover > .jiraConfiguration__syncWarningMessage {
-  display: block;
+    display: block;
 }
 
 .jiraConfiguration__syncWarning__connectFailed__warningIcon {
-  color: #ff9b20;
+    color: #ff9b20;
 }
 
 .jiraConfiguration__table__body
 > .jiraConfiguration__table__row
 > .jiraConfiguration__table__cell__settings {
-  padding: 0;
-  text-align: right;
+    padding: 0;
+    text-align: right;
 }
 
 .jiraConfiguration__table__cell__settings
 > .jiraConfiguration__table__cell__settings__ellipsis,
 .jiraConfiguration__appDropdown {
-  background-color: #fff;
-  border: none;
-  box-shadow: none;
-  color: #7a869a;
-  font-size: 3rem;
-  height: 1em;
-  margin: 0.1em 0.4em;
-  position: relative;
-  right: 0;
-  top: 0em;
-  width: 1em;
+    background-color: #fff;
+    border: none;
+    box-shadow: none;
+    color: #7a869a;
+    font-size: 3rem;
+    height: 1em;
+    margin: 0.1em 0.4em;
+    position: relative;
+    right: 0;
+    top: 0em;
+    width: 1em;
 }
 
 .jiraConfiguration__table__cell__settings__ellipsisSpan,
 .jiraConfiguration__appDropdownIcon {
-  position: absolute;
-  right: 0.15em;
-  top: -0.5em;
+    position: absolute;
+    right: 0.15em;
+    top: -0.5em;
+}
+
+.jiraConfiguration__table__cell__gitHubAppItem {
+    padding: 0.1em 0.3em;
 }
 
 .jiraConfiguration__table__cell__settings
 > .aui-dropdown2-trigger:not(.aui-dropdown2-trigger-arrowless) {
-  padding-right: 0.2em;
+    padding-right: 0.2em;
 }
 
 .jiraConfiguration__appDropdown:hover,
 .jiraConfiguration__table__cell__settings
 > .jiraConfiguration__table__cell__settings__ellipsis:hover,
 .aui-button.active:not(.aui-button-link) {
-  background-color: #091e4208;
+    background-color: #091e4208;
 }
 
 .jiraConfiguration__table__cell__settings
 > .jiraConfiguration__table__cell__settings__ellipsis.bob,
 .aui-button.active:not(.aui-button-link) {
-  background-color: #263858;
-  color: #fff;
+    background-color: #263858;
+    color: #fff;
 }
 
 .jiraConfiguration__table__cell__settings
 > .jiraConfiguration__table__cell__settings__ellipsis::before {
-  content: none;
+    content: none;
 }
 
 .jiraConfiguration__table__cell__settings__headerItem {
-  padding: 0 1.3em;
+    padding: 0 1.3em;
 }
 
 .jiraConfiguration__table__cell__settings__headerItem {
-  font-size: 0.8rem;
+    font-size: 0.8rem;
 }
 
 .aui-dropdown2 > .jiraConfiguration__table__cell__settings__header {
-  margin: 0.7em auto 0.3em;
+    margin: 0.7em auto 0.3em;
 }
 
 .aui-dropdown2 > .jiraConfiguration__table__cell__settings__dropdownItems {
-  margin-top: 0;
+    margin-top: 0;
 }
 
 .aui-dropdown2-item-group
 > .jiraConfiguration__table__cell__settings__dropdownItem {
-  cursor: pointer;
-  padding: 0.6em 1em;
+    cursor: pointer;
+    padding: 0.6em 1em;
 }
 
 .aui-dropdown2-item-group
 > .jiraConfiguration__table__cell__settings__dropdownItem:hover {
-  background-color: #e9edf0;
+    background-color: #e9edf0;
 }
 
 .aui-dropdown2-item-group
 > .jiraConfiguration__table__cell__settings__dropdownItem:active,
 .aui-dropdown2-item-group
 > .jiraConfiguration__table__cell__settings__dropdownItem:focus {
-  background-color: #ecedf0;
-  box-shadow: none;
-  color: #455570;
+    background-color: #ecedf0;
+    box-shadow: none;
+    color: #455570;
 }
 
 .sync-connection-link.restart-backfill-button {
-  padding: 0;
+    padding: 0;
 }
 
 #restart-backfill:hover {
-  background-color: inherit;
+    background-color: inherit;
 }
 
 .jiraConfiguration__table__cell:nth-child(3) {
-  display: flex;
+    display: flex;
 }
 
 .jiraConfiguration__table__cell__avatar {
-  border-radius: 4px;
-  height: 24px;
-  vertical-align: middle;
-  width: 24px;
+    border-radius: 4px;
+    height: 24px;
+    vertical-align: middle;
+    width: 24px;
 }
 
 .jiraConfiguration__table__cell__orgName {
-  margin-left: 0.2em;
+    margin-left: 0.2em;
 }
 
 .jiraConfiguration__table__connectionLinks > :first-child {
-  padding-left: 0;
+    padding-left: 0;
 }
 
 .jiraConfiguration__table__syncStatus,
@@ -351,272 +355,272 @@
 .syncStatusInProgress,
 .syncStatusFinished,
 .syncStatusFailed {
-  border-radius: 5px;
-  font-size: 1rem;
-  font-weight: bold;
-  padding: 0.2em 0.3em;
+    border-radius: 5px;
+    font-size: 1rem;
+    font-weight: bold;
+    padding: 0.2em 0.3em;
 }
 
 .jiraConfiguration__table__pending,
 .syncStatusPending {
-  background-color: #dfe1e6;
-  color: #42526e;
+    background-color: #dfe1e6;
+    color: #42526e;
 }
 
 .jiraConfiguration__table__in-progress,
 .syncStatusInProgress {
-  background-color: #deebff;
-  color: #0747a6;
+    background-color: #deebff;
+    color: #0747a6;
 }
 
 .jiraConfiguration__table__finished,
 .syncStatusFinished {
-  background-color: #e3fcef;
-  color: #006644;
+    background-color: #e3fcef;
+    color: #006644;
 }
 
 .jiraConfiguration__table__failed,
 .syncStatusFailed {
-  background-color: #ffebe6;
-  color: #bf2600;
+    background-color: #ffebe6;
+    color: #bf2600;
 }
 
 .jiraConfiguration__table__refresh {
-  font-weight: bold;
+    font-weight: bold;
 }
 
 .jiraConfiguration__table__cell__settings__header {
-  color: #6b778c;
+    color: #6b778c;
 }
 
 /* Failed connections */
 .jiraConfiguration__failedConnections__container {
-  background-color: #ffebe6;
-  display: flex;
-  margin-top: 1.1em;
-  padding: 0.8em 1.2em 1.2em;
+    background-color: #ffebe6;
+    display: flex;
+    margin-top: 1.1em;
+    padding: 0.8em 1.2em 1.2em;
 }
 
 .jiraConfiguration__failedConnections__errorIcon__container {
-  margin: 0.5em 1em 0 0;
+    margin: 0.5em 1em 0 0;
 }
 
 .jiraConfiguration__failedConnections__errorIcon {
-  color: #bf2600;
+    color: #bf2600;
 }
 
 .jiraConfiguration__failedConnections__orgInfo {
-  line-height: 2;
+    line-height: 2;
 }
 
 .jiraConfiguration__failedConnections__header {
-  font-size: 1.15rem;
-  font-weight: 500;
+    font-size: 1.15rem;
+    font-weight: 500;
 }
 
 .jiraConfiguration__failedConnections__dismiss {
-  background: transparent;
-  border: none;
-  color: #0052cc;
-  cursor: pointer;
-  margin-top: 0.6em;
-  padding: 0;
+    background: transparent;
+    border: none;
+    color: #0052cc;
+    cursor: pointer;
+    margin-top: 0.6em;
+    padding: 0;
 }
 
 /*  Empty state - no orgs connected */
 .jiraConfiguration__empty {
-  margin: auto;
-  max-width: 570px;
-  padding: 6.5em 0;
-  text-align: center;
+    margin: auto;
+    max-width: 570px;
+    padding: 6.5em 0;
+    text-align: center;
 }
 
 .jiraConfiguration__empty__header {
-  font-size: 1.6rem;
+    font-size: 1.6rem;
 }
 
 .jiraConfiguration__empty__message {
-  font-size: 0.9rem;
-  margin: 2em auto;
+    font-size: 0.9rem;
+    margin: 2em auto;
 }
 
 .jiraConfiguration__empty__image {
-  width: 100%;
-  max-width: 332px;
+    width: 100%;
+    max-width: 332px;
 }
 
 .jiraConfiguration__table__editContainer,
 .jiraConfiguration__syncRetryModal__closeBtn {
-  border-radius: 3px;
-  cursor: pointer;
-  padding: 0.45em;
-  position: relative;
+    border-radius: 3px;
+    cursor: pointer;
+    padding: 0.45em;
+    position: relative;
 }
 
 .jiraConfiguration__table__editContainer:hover,
 .jiraConfiguration__syncRetryModal__closeBtn:hover {
-  background: #091E4208;
+    background: #091E4208;
 }
 
 .jiraConfiguration__optionContainer {
-  display: flex;
-  margin-top: 1.5em;
+    display: flex;
+    margin-top: 1.5em;
 }
 
 .jiraConfiguration__option {
-  padding: 0.5em 1em;
-  height: 40px;
-  border-radius: 100px;
-  display: inline-flex;
-  align-items: center;
+    padding: 0.5em 1em;
+    height: 40px;
+    border-radius: 100px;
+    display: inline-flex;
+    align-items: center;
 }
 
 .jiraConfiguration__optionHeader {
-  font-size: 1.25rem;
-  margin: 1.5em 0;
+    font-size: 1.25rem;
+    margin: 1.5em 0;
 }
 
 .jiraConfiguration__selected {
-  background-color: #DEEBFF;
-  color: #0052CC;
-  font-weight: 600;
+    background-color: #DEEBFF;
+    color: #0052CC;
+    font-weight: 600;
 }
 
 .jiraConfiguration__optionsIcon {
-  width: 24px;
-  height: 17px;
-  margin-right: 0.25em;
+    width: 24px;
+    height: 17px;
+    margin-right: 0.25em;
 }
 
 .jiraConfiguration__cloudConnections {
-  box-shadow: 0 1px 1px rgba(9, 30, 66, 0.25), 0 0 1px rgba(9, 30, 66, 0.31);
-  border-radius: 12px;
-  padding: 1.5em 1.5em;
+    box-shadow: 0 1px 1px rgba(9, 30, 66, 0.25), 0 0 1px rgba(9, 30, 66, 0.31);
+    border-radius: 12px;
+    padding: 1.5em 1.5em;
 }
 
 .jiraConfiguration__enterpriseServer {
-  background-color: #F4F5F7;
-  padding: 1.5em;
-  border-radius: 10px;
-  margin-bottom: 1.5em;
+    background-color: #F4F5F7;
+    padding: 1.5em;
+    border-radius: 10px;
+    margin-bottom: 1.5em;
 }
 
 .jiraConfiguration__enterpriseConnections {
-  background-color: #fff;
-  padding: 1.5em 1.5em 0.8em;
-  box-shadow: 0 1px 1px rgba(9, 30, 66, 0.25), 0 0 1px rgba(9, 30, 66, 0.31);
-  border-radius: 3px;
+    background-color: #fff;
+    padding: 1.5em 1.5em 0.8em;
+    box-shadow: 0 1px 1px rgba(9, 30, 66, 0.25), 0 0 1px rgba(9, 30, 66, 0.31);
+    border-radius: 3px;
 }
 
 .jiraConfiguration__enterpriseApplicationTitle {
-  font-weight: 700;
-  font-size: 0.7rem;
-  color: #6B778C;
-  margin-bottom: 1.25em;
-  padding: 0 0.5em;
+    font-weight: 700;
+    font-size: 0.7rem;
+    color: #6B778C;
+    margin-bottom: 1.25em;
+    padding: 0 0.5em;
 }
 
 .jiraConfiguration__collapsibleHeader {
-  cursor: pointer;
-  padding: 0.8em 0;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+    cursor: pointer;
+    padding: 0.8em 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
 .jiraConfiguration__collapsibleHeaderTitle {
-  font-size: 1.25rem;
-  margin: 0 0 1.5em;
+    font-size: 1.25rem;
+    margin: 0 0 1.5em;
 }
 
 .jiraConfiguration__collapsibleBody {
-  padding-left: 0.8em;
+    padding-left: 0.8em;
 }
 
 .jiraConfiguration__noOrgsTitle {
-  font-weight: 600;
-  color: #6B778C;
-  font-size: 12px;
-  border-bottom: 2px solid #DFE1E6;
-  padding: 0.5em 0;
+    font-weight: 600;
+    color: #6B778C;
+    font-size: 12px;
+    border-bottom: 2px solid #DFE1E6;
+    padding: 0.5em 0;
 }
 
 .jiraConfiguration__noOrgsBody {
-  border-bottom: 2px solid #DFE1E6;
-  padding: 1em 0;
+    border-bottom: 2px solid #DFE1E6;
+    padding: 1em 0;
 }
 
 .aui-dropdown2-item-group > .jiraConfiguration__connectBtnDropdownOption {
-  display: flex;
-  justify-content: space-between;
-  padding: 0.8em 1.4em;
+    display: flex;
+    justify-content: space-between;
+    padding: 0.8em 1.4em;
 }
 
 .jiraConfiguration__header > .aui-dropdown2 {
-  width: 250px;
-  padding: 0.5em 0;
+    width: 250px;
+    padding: 0.5em 0;
 }
 
 .jiraConfiguration__connectGHCloudTooltip,
 .jiraConfiguration__connectGHETooltip {
-  display: none;
-  position: absolute;
-  background-color: #172B4D;
-  padding: 0.4em;
-  border-radius: 3px;
-  width: 454px;
-  color: #FFF;
-  right: 0;
-  font-weight: 400;
-  font-size: 0.75rem;
+    display: none;
+    position: absolute;
+    background-color: #172B4D;
+    padding: 0.4em;
+    border-radius: 3px;
+    width: 454px;
+    color: #FFF;
+    right: 0;
+    font-weight: 400;
+    font-size: 0.75rem;
 }
 
 .aui-iconfont-question-filled + .jiraConfiguration__connectGHCloudTooltip {
-  top: -1.8em;
+    top: -1.8em;
 }
 
 .aui-iconfont-question-filled + .jiraConfiguration__connectGHETooltip {
-  bottom: 3.8em;
+    bottom: 3.8em;
 }
 
 .aui-iconfont-question-filled:hover + .jiraConfiguration__connectGHCloudTooltip,
 .aui-iconfont-question-filled:hover + .jiraConfiguration__connectGHETooltip {
-  display: block;
+    display: block;
 }
 
 /* Collapsible Icon*/
 .aui-iconfont-chevron-down {
-  display: none;
+    display: none;
 }
 
 /* This hides the default arrow, which is displayed in Safari */
 details summary::-webkit-details-marker {
-  display:none;
+    display:none;
 }
 
 details[open] summary div .aui-iconfont-chevron-right {
-  display: none;
+    display: none;
 }
 
 details[open] summary div .aui-iconfont-chevron-down {
-  display: inline;
+    display: inline;
 }
 
 details summary div .aui-iconfont-chevron-down {
-  display: none;
+    display: none;
 }
 
 details summary div .aui-iconfont-chevron-right {
-  display: inline;
+    display: inline;
 }
 
 .learn-more-link {
-  display: inline-block;
-  margin-right: 4px;
+    display: inline-block;
+    margin-right: 4px;
 }
 
 .learn-more-link:hover {
-  color: inherit;
+    color: inherit;
 }
 
 /*  NOTE: We can't use standard breakpoints on GitHub config page
@@ -625,18 +629,18 @@ as the left panel navigation in Jira hijacks some of the screen */
 /* ** Media Queries ** */
 /* ******************* */
 @media (max-width: 1530px) {
-  .jiraConfiguration__table__cell__settings__ellipsis {
-    right: 0;
-  }
+    .jiraConfiguration__table__cell__settings__ellipsis {
+        right: 0;
+    }
 }
 
 @media (max-width: 800px) {
-  .jiraConfiguration {
-    padding: 2em;
-  }
+    .jiraConfiguration {
+        padding: 2em;
+    }
 
-  .jiraConfiguration__table__cell__settings
-  > .jiraConfiguration__table__cell__settings__ellipsis {
-    right: 0.2em;
-  }
+    .jiraConfiguration__table__cell__settings
+    > .jiraConfiguration__table__cell__settings__ellipsis {
+        right: 0.2em;
+    }
 }

--- a/static/js/jira-configuration.js
+++ b/static/js/jira-configuration.js
@@ -17,7 +17,7 @@ function openChildWindow(url) {
 $(".add-organization-link").click(function(event) {
 	event.preventDefault();
 	const queryParameter = $(this).data("gh-cloud") ? "" : "?ghRedirect=to";
-	window.AP.context.getToken(function(token) {
+	AP.context.getToken(function(token) {
 		const child = openChildWindow("/session/github/configuration" + queryParameter);
 		child.window.jiraHost = jiraHost;
 		child.window.jwt = token;
@@ -170,4 +170,43 @@ window.onclick = function(event) {
 		restartBackfillModal.style.display = "none";
 	}
 };
+
+$(".jiraConfiguration__deleteGitHubApp").click(function(event) {
+	event.preventDefault();
+	const uuid = $(event.target).data("app-uuid");
+
+	AP.context.getToken(function(token) {
+		$.ajax({
+			type: "DELETE",
+			url: `/jira/connect/enterprise/app/:${uuid}`,
+			data: {
+				uuid,
+				jwt: token,
+				jiraHost: jiraHost
+			},
+			success: function(data) {
+				if (data.success) {
+					AP.navigator.reload();
+				}
+			},
+			error: function (error) {
+				console.log(error);
+			},
+		});
+	});
+});
+
+$(".jiraConfiguration__editGitHubApp").click(function(event) {
+	event.preventDefault();
+	const uuid = $(event.target).data("app-uuid");
+
+	AP.navigator.go(
+		'addonmodule',
+		{
+			moduleKey: "github-edit-app-page",
+			customData: { uuid }
+		}
+	);
+});
+
 

--- a/static/js/jira-configuration.js
+++ b/static/js/jira-configuration.js
@@ -178,7 +178,7 @@ $(".jiraConfiguration__deleteGitHubApp").click(function(event) {
 	AP.context.getToken(function(token) {
 		$.ajax({
 			type: "DELETE",
-			url: `/jira/connect/enterprise/app/:${uuid}`,
+			url: `/jira/connect/enterprise/app/${uuid}`,
 			data: {
 				uuid,
 				jwt: token,

--- a/static/js/jira-configuration.js
+++ b/static/js/jira-configuration.js
@@ -60,9 +60,9 @@ $(".delete-connection-link").click(function(event) {
 			data: {
 				installationId: $(event.target).data("installation-id"),
 				jwt: token,
-				jiraHost: jiraHost
+				jiraHost
 			},
-			success: function(data) {
+			success: function() {
 				AP.navigator.reload();
 			}
 		});
@@ -182,7 +182,7 @@ $(".jiraConfiguration__deleteGitHubApp").click(function(event) {
 			data: {
 				uuid,
 				jwt: token,
-				jiraHost: jiraHost
+				jiraHost
 			},
 			success: function(data) {
 				if (data.success) {
@@ -190,7 +190,7 @@ $(".jiraConfiguration__deleteGitHubApp").click(function(event) {
 				}
 			},
 			error: function (error) {
-				console.log(error);
+				// TODO - we should render an error here when the app fails to delete
 			},
 		});
 	});

--- a/views/jira-configuration-new.hbs
+++ b/views/jira-configuration-new.hbs
@@ -219,6 +219,7 @@
                             <span class="jiraConfiguration__table__cell__settings__headerItem">Application</span>
                           </h6>
                           <aui-section class="jiraConfiguration__table__cell__settings__dropdownItems">
+                             <input type="hidden" id="_csrf" name="_csrf" value="{{../csrfToken}}">
                              <div class="jiraConfiguration__table__cell__gitHubAppItem">
                                <button
                                    class="jiraConfiguration__editGitHubApp"
@@ -226,7 +227,6 @@
                                >
                                  Edit
                                </button>
-                               <input type="hidden" id="_csrf" name="_csrf" value="{{../csrfToken}}">
                              </div>
                              <div class="jiraConfiguration__table__cell__gitHubAppItem" data-app-uuid="{{app.gitHubAppName}}">
                                <button
@@ -235,7 +235,6 @@
                                >
                                  Delete
                                </button>
-                               <input type="hidden" id="_csrf" name="_csrf" value="{{../csrfToken}}">
                              </div>
                            </aui-section>
                          </aui-dropdown-menu>

--- a/views/jira-configuration-new.hbs
+++ b/views/jira-configuration-new.hbs
@@ -214,28 +214,31 @@
                           >
                             <span class="jiraConfiguration__appDropdownIcon">...</span>
                           </button>
-                          <aui-dropdown-menu class="" id="app-settings-dropdown-{{id}}">
-                            <aui-section>
-                              <!--TODO: need to add url for this-->
-                              <a
-                                  class=""
-                                  href="#"
-                                  data-installation-link="{{html_url}}"
-                                  target="_blank"
-                              >
-                                Edit
-                              </a>
-                              <!--TODO: need to add functionality for this-->
-                              <a
-                                  class=""
-                                  href="#"
-                                  data-installation-link="{{html_url}}"
-                                  target="_blank"
-                              >
-                                Delete
-                              </a>
-                            </aui-section>
-                          </aui-dropdown-menu>
+                          <aui-dropdown-menu class="jiraConfiguration__table__dropdown" id="app-settings-dropdown-{{id}}">
+                          <h6 class="jiraConfiguration__table__cell__settings__header">
+                            <span class="jiraConfiguration__table__cell__settings__headerItem">Application</span>
+                          </h6>
+                          <aui-section class="jiraConfiguration__table__cell__settings__dropdownItems">
+                             <div class="jiraConfiguration__table__cell__gitHubAppItem">
+                               <button
+                                   class="jiraConfiguration__editGitHubApp"
+                                   data-app-uuid="{{app.uuid}}"
+                               >
+                                 Edit
+                               </button>
+                               <input type="hidden" id="_csrf" name="_csrf" value="{{../csrfToken}}">
+                             </div>
+                             <div class="jiraConfiguration__table__cell__gitHubAppItem" data-app-uuid="{{app.gitHubAppName}}">
+                               <button
+                                   class="jiraConfiguration__deleteGitHubApp"
+                                   data-app-uuid="{{app.uuid}}"
+                               >
+                                 Delete
+                               </button>
+                               <input type="hidden" id="_csrf" name="_csrf" value="{{../csrfToken}}">
+                             </div>
+                           </aui-section>
+                         </aui-dropdown-menu>
                         </summary>
                         <div class="jiraConfiguration__collapsibleBody">
                           {{#if app.installations.total}}


### PR DESCRIPTION
**What's in this PR?**
Functionality for 'edit' and 'delete' in the GH app dropdown for GHES.

**Why**
So users can edit and delete GH apps.

**Added feature flags**
All behind GHE_SERVER

**Affected issues**  
ARC-1563

**How has this been tested?**  
Tested in stg and locally:

https://user-images.githubusercontent.com/37155488/183027316-f5880528-58c6-48d2-b8d8-960e619b4796.mov

**What's Next?**
- ARC 1572: update a GH app. In this PR I'm simply navigating to the form. Will take care of actually updating the fields in this issue.
- ARC 1577: we need to refactor the jira configuration table partial so it is an actual reusable component. We should be using this for the dropdown from cloud and for server gh apps. This will be addressed outside of the scope for this project.