### PR TITLE
Load user config during discovery

### DIFF
--- a/src/services/user-config-service.test.ts
+++ b/src/services/user-config-service.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { RepoSyncState } from "models/reposyncstate";
 import { Subscription } from "models/subscription";
-import { updateRepoConfig } from "services/user-config-service";
+import { getRepoConfig, updateRepoConfig } from "services/user-config-service";
 import { getInstallationId } from "~/src/github/client/installation-id";
 import { envVars } from "config/env";
 
@@ -61,9 +61,9 @@ describe("User Config Service", () => {
 
 	});
 
-	const givenGitHubReturnsConfigFile = () => {
+	const givenGitHubReturnsConfigFile = (repoOwner: string = repoSyncState.repoOwner, repoName = repoSyncState.repoName) => {
 		// see https://docs.github.com/en/rest/repos/contents#get-repository-content
-		githubNock.get(`/repos/${repoSyncState.repoOwner}/${repoSyncState.repoName}/contents/.jira/config.yml`)
+		githubNock.get(`/repos/${repoOwner}/${repoName}/contents/.jira/config.yml`)
 			.reply(200, {
 				content: configFileContentBase64
 			});
@@ -71,17 +71,31 @@ describe("User Config Service", () => {
 
 	it("should not update config in database when config file hasn't been touched", async () => {
 		await updateRepoConfig(subscription, repoSyncState.repoId, getInstallationId(gitHubInstallationId), ["random.yml", "ignored.yml"]);
-		const freshRepoSyncState = await RepoSyncState.findByRepoId(subscription, repoSyncState.repoId);
-		expect(freshRepoSyncState?.config).toBeFalsy();
+		const config = await getRepoConfig(subscription, getInstallationId(gitHubInstallationId), repoSyncState.repoId, repoSyncState.repoOwner, repoSyncState.repoName);
+		expect(config).toBeFalsy();
 	});
 
 	it("should update config in database when config file has been touched", async () => {
 		githubUserTokenNock(gitHubInstallationId);
 		givenGitHubReturnsConfigFile();
 		await updateRepoConfig(subscription, repoSyncState.repoId, getInstallationId(gitHubInstallationId), ["random.yml", "ignored.yml", ".jira/config.yml"]);
-		const freshRepoSyncState = await RepoSyncState.findByRepoId(subscription, repoSyncState.repoId);
-		expect(freshRepoSyncState?.config).toBeTruthy();
-		expect(freshRepoSyncState?.config?.deployments?.environmentMapping?.development).toHaveLength(4);
+		const config = await getRepoConfig(subscription, getInstallationId(gitHubInstallationId), repoSyncState.repoId, repoSyncState.repoOwner, repoSyncState.repoName);
+		expect(config).toBeTruthy();
+		expect(config?.deployments?.environmentMapping?.development).toHaveLength(4);
 	});
+
+	it("should get config directly from GitHub when we don't have a record of the repo", async () => {
+		// coordinates of a repo that we don't have in the database
+		const unknownRepoName = "unknownRepo";
+		const unknownRepoOwner = "unknownOwner";
+		const unknownRepoId = 42;
+
+		githubUserTokenNock(gitHubInstallationId);
+		givenGitHubReturnsConfigFile(unknownRepoOwner, unknownRepoName);
+		const config = await getRepoConfig(subscription, getInstallationId(gitHubInstallationId), unknownRepoId, unknownRepoOwner, unknownRepoName);
+		expect(config).toBeTruthy();
+		expect(config?.deployments?.environmentMapping?.development).toHaveLength(4);
+	});
+
 
 });

--- a/src/sync/discovery.ts
+++ b/src/sync/discovery.ts
@@ -6,6 +6,7 @@ import { RepositoryNode } from "../github/client/github-queries";
 import { RepoSyncState } from "models/reposyncstate";
 import { TaskPayload } from "~/src/sync/sync.types";
 import { BackfillMessagePayload } from "~/src/sqs/sqs.types";
+import { updateRepoConfigsFromGitHub } from "services/user-config-service";
 
 export const getRepositoryTask = async (
 	logger: Logger,
@@ -59,7 +60,7 @@ export const getRepositoryTask = async (
 	}
 
 	await subscription.update({ totalNumberOfRepos: totalCount });
-	await RepoSyncState.bulkCreate(repositories.map(repo => ({
+	const createdRepoSyncStates = await RepoSyncState.bulkCreate(repositories.map(repo => ({
 		subscriptionId: subscription.id,
 		repoId: repo.id,
 		repoName: repo.name,
@@ -72,6 +73,10 @@ export const getRepositoryTask = async (
 	logger.debug({ repositories }, `Added ${repositories.length} Repositories to state`);
 	logger.info(`Added ${repositories.length} Repositories to state`);
 	logger.debug(hasNextPage ? "Repository Discovery: Continuing" : "Repository Discovery: finished");
+
+	if (await booleanFlag(BooleanFlags.CONFIG_AS_CODE, false, jiraHost)) {
+		await updateRepoConfigsFromGitHub(createdRepoSyncStates, newGithub.githubInstallationId);
+	}
 
 	return {
 		edges,

--- a/src/transforms/transform-deployment.test.ts
+++ b/src/transforms/transform-deployment.test.ts
@@ -399,6 +399,9 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 
 		when(getRepoConfig).calledWith(
 			expect.anything(),
+			expect.anything(),
+			expect.anything(),
+			expect.anything(),
 			expect.anything()
 		).mockResolvedValue(mockConfig);
 
@@ -482,6 +485,9 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 		).mockResolvedValue(false);
 
 		when(getRepoConfig).calledWith(
+			expect.anything(),
+			expect.anything(),
+			expect.anything(),
 			expect.anything(),
 			expect.anything()
 		).mockResolvedValue(mockConfig);

--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -2,7 +2,11 @@ import Logger from "bunyan";
 import { JiraAssociation, JiraDeploymentData } from "interfaces/jira";
 import { WebhookPayloadDeploymentStatus } from "@octokit/webhooks";
 import { Octokit } from "@octokit/rest";
-import { CommitSummary, extractMessagesFromCommitSummaries, getAllCommitsBetweenReferences } from "./util/github-api-requests";
+import {
+	CommitSummary,
+	extractMessagesFromCommitSummaries,
+	getAllCommitsBetweenReferences
+} from "./util/github-api-requests";
 import { GitHubInstallationClient } from "../github/client/github-installation-client";
 import { AxiosResponse } from "axios";
 import _, { deburr } from "lodash";
@@ -145,7 +149,7 @@ export const mapEnvironment = (environment: string, config?: Config): string => 
 	// if there is a user-defined config, we use that config for the mapping
 	if (config) {
 		const environmentType = mapEnvironmentWithConfig(environment, config);
-		if (environmentType){
+		if (environmentType) {
 			return environmentType;
 		}
 	}
@@ -235,10 +239,18 @@ export const transformDeployment = async (githubInstallationClient: GitHubInstal
 
 	if (await booleanFlag(BooleanFlags.CONFIG_AS_CODE, false, jiraHost)) {
 		const subscription = await Subscription.getSingleInstallation(jiraHost, githubInstallationClient.githubInstallationId.installationId, gitHubAppId);
-		if (subscription){
-			config = await getRepoConfig(subscription, payload.repository.id);
+		if (subscription) {
+			config = await getRepoConfig(
+				subscription,
+				githubInstallationClient.githubInstallationId,
+				payload.repository.id,
+				payload.repository.owner.login,
+				payload.repository.name);
 		} else {
-			logger.warn({ jiraHost, githubInstallationId: githubInstallationClient.githubInstallationId.installationId }, "could not find subscription - not using user config to map environments!");
+			logger.warn({
+				jiraHost,
+				githubInstallationId: githubInstallationClient.githubInstallationId.installationId
+			}, "could not find subscription - not using user config to map environments!");
 		}
 	}
 


### PR DESCRIPTION
This PR adds some missing pieces to the config-as-code feature.

A [previous PR ](https://github.com/atlassian/github-for-jira/pulls?q=is%3Apr+is%3Aclosed+config-as-code) added the feature that when someone changes the contents of the file `.jira/config.yml` in a repo, this config is saved in our database.

This PR adds the same thing during discovery (i.e. at the start of a backfilling), so that the config is available shortly after the backfilling has been started.