### PR TITLE
Arc 1619 make GitHub app id mandatory

### DIFF
--- a/src/github/branch.ts
+++ b/src/github/branch.ts
@@ -32,7 +32,7 @@ export const processBranch = async (
 	jiraHost: string,
 	gitHubInstallationId: number,
 	rootLogger: Logger,
-	gitHubAppId?: number
+	gitHubAppId: number | undefined
 ) => {
 	const logger = rootLogger.child({
 		webhookId: webhookId,

--- a/src/github/branch.ts
+++ b/src/github/branch.ts
@@ -53,8 +53,8 @@ export const processBranch = async (
 	const jiraClient = await getJiraClient(
 		jiraHost,
 		gitHubInstallationId,
-		logger,
-		gitHubAppId
+		gitHubAppId,
+		logger
 	);
 
 	const jiraResponse = await jiraClient.devinfo.repository.update(jiraPayload);

--- a/src/github/client/key-locator.test.ts
+++ b/src/github/client/key-locator.test.ts
@@ -27,7 +27,7 @@ describe("key-locator", () => {
 
 	it("should return cloud app private key using PRIVATE_KEY_PATH", async () => {
 		const privateKeyContents = readFileSync(`${process.cwd()}/test/setup/test-key.pem`, "utf-8");
-		const privateKey = await keyLocator();
+		const privateKey = await keyLocator(undefined);
 		expect(privateKey).toBe(privateKeyContents);
 
 	});
@@ -36,7 +36,7 @@ describe("key-locator", () => {
 		const envPrivateKeyPath = envVars.PRIVATE_KEY_PATH;
 		envVars.PRIVATE_KEY_PATH = "cloud-private-key-invalid-path.pem";
 
-		await expect(keyLocator()).rejects.toThrow("Private key does not exists");
+		await expect(keyLocator(undefined)).rejects.toThrow("Private key does not exists");
 		envVars.PRIVATE_KEY_PATH = envPrivateKeyPath;
 
 	});
@@ -47,7 +47,7 @@ describe("key-locator", () => {
 		-----END RSA PRIVATE KEY-----`;
 		const envPrivateKey = envVars.PRIVATE_KEY;
 		envVars.PRIVATE_KEY = privateKetCert;
-		const privateKey = await keyLocator();
+		const privateKey = await keyLocator(undefined);
 		expect(privateKey).toBe(privateKetCert);
 		envVars.PRIVATE_KEY = envPrivateKey;
 	});
@@ -59,7 +59,7 @@ describe("key-locator", () => {
 		const encodedPrivateKey = Buffer.from(privateKetCert).toString("base64");
 		const envPrivateKey = envVars.PRIVATE_KEY;
 		envVars.PRIVATE_KEY = encodedPrivateKey;
-		const privateKey = await keyLocator();
+		const privateKey = await keyLocator(undefined);
 		expect(privateKey).toBe(privateKetCert);
 		envVars.PRIVATE_KEY = envPrivateKey;
 	});

--- a/src/github/client/key-locator.ts
+++ b/src/github/client/key-locator.ts
@@ -7,7 +7,7 @@ import isBase64 from "is-base64";
 /**
  * Look for a Github app's private key
  */
-export const keyLocator = async (gitHubAppId?: number) => {
+export const keyLocator = async (gitHubAppId: number | undefined) => {
 	if (gitHubAppId) {
 		const gitHubServerApp = await GitHubServerApp.getForGitHubServerAppId(gitHubAppId);
 		if (gitHubServerApp) {

--- a/src/github/client/token-cache.test.ts
+++ b/src/github/client/token-cache.test.ts
@@ -43,13 +43,15 @@ describe("InstallationTokenCache & AppTokenHolder", () => {
 		await Subscription.install({
 			host: "http://github.com",
 			installationId: 1234,
-			clientKey: "client-key"
+			clientKey: "client-key",
+			gitHubAppId: undefined
 		});
 
 		await Subscription.install({
 			host: "http://github.com",
 			installationId: 4711,
-			clientKey: "client-key"
+			clientKey: "client-key",
+			gitHubAppId: undefined
 		});
 
 		when(booleanFlag).calledWith(

--- a/src/github/deployment.ts
+++ b/src/github/deployment.ts
@@ -47,7 +47,7 @@ export const processDeployment = async (
 
 	logger.info("processing deployment message!");
 
-	const jiraPayload: JiraDeploymentData | undefined = await transformDeployment(newGitHubClient, webhookPayload, jiraHost, logger);
+	const jiraPayload: JiraDeploymentData | undefined = await transformDeployment(newGitHubClient, webhookPayload, jiraHost, logger, gitHubAppId);
 
 	if (!jiraPayload) {
 		logger.info(

--- a/src/github/deployment.ts
+++ b/src/github/deployment.ts
@@ -60,8 +60,8 @@ export const processDeployment = async (
 	const jiraClient = await getJiraClient(
 		jiraHost,
 		gitHubInstallationId,
-		logger,
-		gitHubAppId
+		gitHubAppId,
+		logger
 	);
 
 	const result: DeploymentsResult = await jiraClient.deployment.submit(jiraPayload);

--- a/src/github/deployment.ts
+++ b/src/github/deployment.ts
@@ -30,7 +30,7 @@ export const processDeployment = async (
 	jiraHost: string,
 	gitHubInstallationId: number,
 	rootLogger: Logger,
-	gitHubAppId?: number
+	gitHubAppId: number | undefined
 ) => {
 
 	const logger = rootLogger.child({

--- a/src/jira/client/jira-client.test.ts
+++ b/src/jira/client/jira-client.test.ts
@@ -23,7 +23,7 @@ describe("Test getting a jira client", () => {
 			jiraHost,
 			gitHubInstallationId
 		});
-		client = await getJiraClient(jiraHost, gitHubInstallationId);
+		client = await getJiraClient(jiraHost, gitHubInstallationId, undefined, undefined);
 	});
 
 	it("Installation exists", async () => {
@@ -31,7 +31,7 @@ describe("Test getting a jira client", () => {
 	});
 
 	it("Installation does not exist", async () => {
-		expect(await getJiraClient("https://non-existing-url.atlassian.net", gitHubInstallationId)).not.toBeDefined();
+		expect(await getJiraClient("https://non-existing-url.atlassian.net", gitHubInstallationId, undefined, undefined)).not.toBeDefined();
 	});
 
 	it("Should truncate issueKeys for commits if over the limit", async () => {
@@ -159,7 +159,7 @@ describe("Test getting a jira client", () => {
 				.calledWith(BooleanFlags.READ_SHARED_SECRET_FROM_CRYPTOR, expect.anything(), expect.anything())
 				.mockResolvedValue(false);
 			jest.spyOn(Axios, "getAxiosInstance");
-			client = await getJiraClient(jiraHost, gitHubInstallationId);
+			client = await getJiraClient(jiraHost, gitHubInstallationId, undefined, undefined);
 			expect(Axios.getAxiosInstance).toHaveBeenCalledWith(
 				expect.anything(),
 				"shared-secret",
@@ -172,7 +172,7 @@ describe("Test getting a jira client", () => {
 				.calledWith(BooleanFlags.READ_SHARED_SECRET_FROM_CRYPTOR, expect.anything(), expect.anything())
 				.mockResolvedValue(true);
 			jest.spyOn(Axios, "getAxiosInstance");
-			client = await getJiraClient(jiraHost, gitHubInstallationId);
+			client = await getJiraClient(jiraHost, gitHubInstallationId, undefined, undefined);
 			expect(Axios.getAxiosInstance).toHaveBeenCalledWith(
 				expect.anything(),
 				"new-encrypted-shared-secret",

--- a/src/jira/client/jira-client.ts
+++ b/src/jira/client/jira-client.ts
@@ -32,8 +32,8 @@ export interface DeploymentsResult {
 export const getJiraClient = async (
 	jiraHost: string,
 	gitHubInstallationId: number,
-	log: Logger = getLogger("jira-client"),
-	gitHubAppId: number | undefined
+	gitHubAppId: number | undefined,
+	log: Logger = getLogger("jira-client")
 ): Promise<any> => {
 	const logger = log.child({ jiraHost, gitHubInstallationId });
 	const installation = await Installation.getForHost(jiraHost);

--- a/src/jira/client/jira-client.ts
+++ b/src/jira/client/jira-client.ts
@@ -33,7 +33,7 @@ export const getJiraClient = async (
 	jiraHost: string,
 	gitHubInstallationId: number,
 	log: Logger = getLogger("jira-client"),
-	gitHubAppId?: number
+	gitHubAppId: number | undefined
 ): Promise<any> => {
 	const logger = log.child({ jiraHost, gitHubInstallationId });
 	const installation = await Installation.getForHost(jiraHost);

--- a/src/middleware/github-server-app-middleware.test.ts
+++ b/src/middleware/github-server-app-middleware.test.ts
@@ -115,6 +115,7 @@ describe("github-server-app-middleware", () => {
 
 		expect(res.locals.gitHubAppId).toBe(GIT_HUB_SERVER_APP_ID);
 		expect(res.locals.gitHubAppConfig).toEqual({
+			gitHubAppId: GIT_HUB_SERVER_APP_ID,
 			appId: GIT_HUB_SERVER_APP_APP_ID,
 			uuid: UUID,
 			clientId: "lvl.1234",

--- a/src/middleware/github-server-app-middleware.ts
+++ b/src/middleware/github-server-app-middleware.ts
@@ -33,6 +33,7 @@ export const GithubServerAppMiddleware = async (req: Request, res: Response, nex
 		//TODO: ARC-1515 decide how to put `gitHubAppId ` inside `gitHubAppConfig`
 		res.locals.gitHubAppId = gitHubServerApp.id;
 		res.locals.gitHubAppConfig = {
+			gitHubAppId: gitHubServerApp.id,
 			appId: gitHubServerApp.appId,
 			uuid: gitHubServerApp.uuid,
 			hostname: gitHubServerApp.gitHubBaseUrl,
@@ -44,13 +45,14 @@ export const GithubServerAppMiddleware = async (req: Request, res: Response, nex
 	} else {
 		req.log.info("Defining GitHub app config for GitHub Cloud.");
 		res.locals.gitHubAppConfig = {
+			gitHubAppId: undefined,
 			appId: envVars.APP_ID,
 			uuid: undefined, //undefined for cloud
 			hostname: GITHUB_CLOUD_HOSTNAME,
 			clientId: envVars.GITHUB_CLIENT_ID,
 			gitHubClientSecret: envVars.GITHUB_CLIENT_SECRET,
 			webhookSecret: envVars.WEBHOOK_SECRET,
-			privateKey: await keyLocator()
+			privateKey: await keyLocator(undefined)
 		};
 	}
 

--- a/src/middleware/github-webhook-middleware.ts
+++ b/src/middleware/github-webhook-middleware.ts
@@ -204,8 +204,8 @@ export const GithubWebhookMiddleware = (
 			const jiraClient = await getJiraClient(
 				jiraHost,
 				gitHubInstallationId,
-				context.log,
-				context.gitHubAppConfig?.gitHubAppId
+				context.gitHubAppConfig?.gitHubAppId,
+				context.log
 			);
 
 			if (!jiraClient) {

--- a/src/models/encrypted-model.ts
+++ b/src/models/encrypted-model.ts
@@ -16,7 +16,8 @@ export abstract class EncryptedModel extends Model {
 	async decrypt(field: (keyof StringValues<this>)): Promise<string> {
 		const value = this[field];
 		if (typeof value !== "string") {
-			throw new Error(`Cannot decrypt '${field}', it is not a string.`);
+			//error TS2731: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.
+			throw new Error(`Cannot decrypt '${String(field)}', it is not a string.`);
 		}
 		return await EncryptionClient.decrypt(value, await this.getEncryptContext(field));
 	}
@@ -24,7 +25,8 @@ export abstract class EncryptedModel extends Model {
 	protected async encrypt(field: (keyof StringValues<this>)): Promise<string> {
 		const value = this[field];
 		if (typeof value !== "string") {
-			throw new Error(`Cannot encrypt '${field}', it is not a string.`);
+			//error TS2731: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.
+			throw new Error(`Cannot encrypt '${String(field)}', it is not a string.`);
 		}
 		return await EncryptionClient.encrypt(this.getEncryptionSecretKey(), value, await this.getEncryptContext(field));
 	}

--- a/src/models/models.test.ts
+++ b/src/models/models.test.ts
@@ -61,13 +61,15 @@ describe("Models", () => {
 			await Subscription.install({
 				host: installation.jiraHost,
 				installationId: 1234,
-				clientKey: installation.clientKey
+				clientKey: installation.clientKey,
+				gitHubAppId: undefined
 			});
 
 			await Subscription.install({
 				host: installation.jiraHost,
 				installationId: 2345,
-				clientKey: installation.clientKey
+				clientKey: installation.clientKey,
+				gitHubAppId: undefined
 			});
 		});
 

--- a/src/models/subscription.test.ts
+++ b/src/models/subscription.test.ts
@@ -30,7 +30,7 @@ describe("Subscription", () => {
 		describe("getAllFiltered", () => {
 			it("should get for cloud record when gitHubAppId not present", async () => {
 				const records = await Subscription.getAllFiltered(
-					[GITHUB_INSTALLATION_ID], []
+					undefined, [GITHUB_INSTALLATION_ID], []
 				);
 				expect(records.length).toBe(1);
 				expect(records[0]).toEqual(expect.objectContaining({
@@ -42,8 +42,7 @@ describe("Subscription", () => {
 			});
 			it("should get correct github server app", async () => {
 				const records = await Subscription.getAllFiltered(
-					[GITHUB_INSTALLATION_ID], [], 0, undefined, undefined,
-					GHES_GITHUB_SERVER_APP_PK_ID_1
+					GHES_GITHUB_SERVER_APP_PK_ID_1, [GITHUB_INSTALLATION_ID], [], 0, undefined, undefined,
 				);
 				expect(records.length).toBe(1);
 				expect(records[0]).toEqual(expect.objectContaining({
@@ -58,7 +57,8 @@ describe("Subscription", () => {
 			it("should get for cloud record when gitHubAppId not present", async () => {
 				const record = await Subscription.getSingleInstallation(
 					jiraHost,
-					GITHUB_INSTALLATION_ID
+					GITHUB_INSTALLATION_ID,
+					undefined
 				);
 				expect(record).toEqual(expect.objectContaining({
 					jiraHost,
@@ -84,7 +84,7 @@ describe("Subscription", () => {
 		describe("findOneForGitHubInstallationId", () => {
 			it("should get for cloud record when gitHubAppId not present", async () => {
 				const record = await Subscription.findOneForGitHubInstallationId(
-					GITHUB_INSTALLATION_ID
+					GITHUB_INSTALLATION_ID, undefined
 				);
 				expect(record).toEqual(expect.objectContaining({
 					jiraHost,
@@ -109,7 +109,7 @@ describe("Subscription", () => {
 		describe("getAllForInstallation", () => {
 			it("should only fetch cloud records when gitHubAppId not present", async () => {
 				const records = await Subscription.getAllForInstallation(
-					GITHUB_INSTALLATION_ID
+					GITHUB_INSTALLATION_ID, undefined
 				);
 				expect(records.length).toBe(1);
 				expect(records[0]).toEqual(expect.objectContaining({
@@ -137,7 +137,8 @@ describe("Subscription", () => {
 			it("should only uninstall cloud records when gitHubAppId not present", async () => {
 				await Subscription.uninstall({
 					host: jiraHost,
-					installationId: GITHUB_INSTALLATION_ID
+					installationId: GITHUB_INSTALLATION_ID,
+					gitHubAppId: undefined
 				});
 				const [results] = await Subscription.sequelize!.query("select * from \"Subscriptions\"");
 				expect(results).toEqual([expect.objectContaining({

--- a/src/models/subscription.test.ts
+++ b/src/models/subscription.test.ts
@@ -42,7 +42,7 @@ describe("Subscription", () => {
 			});
 			it("should get correct github server app", async () => {
 				const records = await Subscription.getAllFiltered(
-					GHES_GITHUB_SERVER_APP_PK_ID_1, [GITHUB_INSTALLATION_ID], [], 0, undefined, undefined,
+					GHES_GITHUB_SERVER_APP_PK_ID_1, [GITHUB_INSTALLATION_ID], [], 0, undefined, undefined
 				);
 				expect(records.length).toBe(1);
 				expect(records[0]).toEqual(expect.objectContaining({

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -79,7 +79,7 @@ export class Subscription extends Model {
 		statusTypes: string[] = ["FAILED", "PENDING", "ACTIVE"],
 		offset = 0,
 		limit?: number,
-		inactiveForSeconds?: number,
+		inactiveForSeconds?: number
 	): Promise<Subscription[]> {
 
 		const andFilter: WhereOptions[] = [];

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -39,7 +39,7 @@ export class Subscription extends Model {
 	numberOfSyncedRepos?: number;
 	repositoryCursor?: string;
 	repositoryStatus?: TaskStatus;
-	gitHubAppId?: number;
+	gitHubAppId: number | undefined;
 
 	static async getAllForHost(jiraHost: string): Promise<Subscription[]> {
 		return this.findAll({
@@ -51,7 +51,7 @@ export class Subscription extends Model {
 
 	static getAllForInstallation(
 		gitHubInstallationId: number,
-		gitHubAppId?: number
+		gitHubAppId: number | undefined
 	): Promise<Subscription[]> {
 		return this.findAll({
 			where: {
@@ -63,7 +63,7 @@ export class Subscription extends Model {
 
 	static findOneForGitHubInstallationId(
 		gitHubInstallationId: number,
-		gitHubAppId?: number
+		gitHubAppId: number | undefined
 	): Promise<Subscription | null> {
 		return this.findOne({
 			where: {
@@ -79,7 +79,7 @@ export class Subscription extends Model {
 		offset = 0,
 		limit?: number,
 		inactiveForSeconds?: number,
-		gitHubAppId?: number
+		gitHubAppId: number | undefined
 	): Promise<Subscription[]> {
 
 		const andFilter: WhereOptions[] = [];
@@ -141,7 +141,7 @@ export class Subscription extends Model {
 	static getSingleInstallation(
 		jiraHost: string,
 		gitHubInstallationId: number,
-		gitHubAppId?: number
+		gitHubAppId: number | undefined
 	): Promise<Subscription | null> {
 		return this.findOne({
 			where: {
@@ -223,7 +223,7 @@ Subscription.init({
 export interface SubscriptionPayload {
 	installationId: number;
 	host: string;
-	gitHubAppId?: number;
+	gitHubAppId: number | undefined;
 }
 
 export interface SubscriptionInstallPayload extends SubscriptionPayload {

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -74,12 +74,12 @@ export class Subscription extends Model {
 	}
 
 	static getAllFiltered(
+		gitHubAppId: number | undefined,
 		installationIds: number[] = [],
 		statusTypes: string[] = ["FAILED", "PENDING", "ACTIVE"],
 		offset = 0,
 		limit?: number,
 		inactiveForSeconds?: number,
-		gitHubAppId: number | undefined
 	): Promise<Subscription[]> {
 
 		const andFilter: WhereOptions[] = [];

--- a/src/routes/api/api-router.ts
+++ b/src/routes/api/api-router.ts
@@ -114,7 +114,9 @@ ApiRouter.post(
 				return;
 			}
 		}
-		const subscriptions = await Subscription.getAllFiltered(installationIds, statusTypes, offset, limit, inactiveForSeconds, gitHubServerApp?.id);
+
+		const gitHubAppId = gitHubServerApp?.id;
+		const subscriptions = await Subscription.getAllFiltered(gitHubAppId, installationIds, statusTypes, offset, limit, inactiveForSeconds);
 
 		await Promise.all(subscriptions.map((subscription) =>
 			findOrStartSync(subscription, req.log, syncType, commitsFromDate, targetTasks)

--- a/src/routes/api/installation/api-installation-delete.ts
+++ b/src/routes/api/installation/api-installation-delete.ts
@@ -9,7 +9,7 @@ export const ApiInstallationDelete = async (req: Request, res: Response): Promis
 	//TODO: ARC-1619 Maybe need to fix this and put it into the path
 	//Not doing it now as it might break pollinator if it use this api
 	const { gitHubAppIdStr } = req.query;
-	const gitHubAppId = parseInt(gitHubAppIdStr as string) || undefined
+	const gitHubAppId = parseInt(gitHubAppIdStr as string) || undefined;
 
 	if (!jiraHost || !githubInstallationId) {
 		const msg = "Missing Jira Host or Installation ID";

--- a/src/routes/api/installation/api-installation-delete.ts
+++ b/src/routes/api/installation/api-installation-delete.ts
@@ -6,11 +6,6 @@ export const ApiInstallationDelete = async (req: Request, res: Response): Promis
 	const githubInstallationId = req.params.installationId;
 	const jiraHost = req.params.jiraHost;
 
-	//TODO: ARC-1619 Maybe need to fix this and put it into the path
-	//Not doing it now as it might break pollinator if it use this api
-	const { gitHubAppIdStr } = req.query;
-	const gitHubAppId = parseInt(gitHubAppIdStr as string) || undefined;
-
 	if (!jiraHost || !githubInstallationId) {
 		const msg = "Missing Jira Host or Installation ID";
 		req.log.warn({ req, res }, msg);
@@ -21,7 +16,7 @@ export const ApiInstallationDelete = async (req: Request, res: Response): Promis
 	const subscription = await Subscription.getSingleInstallation(
 		jiraHost,
 		Number(githubInstallationId),
-		gitHubAppId
+		undefined
 	);
 
 	if (!subscription) {
@@ -31,7 +26,7 @@ export const ApiInstallationDelete = async (req: Request, res: Response): Promis
 	}
 
 	try {
-		const jiraClient = await getJiraClient(jiraHost, Number(githubInstallationId), req.log, gitHubAppId);
+		const jiraClient = await getJiraClient(jiraHost, Number(githubInstallationId), undefined, req.log);
 		req.log.info({ jiraHost, githubInstallationId }, `Deleting DevInfo`);
 		await jiraClient.devinfo.installation.delete(githubInstallationId);
 		res.status(200).send(`DevInfo deleted for jiraHost: ${jiraHost} githubInstallationId: ${githubInstallationId}`);

--- a/src/routes/api/installation/api-installation-delete.ts
+++ b/src/routes/api/installation/api-installation-delete.ts
@@ -6,6 +6,11 @@ export const ApiInstallationDelete = async (req: Request, res: Response): Promis
 	const githubInstallationId = req.params.installationId;
 	const jiraHost = req.params.jiraHost;
 
+	//TODO: ARC-1619 Maybe need to fix this and put it into the path
+	//Not doing it now as it might break pollinator if it use this api
+	const { gitHubAppIdStr } = req.query;
+	const gitHubAppId = parseInt(gitHubAppIdStr as string) || undefined
+
 	if (!jiraHost || !githubInstallationId) {
 		const msg = "Missing Jira Host or Installation ID";
 		req.log.warn({ req, res }, msg);
@@ -15,7 +20,8 @@ export const ApiInstallationDelete = async (req: Request, res: Response): Promis
 
 	const subscription = await Subscription.getSingleInstallation(
 		jiraHost,
-		Number(githubInstallationId)
+		Number(githubInstallationId),
+		gitHubAppId
 	);
 
 	if (!subscription) {
@@ -25,7 +31,7 @@ export const ApiInstallationDelete = async (req: Request, res: Response): Promis
 	}
 
 	try {
-		const jiraClient = await getJiraClient(jiraHost, Number(githubInstallationId), req.log);
+		const jiraClient = await getJiraClient(jiraHost, Number(githubInstallationId), req.log, gitHubAppId);
 		req.log.info({ jiraHost, githubInstallationId }, `Deleting DevInfo`);
 		await jiraClient.devinfo.installation.delete(githubInstallationId);
 		res.status(200).send(`DevInfo deleted for jiraHost: ${jiraHost} githubInstallationId: ${githubInstallationId}`);

--- a/src/routes/api/installation/api-installation-get.ts
+++ b/src/routes/api/installation/api-installation-get.ts
@@ -13,7 +13,7 @@ export const ApiInstallationGet = async (req: Request, res: Response): Promise<v
 	//TODO: ARC-1619 Maybe need to fix this and put it into the path
 	//Not doing it now as it might break pollinator if it use this api
 	const { gitHubAppIdStr } = req.query;
-	if(!gitHubAppId) {
+	if (!gitHubAppId) {
 		//TODO: ARC-1619: I don't think the gitHubAppId presents in the res.locals in this api router, but not fixing it in this PR
 		//so temporary patch it as to get it from query string
 		gitHubAppId = parseInt(gitHubAppIdStr as string) || undefined;

--- a/src/routes/api/installation/api-installation-get.ts
+++ b/src/routes/api/installation/api-installation-get.ts
@@ -7,17 +7,8 @@ import { createAppClient } from "~/src/util/get-github-client-config";
 export const ApiInstallationGet = async (req: Request, res: Response): Promise<void> => {
 	const { installationId } = req.params;
 	const { client, jiraHost } = res.locals;
-	let { gitHubAppId } = res.locals;
+	const { gitHubAppId } = res.locals;
 	const gitHubAppClient = await createAppClient(req.log, jiraHost, gitHubAppId);
-
-	//TODO: ARC-1619 Maybe need to fix this and put it into the path
-	//Not doing it now as it might break pollinator if it use this api
-	const { gitHubAppIdStr } = req.query;
-	if (!gitHubAppId) {
-		//TODO: ARC-1619: I don't think the gitHubAppId presents in the res.locals in this api router, but not fixing it in this PR
-		//so temporary patch it as to get it from query string
-		gitHubAppId = parseInt(gitHubAppIdStr as string) || undefined;
-	}
 
 	try {
 		const subscriptions = await Subscription.getAllForInstallation(Number(installationId), gitHubAppId);

--- a/src/routes/api/installation/api-installation-get.ts
+++ b/src/routes/api/installation/api-installation-get.ts
@@ -6,11 +6,21 @@ import { createAppClient } from "~/src/util/get-github-client-config";
 
 export const ApiInstallationGet = async (req: Request, res: Response): Promise<void> => {
 	const { installationId } = req.params;
-	const { client, jiraHost, gitHubAppId } = res.locals;
+	const { client, jiraHost } = res.locals;
+	let { gitHubAppId } = res.locals;
 	const gitHubAppClient = await createAppClient(req.log, jiraHost, gitHubAppId);
 
+	//TODO: ARC-1619 Maybe need to fix this and put it into the path
+	//Not doing it now as it might break pollinator if it use this api
+	const { gitHubAppIdStr } = req.query;
+	if(!gitHubAppId) {
+		//TODO: ARC-1619: I don't think the gitHubAppId presents in the res.locals in this api router, but not fixing it in this PR
+		//so temporary patch it as to get it from query string
+		gitHubAppId = parseInt(gitHubAppIdStr as string) || undefined;
+	}
+
 	try {
-		const subscriptions = await Subscription.getAllForInstallation(Number(installationId));
+		const subscriptions = await Subscription.getAllForInstallation(Number(installationId), gitHubAppId);
 
 		if (!subscriptions.length) {
 			res.sendStatus(404);

--- a/src/routes/api/installation/api-installation-sync-post.ts
+++ b/src/routes/api/installation/api-installation-sync-post.ts
@@ -7,11 +7,16 @@ export const ApiInstallationSyncPost = async (req: Request, res: Response): Prom
 	req.log.debug({ body: req.body }, "Sync body");
 	const { jiraHost, resetType } = req.body;
 
+	//TODO: ARC-1619 Maybe need to fix this and put it into the path
+	//Not doing it now as it might break pollinator if it use this api
+	const { gitHubAppIdStr } = req.query;
+
 	try {
 		req.log.info(jiraHost, githubInstallationId);
 		const subscription = await Subscription.getSingleInstallation(
 			jiraHost,
-			githubInstallationId
+			githubInstallationId,
+			parseInt(gitHubAppIdStr as string) || undefined
 		);
 
 		if (!subscription) {

--- a/src/routes/api/installation/api-installation-sync-post.ts
+++ b/src/routes/api/installation/api-installation-sync-post.ts
@@ -7,16 +7,12 @@ export const ApiInstallationSyncPost = async (req: Request, res: Response): Prom
 	req.log.debug({ body: req.body }, "Sync body");
 	const { jiraHost, resetType } = req.body;
 
-	//TODO: ARC-1619 Maybe need to fix this and put it into the path
-	//Not doing it now as it might break pollinator if it use this api
-	const { gitHubAppIdStr } = req.query;
-
 	try {
 		req.log.info(jiraHost, githubInstallationId);
 		const subscription = await Subscription.getSingleInstallation(
 			jiraHost,
 			githubInstallationId,
-			parseInt(gitHubAppIdStr as string) || undefined
+			undefined
 		);
 
 		if (!subscription) {

--- a/src/routes/api/installation/api-installation-syncstate-get.ts
+++ b/src/routes/api/installation/api-installation-syncstate-get.ts
@@ -7,10 +7,6 @@ export const ApiInstallationSyncstateGet = async (req: Request, res: Response): 
 	const githubInstallationId = Number(req.params.installationId);
 	const jiraHost = req.params.jiraHost;
 
-	//TODO: ARC-1619 Maybe need to fix this and put it into the path
-	//Not doing it now as it might break pollinator if it use this api
-	const { gitHubAppIdStr } = req.query;
-
 	if (!jiraHost || !githubInstallationId) {
 		const msg = "Missing Jira Host or Installation ID";
 		req.log.warn({ req, res }, msg);
@@ -22,7 +18,7 @@ export const ApiInstallationSyncstateGet = async (req: Request, res: Response): 
 		const subscription = await Subscription.getSingleInstallation(
 			jiraHost,
 			githubInstallationId,
-			parseInt(gitHubAppIdStr as string) || undefined
+			undefined
 		);
 
 		if (!subscription) {

--- a/src/routes/api/installation/api-installation-syncstate-get.ts
+++ b/src/routes/api/installation/api-installation-syncstate-get.ts
@@ -7,6 +7,10 @@ export const ApiInstallationSyncstateGet = async (req: Request, res: Response): 
 	const githubInstallationId = Number(req.params.installationId);
 	const jiraHost = req.params.jiraHost;
 
+	//TODO: ARC-1619 Maybe need to fix this and put it into the path
+	//Not doing it now as it might break pollinator if it use this api
+	const { gitHubAppIdStr } = req.query;
+
 	if (!jiraHost || !githubInstallationId) {
 		const msg = "Missing Jira Host or Installation ID";
 		req.log.warn({ req, res }, msg);
@@ -17,7 +21,8 @@ export const ApiInstallationSyncstateGet = async (req: Request, res: Response): 
 	try {
 		const subscription = await Subscription.getSingleInstallation(
 			jiraHost,
-			githubInstallationId
+			githubInstallationId,
+			parseInt(gitHubAppIdStr as string) || undefined
 		);
 
 		if (!subscription) {

--- a/src/routes/github/configuration/github-configuration-get.ts
+++ b/src/routes/github/configuration/github-configuration-get.ts
@@ -53,7 +53,7 @@ const mergeByLogin = (installationsWithAdmin: InstallationWithAdmin[], connected
 const installationConnectedStatus = async (
 	jiraHost: string,
 	installationsWithAdmin: InstallationWithAdmin[],
-	reqLog: Logger,
+	log: Logger,
 	gitHubAppId: number | undefined
 ): Promise<MergedInstallation[]> => {
 	const subscriptions = await Subscription.getAllForHost(jiraHost, gitHubAppId);

--- a/src/routes/github/configuration/github-configuration-get.ts
+++ b/src/routes/github/configuration/github-configuration-get.ts
@@ -103,7 +103,7 @@ const getInstallationsWithAdmin = async (
 	}));
 };
 
-const removeFailedConnectionsFromDb = async (req: Request, installations: InstallationResults, jiraHost: string): Promise<void> => {
+const removeFailedConnectionsFromDb = async (req: Request, installations: InstallationResults, jiraHost: string, gitHubAppId: number | undefined): Promise<void> => {
 	await Promise.all(installations.rejected
 		// Only uninstall deleted installations
 		.filter(failedInstallation => failedInstallation.deleted)
@@ -111,7 +111,8 @@ const removeFailedConnectionsFromDb = async (req: Request, installations: Instal
 			try {
 				await Subscription.uninstall({
 					installationId: failedInstallation.id,
-					host: jiraHost
+					host: jiraHost,
+					gitHubAppId
 				});
 			} catch (err) {
 				const deleteSubscriptionError = `Failed to delete subscription: ${err}`;
@@ -160,7 +161,7 @@ export const GithubConfigurationGet = async (req: Request, res: Response, next: 
 	// Remove any failed installations before a user attempts to reconnect
 	const subscriptions = await Subscription.getAllForHost(jiraHost);
 	const allInstallations = await getInstallations(subscriptions, log, gitHubAppId);
-	await removeFailedConnectionsFromDb(req, allInstallations, jiraHost);
+	await removeFailedConnectionsFromDb(req, allInstallations, jiraHost, gitHubAppId);
 
 	req.log.debug(`removed failed installations`);
 

--- a/src/routes/github/configuration/github-configuration-get.ts
+++ b/src/routes/github/configuration/github-configuration-get.ts
@@ -54,7 +54,7 @@ const installationConnectedStatus = async (
 	jiraHost: string,
 	installationsWithAdmin: InstallationWithAdmin[],
 	reqLog: Logger,
-	gitHubAppId?: number
+	gitHubAppId: number | undefined
 ): Promise<MergedInstallation[]> => {
 	const subscriptions = await Subscription.getAllForHost(jiraHost);
 	const installationsWithSubscriptions = await getInstallations(subscriptions, reqLog, gitHubAppId);
@@ -69,7 +69,7 @@ const getInstallationsWithAdmin = async (
 	login: string,
 	installations: Octokit.AppsListInstallationsForAuthenticatedUserResponseInstallationsItem[] = [],
 	jiraHost: string,
-	gitHubAppId?: number
+	gitHubAppId: number | undefined
 ): Promise<InstallationWithAdmin[]> => {
 	return await Promise.all(installations.map(async (installation) => {
 		const errors: Error[] = [];

--- a/src/routes/github/subscription/github-subscription-delete.ts
+++ b/src/routes/github/subscription/github-subscription-delete.ts
@@ -38,7 +38,7 @@ export const GithubSubscriptionDelete = async (req: Request, res: Response): Pro
 			return;
 		}
 		try {
-			const subscription = await Subscription.getSingleInstallation(jiraHost, gitHubInstallationId);
+			const subscription = await Subscription.getSingleInstallation(jiraHost, gitHubInstallationId, gitHubAppId);
 			if (!subscription) {
 				res.status(404).send("Cannot find Subscription.");
 				return;

--- a/src/routes/github/subscription/github-subscription-get.ts
+++ b/src/routes/github/subscription/github-subscription-get.ts
@@ -26,7 +26,7 @@ export const GithubSubscriptionGet = async (req: Request, res: Response, next: N
 		const { data: installation } = await gitHubAppClient.getInstallation(gitHubInstallationId);
 
 		// get all subscriptions from the database for this installation ID
-		const subscriptions = await Subscription.getAllForInstallation(gitHubInstallationId);
+		const subscriptions = await Subscription.getAllForInstallation(gitHubInstallationId, gitHubAppId);
 
 		// Only show the page if the logged in user is an admin of this installation
 		if (await isUserAdminOfOrganization(

--- a/src/routes/jira/jira-delete.ts
+++ b/src/routes/jira/jira-delete.ts
@@ -41,7 +41,7 @@ export const JiraDelete = async (req: Request, res: Response): Promise<void> => 
 		return;
 	}
 
-	const jiraClient = await getJiraClient(jiraHost, gitHubInstallationId, req.log, gitHubAppId);
+	const jiraClient = await getJiraClient(jiraHost, gitHubInstallationId, gitHubAppId, req.log);
 	await jiraClient.devinfo.installation.delete(gitHubInstallationId);
 	await subscription.destroy();
 

--- a/src/routes/jira/jira-get.test.ts
+++ b/src/routes/jira/jira-get.test.ts
@@ -104,7 +104,7 @@ describe("Jira Configuration Suite", () => {
 		});
 
 		it("should return no success or failed connections if no subscriptions given", async () => {
-			expect(await getInstallations([], logger)).toEqual({
+			expect(await getInstallations([], logger, undefined)).toEqual({
 				fulfilled: [],
 				rejected: [],
 				total: 0
@@ -116,7 +116,7 @@ describe("Jira Configuration Suite", () => {
 				.get(`/app/installations/${sub.gitHubInstallationId}`)
 				.reply(200, singleInstallation);
 
-			expect(await getInstallations([sub], logger)).toMatchObject({
+			expect(await getInstallations([sub], logger, undefined)).toMatchObject({
 				fulfilled: [{
 					id: sub.gitHubInstallationId,
 					syncStatus: null,
@@ -134,7 +134,7 @@ describe("Jira Configuration Suite", () => {
 				.get(`/app/installations/${sub.gitHubInstallationId}`)
 				.reply(404, failedInstallation);
 
-			expect(await getInstallations([sub], logger)).toMatchObject({
+			expect(await getInstallations([sub], logger, undefined)).toMatchObject({
 				fulfilled: [],
 				rejected: [{
 					error: {
@@ -161,7 +161,7 @@ describe("Jira Configuration Suite", () => {
 				.get(`/app/installations/${failedSub.gitHubInstallationId}`)
 				.reply(404, failedInstallation);
 
-			expect(await getInstallations([sub, failedSub], logger)).toMatchObject({
+			expect(await getInstallations([sub, failedSub], logger, undefined)).toMatchObject({
 				fulfilled: [{
 					id: sub.gitHubInstallationId,
 					syncStatus: null,
@@ -196,7 +196,7 @@ describe("Jira Configuration Suite", () => {
 				.get(`/app/installations/${failedSub.gitHubInstallationId}`)
 				.reply(404, failedInstallation);
 
-			expect(await getInstallations([sub, failedSub], logger)).toMatchObject({
+			expect(await getInstallations([sub, failedSub], logger, undefined)).toMatchObject({
 				fulfilled: [],
 				rejected: [
 					{
@@ -252,7 +252,7 @@ describe("Jira Configuration Suite", () => {
 				.get(`/app/installations/${sub.gitHubInstallationId}`)
 				.reply(200, singleInstallation);
 
-			expect(await getInstallations([sub], logger)).toMatchObject({
+			expect(await getInstallations([sub], logger, undefined)).toMatchObject({
 				fulfilled: [{
 					id: sub.gitHubInstallationId,
 					syncStatus: null,

--- a/src/routes/jira/jira-get.ts
+++ b/src/routes/jira/jira-get.ts
@@ -49,7 +49,7 @@ const mapSyncStatus = (syncStatus: SyncStatus = SyncStatus.PENDING): string => {
 	}
 };
 
-export const getInstallations = async (subscriptions: Subscription[], log: Logger, gitHubAppId?: number): Promise<InstallationResults> => {
+export const getInstallations = async (subscriptions: Subscription[], log: Logger, gitHubAppId: number | undefined): Promise<InstallationResults> => {
 	const installations = await Promise.allSettled(subscriptions.map((sub) => getInstallation(sub, log, gitHubAppId)));
 	// Had to add "unknown" in between type as lodash types is incorrect for
 	const connections = groupBy(installations, "status") as unknown as { fulfilled: PromiseFulfilledResult<AppInstallation>[], rejected: PromiseRejectedResult[] };
@@ -62,7 +62,7 @@ export const getInstallations = async (subscriptions: Subscription[], log: Logge
 	};
 };
 
-const getInstallation = async (subscription: Subscription, log: Logger, gitHubAppId?: number): Promise<AppInstallation> => {
+const getInstallation = async (subscription: Subscription, log: Logger, gitHubAppId: number | undefined): Promise<AppInstallation> => {
 	const { jiraHost, gitHubInstallationId } = subscription;
 	const gitHubAppClient = await createAppClient(log, jiraHost, gitHubAppId);
 	const gitHubProduct = getCloudOrServerFromGitHubAppId(gitHubAppId);

--- a/src/routes/jira/jira-get.ts
+++ b/src/routes/jira/jira-get.ts
@@ -50,7 +50,7 @@ const mapSyncStatus = (syncStatus: SyncStatus = SyncStatus.PENDING): string => {
 };
 
 export const getInstallations = async (subscriptions: Subscription[], log: Logger, gitHubAppId: number | undefined): Promise<InstallationResults> => {
-	const installations = await Promise.allSettled(subscriptions.map((sub) => getInstallation(sub, log, gitHubAppId)));
+	const installations = await Promise.allSettled(subscriptions.map((sub) => getInstallation(sub, gitHubAppId, log)));
 	// Had to add "unknown" in between type as lodash types is incorrect for
 	const connections = groupBy(installations, "status") as unknown as { fulfilled: PromiseFulfilledResult<AppInstallation>[], rejected: PromiseRejectedResult[] };
 	const fulfilled = connections.fulfilled?.map(v => v.value) || [];
@@ -62,7 +62,7 @@ export const getInstallations = async (subscriptions: Subscription[], log: Logge
 	};
 };
 
-const getInstallation = async (subscription: Subscription, log: Logger, gitHubAppId: number | undefined): Promise<AppInstallation> => {
+const getInstallation = async (subscription: Subscription, gitHubAppId: number | undefined, log: Logger): Promise<AppInstallation> => {
 	const { jiraHost, gitHubInstallationId } = subscription;
 	const gitHubAppClient = await createAppClient(log, jiraHost, gitHubAppId);
 	const gitHubProduct = getCloudOrServerFromGitHubAppId(gitHubAppId);

--- a/src/routes/jira/sync/jira-sync-post.test.ts
+++ b/src/routes/jira/sync/jira-sync-post.test.ts
@@ -28,7 +28,8 @@ describe("sync", () => {
 		await Subscription.install({
 			installationId: installationIdForCloud,
 			host: jiraHost,
-			clientKey: installation.clientKey
+			clientKey: installation.clientKey,
+			gitHubAppId: undefined
 		});
 		gitHubServerApp = await GitHubServerApp.install({
 			uuid: newUUID(),

--- a/src/sqs/backfill-discovery.test.ts
+++ b/src/sqs/backfill-discovery.test.ts
@@ -77,7 +77,7 @@ describe("Discovery Queue Test - GitHub Client", () => {
 		mockGitHubReposResponses();
 		await sqsQueues.backfill.sendMessage({ installationId: TEST_INSTALLATION_ID, jiraHost });
 		await waitUntil(async () => {
-			const subscription = await Subscription.getSingleInstallation(jiraHost, TEST_INSTALLATION_ID);
+			const subscription = await Subscription.getSingleInstallation(jiraHost, TEST_INSTALLATION_ID, undefined);
 			expect(subscription).toBeTruthy();
 			const states = await RepoSyncState.findAllFromSubscription(subscription!);
 			expect(states?.length).toBe(2);

--- a/src/sqs/sqs.types.ts
+++ b/src/sqs/sqs.types.ts
@@ -164,12 +164,12 @@ export type PushQueueMessagePayload = {
 }
 
 export type GitHubAppConfig = {
-	gitHubAppId?: number,
+	gitHubAppId: number | undefined,
 	appId: number,
 	clientId: string,
 	gitHubBaseUrl: string,
 	gitHubApiUrl: string,
-	uuid?: string,
+	uuid: string | undefined,
 	//gitHubClientSecret: string,
 	//webhookSecret: string,
 	//privateKey: string

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -191,8 +191,8 @@ const doProcessInstallation = async (data: BackfillMessagePayload, sentry: Hub, 
 	const jiraClient = await getJiraClient(
 		subscription.jiraHost,
 		gitHubInstallationId,
-		logger,
-		data.gitHubAppConfig?.gitHubAppId
+		data.gitHubAppConfig?.gitHubAppId,
+		logger
 	);
 
 	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraHost, logger, data.gitHubAppConfig?.gitHubAppId);

--- a/src/sync/pull-requests.test.ts
+++ b/src/sync/pull-requests.test.ts
@@ -21,7 +21,8 @@ describe.skip("sync/pull-request", () => {
 		await Subscription.install({
 			installationId: 12345678,
 			host: jiraHost,
-			clientKey: "client-key"
+			clientKey: "client-key",
+			gitHubAppId: undefined
 		});
 
 		mockSystemTime(12345678);

--- a/src/sync/sync-utils.test.ts
+++ b/src/sync/sync-utils.test.ts
@@ -19,7 +19,8 @@ describe("findOrStartSync", () => {
 				subscription = await Subscription.install({
 					installationId: JIRA_INSTALLATION_ID,
 					host: jiraHost,
-					clientKey: JIRA_CLIENT_KEY
+					clientKey: JIRA_CLIENT_KEY,
+					gitHubAppId: undefined
 				});
 			});
 			it("should send cloud gitHubAppConfig to msg queue", async () => {

--- a/src/transforms/push.ts
+++ b/src/transforms/push.ts
@@ -116,8 +116,8 @@ export const processPush = async (github: GitHubInstallationClient, payload: Pus
 		const jiraClient = await getJiraClient(
 			subscription.jiraHost,
 			gitHubInstallationId,
-			log,
-			payload.gitHubAppConfig?.gitHubAppId
+			payload.gitHubAppConfig?.gitHubAppId,
+			log
 		);
 
 		const commits: JiraCommit[] = await Promise.all(

--- a/src/transforms/transform-deployment.test.ts
+++ b/src/transforms/transform-deployment.test.ts
@@ -182,7 +182,7 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 			}
 			);
 
-		const jiraPayload = await transformDeployment(githubClient, deployment_status.payload as any, jiraHost, getLogger("deploymentLogger"));
+		const jiraPayload = await transformDeployment(githubClient, deployment_status.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
 
 		expect(jiraPayload).toMatchObject({
 			deployments: [{
@@ -287,7 +287,7 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 			}
 			);
 
-		const jiraPayload = await transformDeployment(githubClient, deployment_status.payload as any, jiraHost, getLogger("deploymentLogger"));
+		const jiraPayload = await transformDeployment(githubClient, deployment_status.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
 
 		// make expected issue id array
 		const expectedIssueIds = [...Array(500).keys()].map(number => "ABC-" + number);
@@ -402,7 +402,7 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 			expect.anything()
 		).mockResolvedValue(mockConfig);
 
-		const jiraPayload = await transformDeployment(githubClient, deployment_status_staging.payload as any, jiraHost, getLogger("deploymentLogger"));
+		const jiraPayload = await transformDeployment(githubClient, deployment_status_staging.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
 		expect(jiraPayload?.deployments[0].environment.type).toBe("development");
 	});
 
@@ -486,7 +486,7 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 			expect.anything()
 		).mockResolvedValue(mockConfig);
 
-		const jiraPayload = await transformDeployment(githubClient, deployment_status_staging.payload as any, jiraHost, getLogger("deploymentLogger"));
+		const jiraPayload = await transformDeployment(githubClient, deployment_status_staging.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
 		expect(jiraPayload?.deployments[0].environment.type).toBe("unmapped");
 	});
 

--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -205,7 +205,7 @@ const mapJiraIssueIdsAndCommitsToAssociationArray = (
 	return associations;
 };
 
-export const transformDeployment = async (githubInstallationClient: GitHubInstallationClient, payload: WebhookPayloadDeploymentStatus, jiraHost: string, logger: Logger): Promise<JiraDeploymentData | undefined> => {
+export const transformDeployment = async (githubInstallationClient: GitHubInstallationClient, payload: WebhookPayloadDeploymentStatus, jiraHost: string, logger: Logger, gitHubAppId: number | undefined): Promise<JiraDeploymentData | undefined> => {
 	const deployment = payload.deployment;
 	const deployment_status = payload.deployment_status;
 	const { data: { commit: { message } } } = await githubInstallationClient.getCommit(payload.repository.owner.login, payload.repository.name, deployment.sha);
@@ -234,7 +234,7 @@ export const transformDeployment = async (githubInstallationClient: GitHubInstal
 	let config: Config | undefined;
 
 	if (await booleanFlag(BooleanFlags.CONFIG_AS_CODE, false, jiraHost)) {
-		const subscription = await Subscription.getSingleInstallation(jiraHost, githubInstallationClient.githubInstallationId.installationId);
+		const subscription = await Subscription.getSingleInstallation(jiraHost, githubInstallationClient.githubInstallationId.installationId, gitHubAppId);
 		if (subscription){
 			config = await getRepoConfig(subscription, payload.repository.id);
 		} else {

--- a/src/util/get-github-client-config.ts
+++ b/src/util/get-github-client-config.ts
@@ -83,7 +83,7 @@ export async function createAppClient(logger: Logger, jiraHost: string, gitHubAp
  * Factory function to create a GitHub client that authenticates as the installation of our GitHub app to get
  * information specific to an organization.
  */
-export async function createInstallationClient(gitHubInstallationId: number, jiraHost: string, logger: Logger, gitHubAppId?: number | undefined): Promise<GitHubInstallationClient> {
+export async function createInstallationClient(gitHubInstallationId: number, jiraHost: string, logger: Logger, gitHubAppId: number | undefined): Promise<GitHubInstallationClient> {
 
 	if (await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)) {
 		const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);

--- a/src/util/get-github-client-config.ts
+++ b/src/util/get-github-client-config.ts
@@ -46,7 +46,7 @@ export const getGitHubClientConfigFromAppId = async (gitHubAppId: number | undef
 		};
 	}
 	// cloud config
-	const privateKey = await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)? await keyLocator(): PrivateKey.findPrivateKey();
+	const privateKey = await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)? await keyLocator(undefined): PrivateKey.findPrivateKey();
 	if (!privateKey) {
 		throw new Error("Private key not found for github cloud");
 	}

--- a/test/setup/setup.ts
+++ b/test/setup/setup.ts
@@ -129,22 +129,8 @@ beforeAll(async () => {
 	redis.disconnect();
 });
 
-const globalGitHubAppConfig = {
-	gitHubAppId: -1, //TODO: ARC-1619, this value is not known yet.
-	appId: 1,
-	uuid: "c97806fc-c433-4ad5-b569-bf5191590be2",
-	hostname: "http://test-server.com",
-	gitHubBaseUrl: "http://test-server.com",
-	gitHubApiUrl: "https://api.test-server.com",
-	clientId: "lvl.128ejqe91n2e128",
-	gitHubClientSecret: "secretone",
-	webhookSecret: "secrettwo",
-	privateKey: "secretthree"
-};
-
 beforeEach(() => {
 	global.jiraHost = process.env.ATLASSIAN_URL || `https://${process.env.INSTANCE_NAME}.atlassian.net`;
-	global.gitHubAppConfig = globalGitHubAppConfig;
 	global.jiraStaginHost = process.env.ATLASSIAN_URL?.replace(".atlassian.net", ".jira-dev.com") || `https://${process.env.INSTANCE_NAME}.jira-dev.com`;
 	global.jiraNock = nock(global.jiraHost);
 	global.jiraStagingNock = nock(global.jiraHost);

--- a/test/setup/setup.ts
+++ b/test/setup/setup.ts
@@ -130,6 +130,7 @@ beforeAll(async () => {
 });
 
 const globalGitHubAppConfig = {
+	gitHubAppId: -1, //TODO: ARC-1619, this value is not known yet.
 	appId: 1,
 	uuid: "c97806fc-c433-4ad5-b569-bf5191590be2",
 	hostname: "http://test-server.com",


### PR DESCRIPTION
**What's in this PR?**
Change many method signature from 

```javascript
someMethod(..., gitHubAppId?: number, ...)
```
to 
```javascript
someMethod(..., gitHubAppId: number | undefined, ...)
```

**Why**
To have more confident in the code that it is doing right thing (passing the gitHubAppId for GHES), I believe making the argument mandatory is better. In deed, I believe some bugs are found in this refactoring. 

In current code base, if the code that intends to support both `cloud` and `GHES`, but forgot the passing the `gitHubAppId`, can still pass the TS checking. I want to ensure that doesn't happen.

So calling bellow will fail
```javascript
Subscriptions.getAllForInstallation(gitHubIntallationId)
```

**Notes**
To ensure catching the bug by refactoring the code without making huge PR or introduce new bugs, I intentionally impl code with following guidelines:
1. First change `gitHubAppId?: number` to `gitHubAppId: number | undefined` by global find&replace
2. Do `tsc --watch` to compile and fix whatever failing the ts check
3. Try NOT to change code behaviour as best as I can (unless it is obvious bug, which is one of the purpose of this PR).
4. DID NOT refactoring any code structure, like merging options, putting the gitHubAppId in a better place, change payload structure to better accommodate the id, fixing any tech debt in the `gitHubServerMiddlware`, etc / blah / blah
5. There're some api routes missing the `gitHubAppId`. I think better way is to introduce it in the `path`, but DID NOT do that because I am afraid it will break the pollinator. Instead make it optional as query string.

**Added feature flags**
N/A

**Affected issues**  
ARC-1619

**How has this been tested?**  
unit test
stage [pollinator and manual: https://bitbucket.org/atlassian/github-for-jira-deployment/pipelines/results/5674]

**Whats Next?**
N/A
