### PR TITLE
NONE: convert a password field into a text one

### DIFF
--- a/views/jira-manual-app-creation.hbs
+++ b/views/jira-manual-app-creation.hbs
@@ -105,7 +105,7 @@
 
         <div class="field-group">
           <label for="webhook-secret">Webhook secret</label>
-          <input class="text full-width-field" type="password"
+          <input class="text full-width-field" type="text"
                  data-aui-validation-field required
                  value="{{app.webhookSecret}}"
                  name="webhookSecret" />


### PR DESCRIPTION
**What's in this PR?**

Converting webhooks secret field into plain text

**Why**

To match designs

**Added feature flags**

Under existing ghe_server flag

**Affected issues**  
NONE (too lazy)

**How has this been tested?**  
locally

**Whats Next?**
:susp:
