### PR TITLE
Bypassing the jiraHost check if provided value is same as session

### DIFF
--- a/src/middleware/jirahost-middleware.test.ts
+++ b/src/middleware/jirahost-middleware.test.ts
@@ -90,6 +90,36 @@ describe("await jirahostMiddleware", () => {
 			expect(next).toBeCalled();
 		});
 
+		it("should skip checking the jiraHost if same value present in the session cookie, and call next()", async () => {
+
+			req.session.jiraHost = LEGIT_JIRA_HOST;
+
+			mockJwtVerificationFn.mockImplementation(()=>{
+				//do not call next, is code shouldn't call this to verify jwt
+			});
+
+			await jirahostMiddleware(req, res, next);
+
+			expect(next).toBeCalled();
+
+		});
+
+		it("should NOT skip checking the jiraHost if DIFFERENT value present in the session cookie, and call next()", async () => {
+
+			req.session.jiraHost = LEGIT_JIRA_HOST + "_in_session";
+
+			mockJwtVerificationFn.mockImplementation((_req, res, next)=>{
+				if (res.locals.jiraHost === LEGIT_JIRA_HOST) {
+					next();
+				}
+			});
+
+			await jirahostMiddleware(req, res, next);
+
+			expect(next).toBeCalled();
+
+		});
+
 		it("should not call next() when invalid", async () => {
 
 			mockJwtVerificationFn.mockImplementation(() => {

--- a/src/middleware/jirahost-middleware.ts
+++ b/src/middleware/jirahost-middleware.ts
@@ -50,7 +50,7 @@ export const jirahostMiddleware = async (req: Request, res: Response, next: Next
 	const takenFromCookies = unsafeJiraHost === req.cookies.jiraHost;
 	res.clearCookie("jiraHost");
 
-	if (unsafeJiraHost && isDifferentFromSession(unsafeJiraHost, req.session.jiraHost)) {
+	if (unsafeJiraHost && unsafeJiraHost !== req.session.jiraHost) {
 		// Even though it is unsafe, we are verifying it straight away below (in "verifyJwtBlahBlah" call)
 		res.locals.jiraHost = unsafeJiraHost;
 		await verifyJiraJwtMiddleware(detectJwtTokenType(req))(req, res, () => {
@@ -72,6 +72,3 @@ export const jirahostMiddleware = async (req: Request, res: Response, next: Next
 	}
 };
 
-const isDifferentFromSession = (unsafeJiraHost: string | undefined, sessionJiraHost: string | undefined) => {
-	return unsafeJiraHost !== sessionJiraHost;
-};


### PR DESCRIPTION
**What's in this PR?**
Bypassing the jiraHost check if provided value is same as session

**Why**
Currently in prod, we can't delete a subscription as the route is `/github/subscription` and contains `jiraHost` in body. Therefore code try to verify it with the jwt token, but jwt token is missing on that subscription managing page.

So instead, I decided to bypass that check if the jiraHost value in request body is same as the one in the session cookie, coz we ALWAYS TRUST session cookie.

**Added feature flags**
N/A

**Affected issues**  
ARC-1614

**How has this been tested?**  
Unit test.
Stage [WIP]

**Whats Next?**
N/A
