### PR TITLE
ARC-1638 - Expand github apps by default for GHE server

### DIFF
--- a/views/jira-configuration-new.hbs
+++ b/views/jira-configuration-new.hbs
@@ -205,7 +205,7 @@
                   <div class="jiraConfiguration__enterpriseConnections">
                     <div class="jiraConfiguration__enterpriseApplicationTitle">APPLICATIONS</div>
                     {{#each server.applications as |app|}}
-                      <details>
+                      <details open>
                         <summary class="jiraConfiguration__collapsibleHeader jiraConfiguration__table__cell__settings">
                           <div>
                             <span class="aui-icon aui-iconfont-chevron-right"></span>


### PR DESCRIPTION
**What's in this PR?**
- The collapsibles are all opened by default in Jira Config page.

**Why**
- People's demand

**How has this been tested?**  
- Locally
