### PR TITLE
ARC-1621: increase max_client_conn for pgbouncer

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -17,7 +17,7 @@ compose:
                                       # Normal business:
                                       #   (5 web servers + 3 workers) * 15 pool size = 120 connections
       PGBOUNCER_SERVER_IDLE_TIMEOUT: 60
-      PGBOUNCER_MAX_CLIENT_CONN: 2000
+      PGBOUNCER_MAX_CLIENT_CONN: 10000
   microservice:
     image: ${DOCKER_IMAGE_NAME}
     tag: ${DOCKER_IMAGE_TAG}


### PR DESCRIPTION
**What's in this PR?**

Increasing the number of allowed connections to pgbouncer

**Why**

Because it refuses connections in peak hours, which causes broken syncs: SequelizeConnectionError strongly correlates with "no more connections allowed (max_client_conn)" from pgbouncer (check the ticket)

**Added feature flags**

**Affected issues**  
ARC-1621

**How has this been tested?**  
We will check the effect in prod :cowboy:

**Whats Next?**
:susp: