### PR TITLE
ARC-1641 - Block uploading files that don't have the .pem extension

### DIFF
--- a/static/js/jira-manual-app-creation.js
+++ b/static/js/jira-manual-app-creation.js
@@ -109,7 +109,7 @@ AJS.$("#jiraManualAppCreation__form").on("aui-valid-submit", (event) => {
 const replaceSpacesAndChangeCasing = (str) => str.replace(/\s+/g, '-').toLowerCase();
 
 $('#jiraManualAppCreation__uploadedFile').bind('DOMSubtreeModified', function () {
-	const hasFileName = document.getElementById("jiraManualAppCreation__uploadedFile").innerText !== "";
+	const fileName = document.getElementById("jiraManualAppCreation__uploadedFile").innerText;
 	// value used when user is updating up and app name already exists
 	const appNameFromData = $(this).data("app-appname");
 	// value used when creating an app and user has entered a value in gitHubAppName
@@ -125,9 +125,10 @@ $('#jiraManualAppCreation__uploadedFile').bind('DOMSubtreeModified', function ()
 			<p>Your file has been uploaded and will be </br>
 			stored with the filename in the format of </br>
 			${appName}.private-key.pem</p>
-	`
+	`;
+	const pemFilePattern = "^\s*$|^.*\.(pem|PEM)$";
 
-	if (hasFileName) {
+	if (fileName !== "" && fileName.match(pemFilePattern)) {
 		AJS.flag({
 			type: "success",
 			body

--- a/static/js/jira-manual-app-creation.js
+++ b/static/js/jira-manual-app-creation.js
@@ -126,7 +126,7 @@ $('#jiraManualAppCreation__uploadedFile').bind('DOMSubtreeModified', function ()
 			stored with the filename in the format of </br>
 			${appName}.private-key.pem</p>
 	`;
-	const pemFilePattern = "^\s*$|^.*\.(pem|PEM)$";
+	const pemFilePattern = "^.*\.(pem|PEM)$";
 
 	if (fileName !== "" && fileName.match(pemFilePattern)) {
 		AJS.flag({

--- a/views/jira-manual-app-creation.hbs
+++ b/views/jira-manual-app-creation.hbs
@@ -154,7 +154,7 @@
             -->
             <input class="jiraManualAppCreation__formFileInput"
                    id="privateKeyFile"
-                   data-aui-validation-pattern="^\s*$|^.*\.(pem|PEM)$"
+                   data-aui-validation-pattern="^.*\.(pem|PEM)$"
                    data-aui-validation-pattern-msg="We couldn&#x2019;t upload this file. Please try again."
                    data-aui-validation-field
                    required


### PR DESCRIPTION
**What's in this PR?**
- Condition updated to check if the file is valid before displaying the success flag.

**Why**
- To avoid confusion when uploading an invalid file.

**How has this been tested?**  
- Tested in local and staging.

**Video**

https://user-images.githubusercontent.com/13076255/186343546-72034b2b-a4b7-4234-9aaf-b0375078139f.mov


