### PR TITLE
Arc-1543 webhook metrics

### DIFF
--- a/src/github/branch.ts
+++ b/src/github/branch.ts
@@ -63,7 +63,8 @@ export const processBranch = async (
 		webhookReceivedDate.getTime(),
 		"create",
 		logger,
-		jiraResponse?.status
+		jiraResponse?.status,
+		gitHubAppId
 	);
 };
 
@@ -83,11 +84,13 @@ export const deleteBranchWebhookHandler = async (context: WebhookContext, jiraCl
 		payload.ref
 	);
 	const { webhookReceived, name, log } = context;
+	const gitHubAppId = context.gitHubAppConfig?.gitHubAppId;
 
 	webhookReceived && emitWebhookProcessedMetrics(
 		webhookReceived,
 		name,
 		log,
-		jiraResponse?.status
+		jiraResponse?.status,
+		gitHubAppId
 	);
 };

--- a/src/github/code-scanning-alert.ts
+++ b/src/github/code-scanning-alert.ts
@@ -21,12 +21,14 @@ export const codeScanningAlertWebhookHandler = async (context: WebhookContext, j
 
 	context.log.info(`Sending code scanning alert event as Remote Link to Jira: ${jiraClient.baseURL}`);
 	const result = await jiraClient.remoteLink.submit(jiraPayload);
+	const gitHubAppId = context.gitHubAppConfig?.gitHubAppId;
 
 	const webhookReceived = context.payload.webhookReceived;
 	webhookReceived && emitWebhookProcessedMetrics(
 		new Date(webhookReceived).getTime(),
 		"code_scanning_alert",
 		context.log,
-		result?.status
+		result?.status,
+		gitHubAppId
 	);
 };

--- a/src/github/deployment.ts
+++ b/src/github/deployment.ts
@@ -76,6 +76,7 @@ export const processDeployment = async (
 		webhookReceivedDate.getTime(),
 		"deployment_status",
 		logger,
-		result?.status
+		result?.status,
+		gitHubAppId
 	);
 };

--- a/src/github/issue-comment.ts
+++ b/src/github/issue-comment.ts
@@ -23,7 +23,8 @@ export const issueCommentWebhookHandler = async (
 	});
 
 	let linkifiedBody;
-	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraClient.baseURL, context.log, context.gitHubAppConfig?.gitHubAppId);
+	const gitHubAppId = context.gitHubAppConfig?.gitHubAppId;
+	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraClient.baseURL, context.log, gitHubAppId);
 
 	// TODO: need to create reusable function for unfurling
 	try {
@@ -54,6 +55,7 @@ export const issueCommentWebhookHandler = async (
 		webhookReceived,
 		name,
 		log,
-		githubResponse?.status
+		githubResponse?.status,
+		gitHubAppId
 	);
 };

--- a/src/github/issue.ts
+++ b/src/github/issue.ts
@@ -18,7 +18,8 @@ export const issueWebhookHandler = async (context: WebhookContext<WebhookPayload
 		jiraHost: jiraClient.baseURL
 	});
 
-	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraClient.baseURL, context.log, context.gitHubAppConfig?.gitHubAppId);
+	const gitHubAppId = context.gitHubAppConfig?.gitHubAppId;
+	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraClient.baseURL, context.log, gitHubAppId);
 
 	// TODO: need to create reusable function for unfurling
 	let linkifiedBody;
@@ -51,6 +52,7 @@ export const issueWebhookHandler = async (context: WebhookContext<WebhookPayload
 		webhookReceived,
 		name,
 		log,
-		githubResponse?.status
+		githubResponse?.status,
+		gitHubAppId
 	);
 };

--- a/src/github/pull-request.ts
+++ b/src/github/pull-request.ts
@@ -31,7 +31,8 @@ export const pullRequestWebhookHandler = async (context: WebhookContext, jiraCli
 		pullRequestId
 	});
 
-	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraClient.baseURL, context.log, context.gitHubAppConfig?.gitHubAppId);
+	const gitHubAppId = context.gitHubAppConfig?.gitHubAppId;
+	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraClient.baseURL, context.log, gitHubAppId);
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	let reviews: Octokit.PullsListReviewsResponse = [];
 	try {
@@ -92,7 +93,8 @@ export const pullRequestWebhookHandler = async (context: WebhookContext, jiraCli
 		webhookReceived,
 		name,
 		log,
-		jiraResponse?.status
+		jiraResponse?.status,
+		gitHubAppId
 	);
 };
 

--- a/src/github/repository.ts
+++ b/src/github/repository.ts
@@ -16,6 +16,7 @@ export const deleteRepository = async (context, jiraClient, _util, gitHubInstall
 		webhookReceived,
 		name,
 		log,
-		jiraResponse?.status
+		jiraResponse?.status,
+		context.gitHubAppConfig?.gitHubAppId
 	);
 };

--- a/src/github/workflow.ts
+++ b/src/github/workflow.ts
@@ -5,11 +5,14 @@ import { WebhookContext } from "../routes/github/webhook/webhook-context";
 
 export const workflowWebhookHandler = async (context: WebhookContext, jiraClient, _util, gitHubInstallationId: number): Promise<void> => {
 	const { payload, log: logger } = context;
+
 	context.log = context.log.child({
 		jiraHost: jiraClient.baseURL,
 		gitHubInstallationId
 	});
-	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraClient.baseURL, context.log, context.gitHubAppConfig?.gitHubAppId);
+
+	const gitHubAppId = context.gitHubAppConfig?.gitHubAppId;
+	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraClient.baseURL, context.log, gitHubAppId);
 	const jiraPayload = await transformWorkflow(gitHubInstallationClient, payload, logger);
 
 	if (!jiraPayload) {
@@ -29,6 +32,7 @@ export const workflowWebhookHandler = async (context: WebhookContext, jiraClient
 		webhookReceived,
 		name,
 		log,
-		jiraResponse?.status
+		jiraResponse?.status,
+		gitHubAppId
 	);
 };

--- a/src/transforms/push.ts
+++ b/src/transforms/push.ts
@@ -101,6 +101,8 @@ export const processPush = async (github: GitHubInstallationClient, payload: Pus
 
 	log.info("Processing push");
 
+	const gitHubAppId = payload.gitHubAppConfig?.gitHubAppId;
+
 	try {
 		const subscription = await Subscription.getSingleInstallation(
 			jiraHost,
@@ -117,7 +119,7 @@ export const processPush = async (github: GitHubInstallationClient, payload: Pus
 			subscription.jiraHost,
 			gitHubInstallationId,
 			log,
-			payload.gitHubAppConfig?.gitHubAppId
+			gitHubAppId
 		);
 
 		const commits: JiraCommit[] = await Promise.all(
@@ -191,7 +193,8 @@ export const processPush = async (github: GitHubInstallationClient, payload: Pus
 					webhookReceived,
 					"push",
 					log,
-					jiraResponse?.status
+					jiraResponse?.status,
+					gitHubAppId
 				);
 			} catch (err) {
 				log.warn({ err }, "Failed to send data to Jira");

--- a/src/util/webhook-utils.ts
+++ b/src/util/webhook-utils.ts
@@ -2,24 +2,16 @@ import { statsd }  from "config/statsd";
 import { metricWebhooks } from "config/metric-names";
 import Logger from "bunyan";
 import { getLogger } from "config/logger";
+import { getCloudOrServerFromGitHubAppId } from "utils/get-cloud-or-server";
 
 export const getCurrentTime = () => Date.now();
 
-/**
- * Emits metrics for successfully processed webhook. These metrics include:
- *  - Webhook processing duration histogram
- *  - Processed webhooks counter
- *
- * @param webhookReceivedTime time when GitHub for Jira app received a webhook from GitHub
- * @param webhookName name of the webhook (type)
- * @param logger logger for the function logs
- * @param status http response code if applicable to this webhook type
- */
 export const emitWebhookProcessedMetrics = (
 	webhookReceivedTime: number,
 	webhookName: string,
 	logger: Logger = getLogger("webhook-metrics"),
-	status?: number
+	status?: number,
+	gitHubAppId?: number
 ): number | undefined | void => {
 	const currentTime = getCurrentTime();
 
@@ -34,9 +26,12 @@ export const emitWebhookProcessedMetrics = (
 				`Webhook processed in ${timeToProcessWebhookEvent} milliseconds`
 			);
 
+			const gitHubProduct = getCloudOrServerFromGitHubAppId(gitHubAppId);
+
 			const tags = {
 				name: webhookName,
-				status: status?.toString() || "none"
+				status: status?.toString() || "none",
+				gitHubProduct
 			};
 
 			statsd.increment(metricWebhooks.webhookProcessed, tags);

--- a/src/util/webhooks.test.ts
+++ b/src/util/webhooks.test.ts
@@ -42,7 +42,8 @@ describe("Webhooks suite", () => {
 				{
 					gsd_histogram: "1000_10000_30000_60000_120000_300000_600000_3000000",
 					name: "workflow_run",
-					status: "202"
+					status: "202",
+					gitHubProduct: "cloud"
 				}
 			);
 
@@ -52,7 +53,8 @@ describe("Webhooks suite", () => {
 				{
 					gsd_histogram: "1000_10000_30000_60000_120000_300000_600000_3000000",
 					name: "workflow_run",
-					status: "202"
+					status: "202",
+					gitHubProduct: "cloud"
 				}
 			);
 		});


### PR DESCRIPTION
**What's in this PR?**
Passing gitHubAppId to emitWebhookProcessedMetrics so we can pass the gitHubProduct tag (cloud/server).

**Why**
So we can update our charts to compare cloud/server.

**Affected issues**  
ARC-1543

**Whats Next?**
Updating the chart/s in our metrics.