### PR TITLE
ARC-1594 - Only render orgs connected to an app on the connect an org page

### DIFF
--- a/src/interfaces/common.ts
+++ b/src/interfaces/common.ts
@@ -37,7 +37,7 @@ declare global {
 			session: {
 				jiraHost?: string;
 				githubToken?: string;
-				githubUuid?: string;
+				gitHubUuid?: string;
 				temp?:  {
 					[key: string]: any;
 				}

--- a/src/interfaces/common.ts
+++ b/src/interfaces/common.ts
@@ -37,6 +37,7 @@ declare global {
 			session: {
 				jiraHost?: string;
 				githubToken?: string;
+				githubUuid?: string;
 				temp?:  {
 					[key: string]: any;
 				}

--- a/src/routes/github/github-oauth-router.ts
+++ b/src/routes/github/github-oauth-router.ts
@@ -107,7 +107,7 @@ const GithubOAuthCallbackGet = async (req: Request, res: Response, next: NextFun
 		req.session.githubToken = response.data.access_token;
 
 		// Saving UUID for each GitHubServerApp
-		req.session.githubUuid = uuid;
+		req.session.gitHubUuid = uuid;
 
 		if (!req.session.githubToken) {
 			req.log.debug(`didn't get access token from GitHub`);
@@ -126,7 +126,7 @@ const GithubOAuthCallbackGet = async (req: Request, res: Response, next: NextFun
 
 export const GithubAuthMiddleware = async (req: Request, res: Response, next: NextFunction) => {
 	try {
-		const { githubToken, githubUuid } = req.session;
+		const { githubToken, gitHubUuid } = req.session;
 		const { jiraHost, gitHubAppId, gitHubAppConfig } = res.locals;
 		/**
 		 * Comparing the `UUID` saved in the session with the `UUID` inside `gitHubAppConfig`,
@@ -134,7 +134,7 @@ export const GithubAuthMiddleware = async (req: Request, res: Response, next: Ne
 		 * This is done because the `user/installations` endpoint is based upon the githubToken
 		 * and to fetch new list of installations we need separate githubTokens
 		 */
-		if (!githubToken || githubUuid !== gitHubAppConfig.uuid) {
+		if (!githubToken || gitHubUuid !== gitHubAppConfig.uuid) {
 			req.log.info("github token missing, calling login()");
 			throw "Missing github token";
 		}

--- a/src/routes/github/github-router.test.ts
+++ b/src/routes/github/github-router.test.ts
@@ -181,7 +181,7 @@ describe("GitHub router", () => {
 						getSignedCookieHeader({
 							jiraHost,
 							githubToken: VALID_TOKEN,
-							githubUuid: GITHUB_SERVER_APP_UUID
+							gitHubUuid: GITHUB_SERVER_APP_UUID
 						})
 					)
 					.expect(200);

--- a/src/routes/github/github-router.test.ts
+++ b/src/routes/github/github-router.test.ts
@@ -212,8 +212,7 @@ describe("GitHub router", () => {
 						"Cookie",
 						getSignedCookieHeader({
 							jiraHost,
-							githubToken: VALID_TOKEN,
-							githubUuid: GITHUB_SERVER_APP_UUID
+							githubToken: VALID_TOKEN
 						})
 					)
 					.expect(404);

--- a/src/routes/github/github-router.test.ts
+++ b/src/routes/github/github-router.test.ts
@@ -212,7 +212,8 @@ describe("GitHub router", () => {
 						"Cookie",
 						getSignedCookieHeader({
 							jiraHost,
-							githubToken: VALID_TOKEN
+							githubToken: VALID_TOKEN,
+							githubUuid: GITHUB_SERVER_APP_UUID
 						})
 					)
 					.expect(404);

--- a/src/routes/github/github-router.test.ts
+++ b/src/routes/github/github-router.test.ts
@@ -180,7 +180,8 @@ describe("GitHub router", () => {
 						"Cookie",
 						getSignedCookieHeader({
 							jiraHost,
-							githubToken: VALID_TOKEN
+							githubToken: VALID_TOKEN,
+							githubUuid: GITHUB_SERVER_APP_UUID
 						})
 					)
 					.expect(200);


### PR DESCRIPTION
**What's in this PR?**
- Added github UUID in the session.
- Checking this saved UUID with the UUID from githubAppConfig.
  - If same do nothing
  - If different, do another login to fetch new gitHubToken. 

**Why**
- The `githubToken` for the endpoint `user/installations`, which fetches the list of installations for a user, is based on the app. So, for every new app, we need a new token. Thats why we are re-authenticating every time when the UUIDs do not match.

**How has this been tested?**  
- In local
- In ddev

**Video**

https://user-images.githubusercontent.com/13076255/185519062-a4b7bc43-e5b1-498a-af7f-e789f9790085.mov


