### PR TITLE
ARC 1605 - Endpoint GitHubConfigurationGet removes the previous GH cloudconnection 

### DIFF
--- a/src/models/subscription.test.ts
+++ b/src/models/subscription.test.ts
@@ -30,6 +30,49 @@ describe("Subscription", () => {
 				jiraClientKey: "myClientKey_ghe_2"
 			});
 		});
+		describe("getAllForHost", () => {
+			it("should get all cloud and server records when only jiraHost is passed", async () => {
+				const records = await Subscription.getAllForHost(jiraHost);
+				expect(records.length).toBe(3);
+				expect(records[0]).toEqual(expect.objectContaining({
+					gitHubInstallationId: GITHUHB_INSTALLATION_ID,
+					jiraHost,
+					jiraClientKey: "myClientKey"
+				}));
+				expect(records[1]).toEqual(expect.objectContaining({
+					gitHubInstallationId: GITHUHB_INSTALLATION_ID,
+					gitHubAppId: GHEH_GITHUB_SERVER_APP_PK_ID_1,
+					jiraHost,
+					jiraClientKey: "myClientKey_ghe_1"
+				}));
+				expect(records[2]).toEqual(expect.objectContaining({
+					gitHubInstallationId: GITHUHB_INSTALLATION_ID,
+					gitHubAppId: GHEH_GITHUB_SERVER_APP_PK_ID_2,
+					jiraHost,
+					jiraClientKey: "myClientKey_ghe_2"
+				}));
+			});
+			it("should get all server records when jiraHost is passed with gitHubAppid", async () => {
+				const record1 = await Subscription.getAllForHost(jiraHost, GHEH_GITHUB_SERVER_APP_PK_ID_1);
+				expect(record1.length).toBe(1);
+				expect(record1[0]).toEqual(expect.objectContaining({
+					gitHubInstallationId: GITHUHB_INSTALLATION_ID,
+					gitHubAppId: GHEH_GITHUB_SERVER_APP_PK_ID_1,
+					jiraHost,
+					jiraClientKey: "myClientKey_ghe_1"
+				}));
+
+				const record2 = await Subscription.getAllForHost(jiraHost, GHEH_GITHUB_SERVER_APP_PK_ID_2);
+				expect(record2.length).toBe(1);
+				expect(record2[0]).toEqual(expect.objectContaining({
+					gitHubInstallationId: GITHUHB_INSTALLATION_ID,
+					gitHubAppId: GHEH_GITHUB_SERVER_APP_PK_ID_2,
+					jiraHost,
+					jiraClientKey: "myClientKey_ghe_2"
+				}));
+			});
+
+		});
 		describe("getAllFiltered", () => {
 			it("should get for cloud record when gitHubAppId not present", async () => {
 				const records = await Subscription.getAllFiltered(
@@ -166,10 +209,6 @@ describe("Subscription", () => {
 	});
 
 	it("should have tests in here", () => {
-		// TODO: add tests
-	});
-
-	describe.skip("getAllForHost", () => {
 		// TODO: add tests
 	});
 

--- a/src/models/subscription.test.ts
+++ b/src/models/subscription.test.ts
@@ -32,38 +32,38 @@ describe("Subscription", () => {
 				const records = await Subscription.getAllForHost(jiraHost);
 				expect(records.length).toBe(3);
 				expect(records[0]).toEqual(expect.objectContaining({
-					gitHubInstallationId: GITHUHB_INSTALLATION_ID,
+					gitHubInstallationId: GITHUB_INSTALLATION_ID,
 					jiraHost,
 					jiraClientKey: "myClientKey"
 				}));
 				expect(records[1]).toEqual(expect.objectContaining({
-					gitHubInstallationId: GITHUHB_INSTALLATION_ID,
-					gitHubAppId: GHEH_GITHUB_SERVER_APP_PK_ID_1,
+					gitHubInstallationId: GITHUB_INSTALLATION_ID,
+					gitHubAppId: GHES_GITHUB_SERVER_APP_PK_ID_1,
 					jiraHost,
 					jiraClientKey: "myClientKey_ghe_1"
 				}));
 				expect(records[2]).toEqual(expect.objectContaining({
-					gitHubInstallationId: GITHUHB_INSTALLATION_ID,
-					gitHubAppId: GHEH_GITHUB_SERVER_APP_PK_ID_2,
+					gitHubInstallationId: GITHUB_INSTALLATION_ID,
+					gitHubAppId: GHES_GITHUB_SERVER_APP_PK_ID_2,
 					jiraHost,
 					jiraClientKey: "myClientKey_ghe_2"
 				}));
 			});
 			it("should get all server records when jiraHost is passed with gitHubAppid", async () => {
-				const record1 = await Subscription.getAllForHost(jiraHost, GHEH_GITHUB_SERVER_APP_PK_ID_1);
+				const record1 = await Subscription.getAllForHost(jiraHost, GHES_GITHUB_SERVER_APP_PK_ID_1);
 				expect(record1.length).toBe(1);
 				expect(record1[0]).toEqual(expect.objectContaining({
-					gitHubInstallationId: GITHUHB_INSTALLATION_ID,
-					gitHubAppId: GHEH_GITHUB_SERVER_APP_PK_ID_1,
+					gitHubInstallationId: GITHUB_INSTALLATION_ID,
+					gitHubAppId: GHES_GITHUB_SERVER_APP_PK_ID_1,
 					jiraHost,
 					jiraClientKey: "myClientKey_ghe_1"
 				}));
 
-				const record2 = await Subscription.getAllForHost(jiraHost, GHEH_GITHUB_SERVER_APP_PK_ID_2);
+				const record2 = await Subscription.getAllForHost(jiraHost, GHES_GITHUB_SERVER_APP_PK_ID_2);
 				expect(record2.length).toBe(1);
 				expect(record2[0]).toEqual(expect.objectContaining({
-					gitHubInstallationId: GITHUHB_INSTALLATION_ID,
-					gitHubAppId: GHEH_GITHUB_SERVER_APP_PK_ID_2,
+					gitHubInstallationId: GITHUB_INSTALLATION_ID,
+					gitHubAppId: GHES_GITHUB_SERVER_APP_PK_ID_2,
 					jiraHost,
 					jiraClientKey: "myClientKey_ghe_2"
 				}));

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -41,9 +41,10 @@ export class Subscription extends Model {
 	repositoryStatus?: TaskStatus;
 	gitHubAppId?: number;
 
-	static async getAllForHost(jiraHost: string): Promise<Subscription[]> {
+	static async getAllForHost(jiraHost: string, gitHubAppId?: number): Promise<Subscription[]> {
 		return this.findAll({
 			where: {
+				...(gitHubAppId && { gitHubAppId }), // Add gitHubAppId only if passed
 				jiraHost
 			}
 		});

--- a/src/routes/github/configuration/github-configuration-get.ts
+++ b/src/routes/github/configuration/github-configuration-get.ts
@@ -56,7 +56,7 @@ const installationConnectedStatus = async (
 	reqLog: Logger,
 	gitHubAppId?: number
 ): Promise<MergedInstallation[]> => {
-	const subscriptions = await Subscription.getAllForHost(jiraHost);
+	const subscriptions = await Subscription.getAllForHost(jiraHost, gitHubAppId);
 	const installationsWithSubscriptions = await getInstallations(subscriptions, reqLog, gitHubAppId);
 	await removeFailedConnectionsFromDb(reqLog, installationsWithSubscriptions, jiraHost);
 	reqLog.debug(`Removed failed installations`);

--- a/src/routes/github/configuration/github-configuration-get.ts
+++ b/src/routes/github/configuration/github-configuration-get.ts
@@ -56,8 +56,11 @@ const installationConnectedStatus = async (
 	reqLog: Logger,
 	gitHubAppId?: number
 ): Promise<MergedInstallation[]> => {
-	const subscriptions = await Subscription.getAllForHost(jiraHost);
+	const subscriptions = await Subscription.getAllForHost(jiraHost, gitHubAppId);
 	const installationsWithSubscriptions = await getInstallations(subscriptions, reqLog, gitHubAppId);
+	await removeFailedConnectionsFromDb(reqLog, installationsWithSubscriptions, jiraHost);
+	reqLog.debug(`Removed failed installations`);
+
 	const connectedStatuses = getConnectedStatus(installationsWithSubscriptions.fulfilled, jiraHost);
 
 	return mergeByLogin(installationsWithAdmin, connectedStatuses);
@@ -103,7 +106,7 @@ const getInstallationsWithAdmin = async (
 	}));
 };
 
-const removeFailedConnectionsFromDb = async (req: Request, installations: InstallationResults, jiraHost: string): Promise<void> => {
+const removeFailedConnectionsFromDb = async (logger: Logger, installations: InstallationResults, jiraHost: string): Promise<void> => {
 	await Promise.all(installations.rejected
 		// Only uninstall deleted installations
 		.filter(failedInstallation => failedInstallation.deleted)
@@ -115,7 +118,7 @@ const removeFailedConnectionsFromDb = async (req: Request, installations: Instal
 				});
 			} catch (err) {
 				const deleteSubscriptionError = `Failed to delete subscription: ${err}`;
-				req.log.error(deleteSubscriptionError);
+				logger.error(deleteSubscriptionError);
 			}
 		}));
 };
@@ -156,13 +159,6 @@ export const GithubConfigurationGet = async (req: Request, res: Response, next: 
 	const { data: { login } } = await gitHubUserClient.getUser();
 
 	req.log.debug(`got login name: ${login}`);
-
-	// Remove any failed installations before a user attempts to reconnect
-	const subscriptions = await Subscription.getAllForHost(jiraHost, gitHubAppId);
-	const allInstallations = await getInstallations(subscriptions, log, gitHubAppId);
-	await removeFailedConnectionsFromDb(req, allInstallations, jiraHost);
-
-	req.log.debug(`removed failed installations`);
 
 	try {
 

--- a/src/routes/github/configuration/github-configuration-get.ts
+++ b/src/routes/github/configuration/github-configuration-get.ts
@@ -56,7 +56,7 @@ const installationConnectedStatus = async (
 	reqLog: Logger,
 	gitHubAppId?: number
 ): Promise<MergedInstallation[]> => {
-	const subscriptions = await Subscription.getAllForHost(jiraHost, gitHubAppId);
+	const subscriptions = await Subscription.getAllForHost(jiraHost);
 	const installationsWithSubscriptions = await getInstallations(subscriptions, reqLog, gitHubAppId);
 	await removeFailedConnectionsFromDb(reqLog, installationsWithSubscriptions, jiraHost);
 	reqLog.debug(`Removed failed installations`);

--- a/src/routes/github/configuration/github-configuration-get.ts
+++ b/src/routes/github/configuration/github-configuration-get.ts
@@ -158,7 +158,7 @@ export const GithubConfigurationGet = async (req: Request, res: Response, next: 
 	req.log.debug(`got login name: ${login}`);
 
 	// Remove any failed installations before a user attempts to reconnect
-	const subscriptions = await Subscription.getAllForHost(jiraHost);
+	const subscriptions = await Subscription.getAllForHost(jiraHost, gitHubAppId);
 	const allInstallations = await getInstallations(subscriptions, log, gitHubAppId);
 	await removeFailedConnectionsFromDb(req, allInstallations, jiraHost);
 

--- a/src/routes/github/configuration/github-configuration-get.ts
+++ b/src/routes/github/configuration/github-configuration-get.ts
@@ -53,13 +53,13 @@ const mergeByLogin = (installationsWithAdmin: InstallationWithAdmin[], connected
 const installationConnectedStatus = async (
 	jiraHost: string,
 	installationsWithAdmin: InstallationWithAdmin[],
-	reqLog: Logger,
+	log: Logger,
 	gitHubAppId?: number
 ): Promise<MergedInstallation[]> => {
 	const subscriptions = await Subscription.getAllForHost(jiraHost, gitHubAppId);
-	const installationsWithSubscriptions = await getInstallations(subscriptions, reqLog, gitHubAppId);
-	await removeFailedConnectionsFromDb(reqLog, installationsWithSubscriptions, jiraHost);
-	reqLog.debug(`Removed failed installations`);
+	const installationsWithSubscriptions = await getInstallations(subscriptions, log, gitHubAppId);
+	await removeFailedConnectionsFromDb(log, installationsWithSubscriptions, jiraHost);
+	log.debug("Removed failed installations");
 
 	const connectedStatuses = getConnectedStatus(installationsWithSubscriptions.fulfilled, jiraHost);
 

--- a/src/routes/github/configuration/github-configuration-router.test.ts
+++ b/src/routes/github/configuration/github-configuration-router.test.ts
@@ -126,22 +126,6 @@ describe("Github Configuration", () => {
 			githubUserTokenNock(sub.gitHubInstallationId);
 
 			githubNock
-				.get(`/app/installations/${sub.gitHubInstallationId}`)
-				.twice()
-				.reply(200, {
-					"id": 1,
-					"account": {
-						"login": "octocat",
-						"id": 1,
-						"type": "User"
-					},
-					"html_url": "https://github.com/organizations/github/settings/installations/1",
-					"target_type": "Organization",
-					"created_at": "2017-07-08T16:18:44-04:00",
-					"updated_at": "2017-07-08T16:18:44-04:00"
-				});
-
-			githubNock
 				.get(`/user/installations`)
 				.reply(200, {
 					installations: [{
@@ -201,13 +185,6 @@ describe("Github Configuration", () => {
 				.reply(200, { login: "test-user" });
 
 			githubUserTokenNock(sub.gitHubInstallationId);
-
-			githubNock
-				.get(`/app/installations/${sub.gitHubInstallationId}`)
-				.twice()
-				.reply(403, {
-					message: "Although you appear to have the correct authorization credentials, the `Fusion-Arc` organization has an IP allow list enabled, and 13.52.4.51 is not permitted to access this resource."
-				});
 
 			githubNock
 				.get("/user/installations")

--- a/src/routes/github/configuration/github-configuration-router.test.ts
+++ b/src/routes/github/configuration/github-configuration-router.test.ts
@@ -126,6 +126,22 @@ describe("Github Configuration", () => {
 			githubUserTokenNock(sub.gitHubInstallationId);
 
 			githubNock
+				.get(`/app/installations/${sub.gitHubInstallationId}`)
+				.twice()
+				.reply(200, {
+					"id": 1,
+					"account": {
+						"login": "octocat",
+						"id": 1,
+						"type": "User"
+					},
+					"html_url": "https://github.com/organizations/github/settings/installations/1",
+					"target_type": "Organization",
+					"created_at": "2017-07-08T16:18:44-04:00",
+					"updated_at": "2017-07-08T16:18:44-04:00"
+				});
+
+			githubNock
 				.get(`/user/installations`)
 				.reply(200, {
 					installations: [{
@@ -185,6 +201,13 @@ describe("Github Configuration", () => {
 				.reply(200, { login: "test-user" });
 
 			githubUserTokenNock(sub.gitHubInstallationId);
+
+			githubNock
+				.get(`/app/installations/${sub.gitHubInstallationId}`)
+				.twice()
+				.reply(403, {
+					message: "Although you appear to have the correct authorization credentials, the `Fusion-Arc` organization has an IP allow list enabled, and 13.52.4.51 is not permitted to access this resource."
+				});
 
 			githubNock
 				.get("/user/installations")

--- a/src/routes/github/configuration/github-configuration-router.test.ts
+++ b/src/routes/github/configuration/github-configuration-router.test.ts
@@ -126,6 +126,21 @@ describe("Github Configuration", () => {
 			githubUserTokenNock(sub.gitHubInstallationId);
 
 			githubNock
+				.get(`/app/installations/${sub.gitHubInstallationId}`)
+				.reply(200, {
+					"id": 1,
+					"account": {
+						"login": "octocat",
+						"id": 1,
+						"type": "User"
+					},
+					"html_url": "https://github.com/organizations/github/settings/installations/1",
+					"target_type": "Organization",
+					"created_at": "2017-07-08T16:18:44-04:00",
+					"updated_at": "2017-07-08T16:18:44-04:00"
+				});
+
+			githubNock
 				.get(`/user/installations`)
 				.reply(200, {
 					installations: [{
@@ -187,6 +202,12 @@ describe("Github Configuration", () => {
 			githubUserTokenNock(sub.gitHubInstallationId);
 
 			githubNock
+				.get(`/app/installations/${sub.gitHubInstallationId}`)
+				.reply(403, {
+					message: "Although you appear to have the correct authorization credentials, the `Fusion-Arc` organization has an IP allow list enabled, and 13.52.4.51 is not permitted to access this resource."
+				});
+
+			githubNock
 				.get("/user/installations")
 				.reply(200, {
 					installations: [{
@@ -223,7 +244,7 @@ describe("Github Configuration", () => {
 					"Cookie",
 					getSignedCookieHeader({
 						jiraHost,
-						githubToken: "token"
+						githubToken: "token2"
 					})
 				)
 				.expect(200);


### PR DESCRIPTION
**What's in this PR?**
- Added `gitHubAppId` to fetch the correct subscriptions in `github-configuration-get`
- Removed multiple DB calls.

**Why**
- The previous usage of `Subscription.getAllForHost` was pulling both cloud and server apps. This caused the cloud apps to be failed installations because they don't exist in the GHES. So, it was being removed from the DB as failed installations are all being removed. 

**How has this been tested?**  
- In local and ddev environment
