### PR TITLE
ARC-1615 - Nits and Frogs - App selection screen

### DIFF
--- a/static/js/jira-select-card-option.js
+++ b/static/js/jira-select-card-option.js
@@ -55,13 +55,7 @@ $(document).ready(function() {
 	$(".jiraAppCreation__actionBtn").click(function (event) {
 		event.preventDefault();
 
-		if (selectedVersion === "automatic") {
-			AP.context.getToken(function(token) {
-				const child = openChildWindow("/session?ghRedirect=to&autoApp=1&baseUrl=" + gitHubServerBaseUrl);
-				child.window.jiraHost = jiraHost;
-				child.window.jwt = token;
-			});
-		} else {
+		if (selectedVersion === "manual") {
 			AP.navigator.go(
 				'addonmodule',
 				{
@@ -69,6 +63,12 @@ $(document).ready(function() {
 					customData: { serverUrl: gitHubServerBaseUrl }
 				}
 			);
+		} else {
+			AP.context.getToken(function(token) {
+				const child = openChildWindow("/session?ghRedirect=to&autoApp=1&baseUrl=" + gitHubServerBaseUrl);
+				child.window.jiraHost = jiraHost;
+				child.window.jwt = token;
+			});
 		}
 	});
 });


### PR DESCRIPTION
**What's in this PR?**
- Flipped the condition to check for manual first instead of automatic.

**Why**
- In the view, by default automatic app is selected, but nothing has been selected yet. So, when the user slicks on the **Create** button, the selected option is undefined, which was just going to the `else` part. 
- So, went with the quick solution by simply flipping the condition to check manual first.

**How has this been tested?**  
- Local
