### PR TITLE
ARC-1354 Supress error logging during healthcheck for Worker

### DIFF
--- a/src/models/encrypted-model.ts
+++ b/src/models/encrypted-model.ts
@@ -6,6 +6,8 @@ type StringValues<Obj> = {
 	[Prop in keyof Obj]: Obj[Prop] extends string ? Prop : never
 };
 
+const logger = getLogger("encryption-model");
+
 export abstract class EncryptedModel extends Model {
 
 	abstract getEncryptContext(field: (keyof StringValues<this>)): Promise<Record<string, string | number>>;
@@ -22,7 +24,7 @@ export abstract class EncryptedModel extends Model {
 		try {
 			return await EncryptionClient.decrypt(value, await this.getEncryptContext(field));
 		} catch (e) {
-			getLogger("cryptor").error(`Fail to decrypt field ${field}`, { error: e });
+			logger.error(`Fail to decrypt field ${field}`, { error: e });
 			throw e;
 		}
 	}
@@ -35,7 +37,7 @@ export abstract class EncryptedModel extends Model {
 		try {
 			return await EncryptionClient.encrypt(this.getEncryptionSecretKey(), value, await this.getEncryptContext(field));
 		} catch (e) {
-			getLogger("cryptor").error(`Fail to encrypt field ${field}`, { error: e });
+			logger.error(`Fail to encrypt field ${field}`, { error: e });
 			throw e;
 		}
 	}

--- a/src/routes/healthcheck/deepcheck-get.ts
+++ b/src/routes/healthcheck/deepcheck-get.ts
@@ -22,7 +22,7 @@ export const DeepcheckGet = async (_: Request, res: Response): Promise<void> => 
 		logger.debug("Successfully called /deepcheck");
 		res.status(200).send("OK");
 	} catch (error) {
-		logger.error({ reason: error }, "Error during /deepcheck");
+		logger.warn({ reason: error }, "Error during /deepcheck");
 		res.status(500).send("NOT OK");
 	}
 };

--- a/src/routes/healthcheck/deepcheck-get.ts
+++ b/src/routes/healthcheck/deepcheck-get.ts
@@ -22,7 +22,7 @@ export const DeepcheckGet = async (_: Request, res: Response): Promise<void> => 
 		logger.debug("Successfully called /deepcheck");
 		res.status(200).send("OK");
 	} catch (error) {
-		logger.warn({ reason: error }, "Error during /deepcheck");
+		logger.error({ reason: error }, "Error during /deepcheck");
 		res.status(500).send("NOT OK");
 	}
 };

--- a/src/routes/healthcheck/healthcheck-get.ts
+++ b/src/routes/healthcheck/healthcheck-get.ts
@@ -10,7 +10,7 @@ export const HealthcheckGet = async (_: Request, res: Response): Promise<void> =
 		try {
 			await deepCheckCryptor();
 		} catch (e) {
-			logger.warn("Cryptor deepcheck failed.", { error: e });
+			logger.warn("Cryptor deepcheck failed in work. This happen during startup when Worker started by Cryptor sidecar is not ready.", { error: e });
 			res.status(500).send("NOT OK");
 			return;
 		}

--- a/src/util/encryption-client.ts
+++ b/src/util/encryption-client.ts
@@ -1,6 +1,5 @@
 import { envVars } from "config/env";
 import axios, { AxiosInstance, AxiosResponse } from "axios";
-import { getLogger } from "config/logger";
 
 export enum EncryptionSecretKeyEnum {
 	GITHUB_SERVER_APP = "github-server-app-secrets",
@@ -8,7 +7,6 @@ export enum EncryptionSecretKeyEnum {
 }
 
 export type EncryptionContext = Record<string, string | number>;
-const logger = getLogger("encryption-client");
 
 interface EncryptResponse {
 	cipherText: string;
@@ -38,29 +36,19 @@ export class EncryptionClient {
 	});
 
 	static async encrypt(secretKey: EncryptionSecretKeyEnum, plainText: string, encryptionContext: EncryptionContext = {}): Promise<string> {
-		try {
-			const response = await this.axios.post<EncryptResponse>(`/cryptor/encrypt/micros/github-for-jira/${secretKey}`, {
-				plainText,
-				encryptionContext
-			});
-			return response.data.cipherText;
-		} catch (e) {
-			logger.error("Cryptor encrypt request failed");
-			throw e;
-		}
+		const response = await this.axios.post<EncryptResponse>(`/cryptor/encrypt/micros/github-for-jira/${secretKey}`, {
+			plainText,
+			encryptionContext
+		});
+		return response.data.cipherText;
 	}
 
 	static async decrypt(cipherText: string, encryptionContext: EncryptionContext = {}): Promise<string> {
-		try {
-			const response = await this.axios.post<DecryptResponse>(`/cryptor/decrypt`, {
-				cipherText,
-				encryptionContext
-			});
-			return response.data.plainText;
-		} catch (e) {
-			logger.error("Cryptor decrypt request failed");
-			throw e;
-		}
+		const response = await this.axios.post<DecryptResponse>(`/cryptor/decrypt`, {
+			cipherText,
+			encryptionContext
+		});
+		return response.data.plainText;
 	}
 
 	static async healthcheck(): Promise<AxiosResponse> {


### PR DESCRIPTION
**What's in this PR?**
Move the error logging from within EncryptionClient to EncryptedModel

**Why**
Don't want to get too much noise during worker starting up and when cryptor is not ready. It is okay because:
1. If it stays error, we will found out, the cicd pipeline will be red.
2. If it is only transient, it will turns green when the cryptor sidecar catchup and started, then we shouldn't care about this error. So warn instead.

**Added feature flags**
N/A

**Affected issues**  
ARC-1354

**How has this been tested?**  
N/A

**Whats Next?**
N/A
