### PR TITLE
Easy Karma: remove unused gitHubAppId from Installations model

### DIFF
--- a/src/models/installation.ts
+++ b/src/models/installation.ts
@@ -21,7 +21,6 @@ export class Installation extends EncryptedModel {
 	clientKey: string;
 	updatedAt: Date;
 	createdAt: Date;
-	githubAppId?: number;
 
 	getEncryptionSecretKey() {
 		return EncryptionSecretKeyEnum.JIRA_INSTANCE_SECRETS;
@@ -142,11 +141,7 @@ Installation.init({
 	},
 	enabled: BOOLEAN,
 	createdAt: DATE,
-	updatedAt: DATE,
-	githubAppId: {
-		type: DataTypes.INTEGER,
-		allowNull: true
-	}
+	updatedAt: DATE
 }, {
 	hooks: {
 		beforeSave: async (instance: Installation, opts) => {


### PR DESCRIPTION
**What's in this PR?**

Removing unused column from Installations table/model

**Why**

Because it is not used

**Added feature flags**

Nah

**Affected issues**  
None (too lazy)

**How has this been tested?**  
locally

**Whats Next?**
Schema migration after this one is in prod.