### PR TITLE
ARC-1561 remove unused endpoints from jira client

### DIFF
--- a/src/jira/client/jira-client.ts
+++ b/src/jira/client/jira-client.ts
@@ -36,6 +36,7 @@ export const getJiraClient = async (
 ): Promise<any> => {
 	const logger = log.child({ jiraHost, gitHubInstallationId });
 	const installation = await Installation.getForHost(jiraHost);
+
 	if (!installation) {
 		logger.warn("Cannot initialize Jira Client, Installation doesn't exist.");
 		return undefined;
@@ -78,13 +79,6 @@ export const getJiraClient = async (
 			},
 			comments: {
 				// eslint-disable-next-line camelcase
-				getForIssue: (issue_id: string) =>
-					instance.get("/rest/api/latest/issue/{issue_id}/comment", {
-						urlParams: {
-							issue_id
-						}
-					}),
-				// eslint-disable-next-line camelcase
 				addForIssue: (issue_id: string, payload) =>
 					instance.post("/rest/api/latest/issue/{issue_id}/comment", payload, {
 						urlParams: {
@@ -118,13 +112,6 @@ export const getJiraClient = async (
 			},
 			worklogs: {
 				// eslint-disable-next-line camelcase
-				getForIssue: (issue_id: string) =>
-					instance.get("/rest/api/latest/issue/{issue_id}/worklog", {
-						urlParams: {
-							issue_id
-						}
-					}),
-				// eslint-disable-next-line camelcase
 				addForIssue: (issue_id: string, payload) =>
 					instance.post("/rest/api/latest/issue/{issue_id}/worklog", payload, {
 						urlParams: {
@@ -151,15 +138,6 @@ export const getJiraClient = async (
 			},
 			// Add methods for handling installationId properties that exist in Jira
 			installation: {
-				exists: (gitHubInstallationId: string | number) =>
-					instance.get(
-						`/rest/devinfo/0.10/existsByProperties`,
-						{
-							params: {
-								installationId: gitHubInstallationId
-							}
-						}
-					),
 				delete: async (gitHubInstallationId: string | number) =>
 					Promise.all([
 
@@ -210,10 +188,6 @@ export const getJiraClient = async (
 					)
 			},
 			repository: {
-				get: (repositoryId: string) =>
-					instance.get("/rest/devinfo/0.10/repository/{repositoryId}", {
-						urlParams: { repositoryId }
-					}),
 				delete: (repositoryId: string) =>
 					instance.delete("/rest/devinfo/0.10/repository/{repositoryId}", {
 						params: {

--- a/test/snapshots/jira/client/jira-client.test.ts.snap
+++ b/test/snapshots/jira/client/jira-client.test.ts.snap
@@ -12,21 +12,18 @@ Object {
     },
     "installation": Object {
       "delete": [Function],
-      "exists": [Function],
     },
     "pullRequest": Object {
       "delete": [Function],
     },
     "repository": Object {
       "delete": [Function],
-      "get": [Function],
       "update": [Function],
     },
   },
   "issues": Object {
     "comments": Object {
       "addForIssue": [Function],
-      "getForIssue": [Function],
     },
     "get": [Function],
     "getAll": [Function],
@@ -37,7 +34,6 @@ Object {
     },
     "worklogs": Object {
       "addForIssue": [Function],
-      "getForIssue": [Function],
     },
   },
   "remoteLink": Object {


### PR DESCRIPTION
**What's in this PR?**
Removal of unused endpoints from jiraClient.

**Why**
Because we don't need them...

**Affected issues**  
ARC-1561

**How has this been tested?**  
Deployed to staging and no issues detected. Have triple checked the removed endpoints aren't being used anywhere.

**What's Next?**
Continue on ARC-1561: updating all calls the jiraClient that use gitHubInstallationId. Was going to do them all in one PR but figured that's a sure fire way to break something. Going to tackle each yellow highlighted area in this doc separately https://hello.atlassian.net/wiki/spaces/PF/pages/1856341692/Jira+Client
 