### PR TITLE
DO NOT MERGE: ARC-1620 doc links (redo)

### DIFF
--- a/static/js/jira-manual-app-creation.js
+++ b/static/js/jira-manual-app-creation.js
@@ -21,7 +21,14 @@ const openChildWindow = (url) => {
 
 const handleFormErrors = (isUpdate) => {
 	$(".jiraManualAppCreation__serverError").show();
-	$(".errorMessageBox__message").empty().append("Please make sure all the details you entered are correct.");
+	$(".errorMessageBox__message")
+		.empty()
+		.append("Please make sure all the details you entered are correct.")
+		.append(
+			'<div class="jiraManualAppCreation__serverError__linkContainer">' +
+			'	<a href="https://support.atlassian.com/jira-cloud-administration/docs/manually-create-a-github-app" target="_blank">Learn more</a>' +
+			'</div>'
+		);
 	const errorTitle = ".errorMessageBox__title";
 
 	isUpdate
@@ -155,5 +162,3 @@ $("#jiraManualAppCreation__clearUploadedFile").click(() => {
 	$(".jiraManualAppCreation__formFileInput").attr("data-aui-validation-state", "unvalidated");
 	$(".jiraManualAppCreation__formFileDropArea .error").remove();
 });
-
-

--- a/static/js/jira-server-url.js
+++ b/static/js/jira-server-url.js
@@ -9,8 +9,12 @@ AJS.formValidation.register(['ghe-url'], (field) => {
 		const { protocol, hostname } = new URL(inputURL);
 
 		if (!/^https?:$/.test(protocol)) {
-			// TODO: add URL for this
-			field.invalidate(AJS.format('The entered URL is not valid. <a href="#">Learn more</a>.'));
+			field.invalidate(AJS.format(
+				'The entered URL is not valid. ' +
+				'<a href="https://support.atlassian.com/jira-cloud-administration/docs/integrate-with-github/#How-the-GitHub-for-Jira-app-fetches-data" target="_blank">' +
+				'Learn more' +
+				'</a>.'
+			));
 		}
 		else if (GITHUB_CLOUD.includes(hostname)) {
 			field.invalidate(AJS.format('The entered URL is a GitHub Cloud site. <a href="/session/github/configuration&ghRedirect=to" target="_blank">Connect a GitHub Cloud site<a/>.'));
@@ -18,11 +22,11 @@ AJS.formValidation.register(['ghe-url'], (field) => {
 			field.validate();
 		}
 	} catch (e) {
-    if (!inputURL.trim().length) {
-      field.invalidate(AJS.format('This is a required field.'));
-    } else {
-      field.invalidate(AJS.format('The entered URL is not valid. Learn more.'));
-    }
+		if (!inputURL.trim().length) {
+			field.invalidate(AJS.format('This is a required field.'));
+		} else {
+			field.invalidate(AJS.format('The entered URL is not valid. Learn more.'));
+		}
 	}
 });
 
@@ -93,7 +97,7 @@ const verifyGitHubServerUrl = (gheServerURL) => {
 				} else {
 					mapErrorCode(data.errors[0].code);
 				}
-      }
+			}
 		);
 	});
 };

--- a/views/jira-manual-app-creation.hbs
+++ b/views/jira-manual-app-creation.hbs
@@ -47,7 +47,12 @@
           {{else}}
             Enter all the fields to create your app.
         {{/if}}
-        <a href="#">Learn more about manual GitHub app creation.</a>
+        <a
+            href="https://support.atlassian.com/jira-cloud-administration/docs/manually-create-a-github-app/"
+            target="_blank"
+        >
+            Learn more about manual GitHub app creation.
+        </a>
       </div>
 
       <form

--- a/views/jira-select-app-creation.hbs
+++ b/views/jira-select-app-creation.hbs
@@ -67,8 +67,12 @@
             <p class="jiraAppCreation__versionDisclaimer__prompt">
                 To automatically connect your Github Enterprise Server to Jira, your GitHub Enterprise Server must be
                 <span class="jiraAppCreation__versionDisclaimer__version">Version 3.1.x</span> or higher.
-                <!-- TODO - add link to documentation once it's been written-->
-                <a href="" target="_blank">Learn more</a>
+                <a
+                    href="https://support.atlassian.com/jira-cloud-administration/docs/integrate-with-github/#FAQs"
+                    target="_blank"
+                >
+                    Learn more
+                </a>
             </p>
         </div>
 

--- a/views/jira-server-url.hbs
+++ b/views/jira-server-url.hbs
@@ -46,8 +46,12 @@
         <div class="jiraServerUrl__prompt">
             Connecting GitHub Enterprise Server to Jira requires opening a hole in your firewall,
             as Atlassian’s IP addresses must be able to call your GitHub Enterprise Server.
-          <!--TODO: Add a link here-->
-          <a href="" target="_blank">Learn more about network configuration for GitHub for Jira.</a>
+            <a
+                href="https://support.atlassian.com/jira-cloud-administration/docs/integrate-with-github/#How-the-GitHub-for-Jira-app-fetches-data"
+                target="_blank"
+            >
+                Learn more about network configuration for GitHub for Jira.
+            </a>
         </div>
 
         <div>


### PR DESCRIPTION
What's in this PR?
Links to documentation.

Why
So customers can read documentation... but they probably won't coz nobody reads things 🙃

Added feature flags
GHE_SERVER

Affected issues
ARC-1620

How has this been tested?
Locally

What's Next?
Publication of docs so links actually work (won't merge before then)