### PR TITLE
ARC 1591 - Create a new route and placeholder page for create-branch

### DIFF
--- a/src/routes/github/create-branch/github-create-branch-get.test.ts
+++ b/src/routes/github/create-branch/github-create-branch-get.test.ts
@@ -1,0 +1,22 @@
+import express, { Application } from "express";
+import { GithubCreateBranchGet } from "./github-create-branch-get";
+import supertest from "supertest";
+
+jest.mock("./github-create-branch-get");
+
+describe("GitHub Create Branch Get", () => {
+	let app: Application;
+	beforeEach(() => {
+		app = express();
+		app.use("/create-branch", GithubCreateBranchGet);
+
+	});
+	describe("Testing the GET route", () => {
+		it("should hit the create branch on GET", async () => {
+			jest.mocked(GithubCreateBranchGet).mockImplementation(async (_req, res) => {res.end("ok");});
+			await supertest(app).get("/create-branch");
+			expect(GithubCreateBranchGet).toHaveBeenCalled();
+		});
+	});
+});
+

--- a/src/routes/github/create-branch/github-create-branch-get.test.ts
+++ b/src/routes/github/create-branch/github-create-branch-get.test.ts
@@ -25,7 +25,8 @@ describe("GitHub Create Branch Get", () => {
 					"Cookie",
 					getSignedCookieHeader({
 						jiraHost
-					})).expect(res => {
+					}))
+				.expect(res => {
 					expect(res.status).toBe(302);
 					expect(res.headers.location).toContain("github.com/login/oauth/authorize");
 				});

--- a/src/routes/github/create-branch/github-create-branch-get.ts
+++ b/src/routes/github/create-branch/github-create-branch-get.ts
@@ -1,0 +1,23 @@
+import { NextFunction, Request, Response } from "express";
+import { Errors } from "config/errors";
+
+export const GithubCreateBranchGet = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+	const {
+		jiraHost,
+		githubToken
+	} = res.locals;
+
+	if (!githubToken) {
+		return next(new Error(Errors.MISSING_GITHUB_TOKEN));
+	}
+
+
+	res.render("github-create-branch.hbs", {
+		csrfToken: req.csrfToken(),
+		jiraHost,
+		nonce: res.locals.nonce,
+		title: "Create a Branch"
+	});
+
+	req.log.debug(`Github Create Branch Page rendered page`);
+};

--- a/src/routes/github/create-branch/github-create-branch-router.ts
+++ b/src/routes/github/create-branch/github-create-branch-router.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { GithubCreateBranchGet } from "routes/github/create-branch/github-create-branch-get";
+
+export const GithubCreateBranchRouter = Router();
+
+GithubCreateBranchRouter.route("/")
+	.get(GithubCreateBranchGet);
+

--- a/src/routes/github/github-router.ts
+++ b/src/routes/github/github-router.ts
@@ -10,6 +10,7 @@ import { WebhookReceiverPost } from "./webhook/webhook-receiver-post";
 import { GithubManifestRouter } from "~/src/routes/github/manifest/github-manifest-router";
 import { GithubServerAppMiddleware } from "middleware/github-server-app-middleware";
 import { UUID_REGEX } from "~/src/util/regex";
+import { GithubCreateBranchRouter } from "routes/github/create-branch/github-create-branch-router";
 
 export const GithubRouter = Router();
 const subRouter = Router({ mergeParams: true });
@@ -43,4 +44,6 @@ subRouter.use("/configuration", GithubConfigurationRouter);
 
 // TODO: remove optional "s" once we change the frontend to use the proper delete method
 subRouter.use("/subscriptions?", GithubSubscriptionRouter);
+
+subRouter.use("/create-branch", GithubCreateBranchRouter);
 

--- a/static/css/github-create-branch.css
+++ b/static/css/github-create-branch.css
@@ -1,0 +1,12 @@
+
+.gitHubCreateBranch {
+    margin: auto;
+    max-width: 740px;
+    height: 100vh;
+}
+
+.gitHubCreateBranch__title {
+    color: #6B778C;
+    margin: 0.8em 0;
+    text-align: center;
+}

--- a/views/github-create-branch.hbs
+++ b/views/github-create-branch.hbs
@@ -1,0 +1,46 @@
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="ap-local-base-url" content="{{localBaseUrl}}" />
+  <title>{{title}}</title>
+  <link
+    rel="stylesheet"
+    href="/public/aui/aui-prototyping.css"
+    integrity="DTM1Q+8lU7SzJT+FWr0JFisCSZlwfM0GiAKYy7h1s9vIKa/CIh37s9NuOCqIOgK4tmqrjLK4NuWuIPUQNsikHA=="
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+  />
+  <link rel="stylesheet" href="/public/primer/build.css" media="all" />
+  <link rel="stylesheet" href="/public/css/github-create-branch.css" media="all" />
+  <link rel="stylesheet" href="/public/css/global.css" media="all" />
+  <script src="/public/js/jquery.min.js" nonce="{{nonce}}"></script>
+</head>
+
+<body>
+<input type="hidden" id="_csrf" name="_csrf" value="{{csrfToken}}" />
+<input type="hidden" id="jiraHost" name="jiraHost" value="{{jiraHost}}" />
+
+{{> navigation hideBackButton=true }}
+
+<section class="gitHubCreateBranch">
+  <div class="headerImage">
+    <img src="/public/assets/jira-and-github.png" alt="Jira and GitHub logos" />
+  </div>
+  <div class="gitHubCreateBranch__title">
+    Create a Branch
+  </div>
+</section>
+
+<script src="https://connect-cdn.atl-paas.net/all.js" nonce="{{nonce}}"></script>
+<script
+  src="/public/aui/aui-prototyping.js"
+  integrity="sha512-DkENIkhNP5r+sfHUC5hhFAzApGNR5HTu1fzymBBhXZma4zytOUQh8qhz5xc3nSbSQfdYI6qdI281YwUNmubEMw=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+  nonce="{{nonce}}"
+></script>
+<script src="/public/js/navigation.js" nonce="{{nonce}}"></script>
+</body>
+
+</html>


### PR DESCRIPTION
**What's in this PR?**
- New route(GET), view and css file for Create Branch.
- Test case added for the new route.

**Why**
- To unblock other tasks.

**How has this been tested?**  
- Tested the route `/github/create-branch` in local and staging environments.

**Screenshot**
- In local
![Screen Shot 2022-08-31 at 11 58 41 am](https://user-images.githubusercontent.com/13076255/187576173-7960f5ca-0409-4fd5-a1b1-79ea4b15072d.png)

- In staging
![Screen Shot 2022-08-31 at 4 25 39 pm](https://user-images.githubusercontent.com/13076255/187608575-7948bb0e-2b5b-421b-b722-ae19722b4683.png)
