### PR TITLE
VULN-892689 - Forced zlib update for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add g++ make python3
 RUN apk add --update --upgrade busybox
 RUN apk add --update --upgrade libretls
 RUN apk add --update --upgrade openssl
+RUN apk add --update --upgrade zlib
 
 COPY . /app
 WORKDIR /app

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -7,6 +7,7 @@ RUN apk add g++ make python3
 RUN apk add --update --upgrade busybox
 RUN apk add --update --upgrade libretls
 RUN apk add --update --upgrade openssl
+RUN apk add --update --upgrade zlib
 
 COPY . /app
 WORKDIR /app
@@ -23,6 +24,7 @@ FROM node:14.19-alpine3.16
 # adding to solve vuln
 RUN apk add --update --upgrade busybox
 RUN apk add --update --upgrade openssl
+RUN apk add --update --upgrade zlib
 
 USER node
 COPY --chown=node:node --from=build /app /app


### PR DESCRIPTION
**What's in this PR?**
Update zlib package.

Annoyingly, the image we are using Alpine 3.16 has the correct package but the scanner still complains so have to force the zlib package to update.....This highlights that there is something else wrong for me. We shouldn't need to do this, so need to investigate why the image update isn't satisfying Snyk!!


**Why**
VULN scanner picked up a vulnerability
[VULN](https://asecurityteam.atlassian.net/browse/VULN-892689?jql=project%20%3D%20VULN%20AND%20resolution%20%3D%20Unresolved%20AND%20%22Product%20-%20Team%5BSelect%20List%20(cascading)%5D%22%20in%20cascadeOption(%22Fusion%22%2C%22Arc%22)%20AND%20%22SLO%20Start%20Date%5BDate%5D%22%20IS%20NOT%20EMPTY%20AND%20assignee%20IS%20NOT%20EMPTY%20ORDER%20BY%20created%20DESC)

