### PR TITLE
ARC-1643 refactor config class a bit

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -25,7 +25,8 @@ export enum BooleanFlags {
 	TAG_BACKFILL_REQUESTS = "tag-backfill-requests",
 	READ_SHARED_SECRET_FROM_CRYPTOR = "read-shared-secret-from-cryptor",
 	CONFIG_AS_CODE = "config-as-code",
-	CREATE_BRANCH = "create-branch"
+	CREATE_BRANCH = "create-branch",
+	USE_GITHUB_CONFIG_IN_BASE_CLIENT = "use-githubconfig-in-base-client"
 }
 
 export enum StringFlags {

--- a/src/github/client/github-app-client.ts
+++ b/src/github/client/github-app-client.ts
@@ -22,9 +22,9 @@ export class GitHubAppClient extends GitHubClient {
 	private readonly appToken: AuthToken;
 
 	constructor(
-		gitHubConfig?: GitHubConfig,
+		gitHubConfig?: GitHubConfig, // becomes mandatory once we remove the FF
 		logger?: Logger,
-		baseUrl?: string,
+		baseUrl?: string, // will go away once gitHubConfig is mandatory
 		appId = envVars.APP_ID,
 		privateKey = PrivateKey.findPrivateKey() || ""
 	) {

--- a/src/github/client/github-app-client.ts
+++ b/src/github/client/github-app-client.ts
@@ -22,9 +22,9 @@ export class GitHubAppClient extends GitHubClient {
 	private readonly appToken: AuthToken;
 
 	constructor(
-		gitHubConfig?: GitHubConfig, // becomes mandatory once we remove the FF
+		gitHubConfig: GitHubConfig,
 		logger?: Logger,
-		baseUrl?: string, // will go away once gitHubConfig is mandatory
+		baseUrl?: string, // goes away once it goes away in the parent class
 		appId = envVars.APP_ID,
 		privateKey = PrivateKey.findPrivateKey() || ""
 	) {

--- a/src/github/client/github-app-client.ts
+++ b/src/github/client/github-app-client.ts
@@ -9,7 +9,7 @@ import * as PrivateKey from "probot/lib/private-key";
 import { envVars } from "config/env";
 import { AuthToken } from "~/src/github/client/auth-token";
 import { GITHUB_ACCEPT_HEADER } from "~/src/util/get-github-client-config";
-import { GitHubClient } from "./github-client";
+import { GitHubClient, GitHubConfig } from "./github-client";
 
 
 /**
@@ -22,12 +22,13 @@ export class GitHubAppClient extends GitHubClient {
 	private readonly appToken: AuthToken;
 
 	constructor(
+		gitHubConfig?: GitHubConfig,
 		logger?: Logger,
 		baseUrl?: string,
 		appId = envVars.APP_ID,
 		privateKey = PrivateKey.findPrivateKey() || ""
 	) {
-		super(logger, baseUrl);
+		super(gitHubConfig, logger, baseUrl);
 		this.appToken = AppTokenHolder.createAppJwt(privateKey, appId);
 
 		this.axios.interceptors.request.use(setRequestStartTime);

--- a/src/github/client/github-client-cloud.test.ts
+++ b/src/github/client/github-client-cloud.test.ts
@@ -10,6 +10,13 @@ import { numberFlag, NumberFlags } from "config/feature-flags";
 
 jest.mock("config/feature-flags");
 
+const GITHUB_CLOUD_CONFIG = {
+	hostname: "https://github.com",
+	baseUrl: "https://github.com",
+	apiUrl: "https://api.github.com",
+	graphqlUrl: "https://api.github.com/graphql"
+};
+
 describe("GitHub Client", () => {
 	const githubInstallationId = 17979017;
 	let statsdHistogramSpy, statsdIncrementSpy;
@@ -91,7 +98,7 @@ describe("GitHub Client", () => {
 			"installation token"
 		);
 
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), undefined, getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), GITHUB_CLOUD_CONFIG, getLogger("test"));
 		const pullrequests = await client.getPullRequests(owner, repo, {
 			per_page: pageSize,
 			page
@@ -114,7 +121,7 @@ describe("GitHub Client", () => {
 			"installation token"
 		);
 
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), undefined, getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), GITHUB_CLOUD_CONFIG, getLogger("test"));
 		const commit = await client.getCommit(owner, repo, sha);
 
 		expect(commit).toBeTruthy();
@@ -151,7 +158,7 @@ describe("GitHub Client", () => {
 			}
 		);
 		mockSystemTime(1000000);
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), undefined, getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), GITHUB_CLOUD_CONFIG, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});
@@ -178,7 +185,7 @@ describe("GitHub Client", () => {
 			}
 		);
 		mockSystemTime(1000000);
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), undefined, getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), GITHUB_CLOUD_CONFIG, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});
@@ -201,7 +208,7 @@ describe("GitHub Client", () => {
 			403, { message: "Org has an IP allow list enabled" }
 		);
 		mockSystemTime(1000000);
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), undefined, getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), GITHUB_CLOUD_CONFIG, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});
@@ -226,7 +233,7 @@ describe("GitHub Client", () => {
 			}
 		);
 		mockSystemTime(1000000);
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), undefined, getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), GITHUB_CLOUD_CONFIG, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});
@@ -252,7 +259,7 @@ describe("GitHub Client", () => {
 			}
 		);
 		mockSystemTime(1000000);
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), undefined, getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), GITHUB_CLOUD_CONFIG, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});
@@ -280,7 +287,7 @@ describe("GitHub Client", () => {
 			200, [{ number: 1 }]
 		);
 
-		const client = await new GitHubInstallationClient(getInstallationId(githubInstallationId), undefined, getLogger("test"));
+		const client = await new GitHubInstallationClient(getInstallationId(githubInstallationId), GITHUB_CLOUD_CONFIG, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});

--- a/src/github/client/github-client-cloud.test.ts
+++ b/src/github/client/github-client-cloud.test.ts
@@ -91,7 +91,7 @@ describe("GitHub Client", () => {
 			"installation token"
 		);
 
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), undefined, getLogger("test"));
 		const pullrequests = await client.getPullRequests(owner, repo, {
 			per_page: pageSize,
 			page
@@ -114,7 +114,7 @@ describe("GitHub Client", () => {
 			"installation token"
 		);
 
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), undefined, getLogger("test"));
 		const commit = await client.getCommit(owner, repo, sha);
 
 		expect(commit).toBeTruthy();
@@ -151,7 +151,7 @@ describe("GitHub Client", () => {
 			}
 		);
 		mockSystemTime(1000000);
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), undefined, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});
@@ -178,7 +178,7 @@ describe("GitHub Client", () => {
 			}
 		);
 		mockSystemTime(1000000);
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), undefined, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});
@@ -201,7 +201,7 @@ describe("GitHub Client", () => {
 			403, { message: "Org has an IP allow list enabled" }
 		);
 		mockSystemTime(1000000);
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), undefined, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});
@@ -226,7 +226,7 @@ describe("GitHub Client", () => {
 			}
 		);
 		mockSystemTime(1000000);
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), undefined, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});
@@ -252,7 +252,7 @@ describe("GitHub Client", () => {
 			}
 		);
 		mockSystemTime(1000000);
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), undefined, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});
@@ -280,7 +280,7 @@ describe("GitHub Client", () => {
 			200, [{ number: 1 }]
 		);
 
-		const client = await new GitHubInstallationClient(getInstallationId(githubInstallationId), getLogger("test"));
+		const client = await new GitHubInstallationClient(getInstallationId(githubInstallationId), undefined, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});

--- a/src/github/client/github-client-server.test.ts
+++ b/src/github/client/github-client-server.test.ts
@@ -84,7 +84,12 @@ describe("GitHub Client", () => {
 
 		const client = new GitHubInstallationClient(
 			new InstallationId(gheUrl, 4711, githubInstallationId),
-			undefined,
+			{
+				hostname: gheUrl,
+				baseUrl: gheUrl,
+				apiUrl: gheApiUrl,
+				graphqlUrl: gheApiUrl  + '/graphql'
+			},
 			getLogger("test"),
 			"https://github.mydomain.com"
 		);

--- a/src/github/client/github-client-server.test.ts
+++ b/src/github/client/github-client-server.test.ts
@@ -84,6 +84,7 @@ describe("GitHub Client", () => {
 
 		const client = new GitHubInstallationClient(
 			new InstallationId(gheUrl, 4711, githubInstallationId),
+			undefined,
 			getLogger("test"),
 			"https://github.mydomain.com"
 		);

--- a/src/github/client/github-client.test.ts
+++ b/src/github/client/github-client.test.ts
@@ -1,27 +1,78 @@
 /* eslint-disable jest/no-standalone-expect */
-import { getLogger } from "config/logger";
-import { GitHubInstallationClient } from "./github-installation-client";
-import { getInstallationId } from "./installation-id";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import "config/env";
 
+import * as axios from "axios";
+import { GitHubClient, GitHubConfig } from "~/src/github/client/github-client";
+
+jest.mock("axios");
+
 jest.mock("config/feature-flags");
 
+class TestGitHubClient extends GitHubClient {
+	constructor(config?: GitHubConfig) {
+		super(config);
+	}
+	public doTestGraphqlCall() {
+		return this.graphql("foo", {});
+	}
+}
+
+const TEST_API_URL = 'http://api.myBaseUrl.com';
+const TEST_GRAPHQL_URL = 'http://graphql.myBaseUrl.com';
+
+const TEST_GITHUB_CONFIG = {
+	hostname: 'myHostname',
+	baseUrl: 'http://myBaseUrl.com',
+	apiUrl: TEST_API_URL,
+	graphqlUrl: TEST_GRAPHQL_URL
+};
+
 describe("GitHub Client", () => {
-	const githubInstallationId = 17979017;
+
+	const mockedAxiosPost = jest.fn();
+
+	beforeEach(() => {
+		const mockedAxiosCreate = {
+			interceptors: {
+				request: {
+					use: jest.fn()
+				},
+				response: {
+					use: jest.fn()
+				}
+			},
+			post: mockedAxiosPost
+		};
+		(axios.default.create as jest.Mock).mockReturnValue(mockedAxiosCreate);
+		mockedAxiosPost.mockReset();
+		mockedAxiosPost.mockResolvedValue({});
+	});
 
 	it("configures the proxy for outbound calls", async () => {
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), getLogger("test"));
+		const client = new TestGitHubClient(undefined);
 		const outboundProxyConfig = client.getProxyConfig("https://github.com");
 		expect(outboundProxyConfig.proxy).toBe(false);
 		expect(outboundProxyConfig.httpsAgent).toBeInstanceOf(HttpsProxyAgent);
 	});
 
 	it("configures no proxy for calls to the Atlassian network", async () => {
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), getLogger("test"));
+		const client = new TestGitHubClient();
 		const outboundProxyConfig = client.getProxyConfig("http://github.internal.atlassian.com/api");
 		expect(outboundProxyConfig.proxy).toBe(false);
 		expect(outboundProxyConfig.httpsAgent).toBeUndefined();
+	});
+
+	it("uses gitHubConfig.apiUrl, if provided", async () => {
+		new TestGitHubClient(TEST_GITHUB_CONFIG);
+		const calls = (axios.default.create as jest.Mock).mock.calls[0];
+		expect(calls[0].baseURL).toEqual(TEST_API_URL);
+	});
+
+	it("uses gitHubConfig.graphqlUrl, if provided", async () => {
+		const client = new TestGitHubClient(TEST_GITHUB_CONFIG);
+		await client.doTestGraphqlCall();
+		expect(mockedAxiosPost.mock.calls[0][0]).toEqual(TEST_GRAPHQL_URL);
 	});
 
 });

--- a/src/github/client/github-installation-client.ts
+++ b/src/github/client/github-installation-client.ts
@@ -44,9 +44,9 @@ export class GitHubInstallationClient extends GitHubClient {
 
 	constructor(
 		githubInstallationId: InstallationId,
-		githubConfig?: GitHubConfig, // will become mandatory once the FF is removed
+		githubConfig: GitHubConfig,
 		logger?: Logger,
-		baseUrl?: string, // will go away once githubConfig is used
+		baseUrl?: string, // goes away once it goes away in the parent class
 		gshaId?: number
 	) {
 		super(githubConfig, logger, baseUrl);

--- a/src/github/client/github-installation-client.ts
+++ b/src/github/client/github-installation-client.ts
@@ -44,12 +44,12 @@ export class GitHubInstallationClient extends GitHubClient {
 
 	constructor(
 		githubInstallationId: InstallationId,
-		githubConfig: GitHubConfig,
+		gitHubConfig: GitHubConfig,
 		logger?: Logger,
 		baseUrl?: string, // goes away once it goes away in the parent class
 		gshaId?: number
 	) {
-		super(githubConfig, logger, baseUrl);
+		super(gitHubConfig, logger, baseUrl);
 
 		this.axios.interceptors.request.use(setRequestStartTime);
 		this.axios.interceptors.request.use(setRequestTimeout);

--- a/src/github/client/github-user-client.ts
+++ b/src/github/client/github-user-client.ts
@@ -5,7 +5,7 @@ import { handleFailedRequest, instrumentFailedRequest, instrumentRequest, setReq
 import { metricHttpRequest } from "config/metric-names";
 import { urlParamsMiddleware } from "utils/axios/url-params-middleware";
 import { GITHUB_ACCEPT_HEADER } from "utils/get-github-client-config";
-import { GitHubClient } from "./github-client";
+import { GitHubClient, GitHubConfig } from "./github-client";
 
 /**
  * A GitHub client that supports authentication as a GitHub User.
@@ -13,8 +13,8 @@ import { GitHubClient } from "./github-client";
 export class GitHubUserClient extends GitHubClient {
 	private readonly userToken: string;
 
-	constructor(userToken: string, logger?: Logger, baseUrl?: string) {
-		super(logger, baseUrl);
+	constructor(userToken: string, githubConfig?: GitHubConfig, logger?: Logger, baseUrl?: string) {
+		super(githubConfig, logger, baseUrl);
 		this.userToken = userToken;
 
 		this.axios.interceptors.request.use((config: AxiosRequestConfig) => {

--- a/src/github/client/github-user-client.ts
+++ b/src/github/client/github-user-client.ts
@@ -13,7 +13,7 @@ import { GitHubClient, GitHubConfig } from "./github-client";
 export class GitHubUserClient extends GitHubClient {
 	private readonly userToken: string;
 
-	constructor(userToken: string, githubConfig?: GitHubConfig, logger?: Logger, baseUrl?: string) {
+	constructor(userToken: string, githubConfig: GitHubConfig, logger?: Logger, baseUrl?: string) {
 		super(githubConfig, logger, baseUrl);
 		this.userToken = userToken;
 

--- a/src/transforms/transform-deployment.test.ts
+++ b/src/transforms/transform-deployment.test.ts
@@ -114,10 +114,17 @@ describe("deployment environment mapping", () => {
 	});
 });
 
+const GITHUB_CLOUD_CONFIG = {
+	hostname: "https://github.com",
+	baseUrl: "https://github.com",
+	apiUrl: "https://api.github.com",
+	graphqlUrl: "https://api.github.com/graphql"
+};
+
 const TEST_INSTALLATION_ID = 1234;
 describe("transform GitHub webhook payload to Jira payload", () => {
 	const { payload: { repository: { name: repoName, owner } } } = deployment_status;
-	const githubClient = new GitHubInstallationClient(getInstallationId(TEST_INSTALLATION_ID), undefined, getLogger("test"));
+	const githubClient = new GitHubInstallationClient(getInstallationId(TEST_INSTALLATION_ID), GITHUB_CLOUD_CONFIG, getLogger("test"));
 
 	it(`supports branch and merge workflows, sending related commits in deployment`, async () => {
 

--- a/src/transforms/transform-deployment.test.ts
+++ b/src/transforms/transform-deployment.test.ts
@@ -117,7 +117,7 @@ describe("deployment environment mapping", () => {
 const TEST_INSTALLATION_ID = 1234;
 describe("transform GitHub webhook payload to Jira payload", () => {
 	const { payload: { repository: { name: repoName, owner } } } = deployment_status;
-	const githubClient = new GitHubInstallationClient(getInstallationId(TEST_INSTALLATION_ID), getLogger("test"));
+	const githubClient = new GitHubInstallationClient(getInstallationId(TEST_INSTALLATION_ID), undefined, getLogger("test"));
 
 	it(`supports branch and merge workflows, sending related commits in deployment`, async () => {
 

--- a/src/util/get-github-client-config.ts
+++ b/src/util/get-github-client-config.ts
@@ -8,16 +8,14 @@ import { GitHubAppClient } from "../github/client/github-app-client";
 import { envVars } from "~/src/config/env";
 import * as PrivateKey from "probot/lib/private-key";
 import { keyLocator } from "~/src/github/client/key-locator";
+import { GitHubConfig } from "~/src/github/client/github-client";
 
 export const GITHUB_CLOUD_HOSTNAME = "https://github.com";
 export const GITHUB_CLOUD_API_BASEURL = "https://api.github.com";
 export const GITHUB_ACCEPT_HEADER = "application/vnd.github.v3+json";
 
-export interface GitHubClientConfig {
+interface GitHubClientConfig extends GitHubConfig {
 	serverId?: number;
-	hostname: string;
-	baseUrl: string;
-	apiUrl: string;
 	appId: number;
 	privateKey: string;
 	gitHubClientId: string;
@@ -39,6 +37,7 @@ export const getGitHubClientConfigFromAppId = async (gitHubAppId: number | undef
 			hostname: gitHubServerApp.gitHubBaseUrl,
 			baseUrl: gitHubServerApp.gitHubBaseUrl,
 			apiUrl: `${gitHubServerApp.gitHubBaseUrl}/api/v3`,
+			graphqlUrl: `${gitHubServerApp.gitHubBaseUrl}/api/graphql`,
 			appId: gitHubServerApp.appId,
 			gitHubClientId: gitHubServerApp.gitHubClientId,
 			gitHubClientSecret: await gitHubServerApp.decrypt("gitHubClientSecret"),
@@ -54,6 +53,7 @@ export const getGitHubClientConfigFromAppId = async (gitHubAppId: number | undef
 		hostname: GITHUB_CLOUD_HOSTNAME,
 		baseUrl: GITHUB_CLOUD_API_BASEURL,
 		apiUrl: GITHUB_CLOUD_API_BASEURL,
+		graphqlUrl: `${GITHUB_CLOUD_API_BASEURL}/graphql`,
 		appId: parseInt(envVars.APP_ID),
 		gitHubClientId: envVars.GITHUB_CLIENT_ID,
 		gitHubClientSecret: envVars.GITHUB_CLIENT_SECRET,
@@ -75,8 +75,8 @@ export async function getGitHubHostname(jiraHost: string, gitHubAppId: number) {
 export async function createAppClient(logger: Logger, jiraHost: string, gitHubAppId: number | undefined): Promise<GitHubAppClient> {
 	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
 	return await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)
-		? new GitHubAppClient(logger, gitHubClientConfig.baseUrl, gitHubClientConfig.appId.toString(), gitHubClientConfig.privateKey)
-		: new GitHubAppClient(logger);
+		? new GitHubAppClient(gitHubClientConfig, logger, gitHubClientConfig.baseUrl, gitHubClientConfig.appId.toString(), gitHubClientConfig.privateKey)
+		: new GitHubAppClient(gitHubClientConfig, logger);
 }
 
 /**
@@ -84,12 +84,11 @@ export async function createAppClient(logger: Logger, jiraHost: string, gitHubAp
  * information specific to an organization.
  */
 export async function createInstallationClient(gitHubInstallationId: number, jiraHost: string, logger: Logger, gitHubAppId: number | undefined): Promise<GitHubInstallationClient> {
-
+	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
 	if (await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)) {
-		const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
-		return new GitHubInstallationClient(getInstallationId(gitHubInstallationId, gitHubClientConfig.baseUrl, gitHubClientConfig.appId), logger, gitHubClientConfig.baseUrl, gitHubClientConfig.serverId);
+		return new GitHubInstallationClient(getInstallationId(gitHubInstallationId, gitHubClientConfig.baseUrl, gitHubClientConfig.appId), gitHubClientConfig, logger, gitHubClientConfig.baseUrl, gitHubClientConfig.serverId);
 	} else {
-		return new GitHubInstallationClient(getInstallationId(gitHubInstallationId), logger);
+		return new GitHubInstallationClient(getInstallationId(gitHubInstallationId), gitHubClientConfig, logger);
 	}
 }
 
@@ -99,6 +98,6 @@ export async function createInstallationClient(gitHubInstallationId: number, jir
 export async function createUserClient(githubToken: string, jiraHost: string, logger: Logger, gitHubAppId: number | undefined): Promise<GitHubUserClient> {
 	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
 	return await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)
-		? new GitHubUserClient(githubToken, logger, gitHubClientConfig.baseUrl)
-		: new GitHubUserClient(githubToken, logger);
+		? new GitHubUserClient(githubToken, gitHubClientConfig, logger, gitHubClientConfig.baseUrl)
+		: new GitHubUserClient(githubToken, gitHubClientConfig, logger);
 }

--- a/src/util/get-github-client-config.ts
+++ b/src/util/get-github-client-config.ts
@@ -76,7 +76,7 @@ export async function createAppClient(logger: Logger, jiraHost: string, gitHubAp
 	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
 	return await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)
 		? new GitHubAppClient(gitHubClientConfig, logger, gitHubClientConfig.baseUrl, gitHubClientConfig.appId.toString(), gitHubClientConfig.privateKey)
-		: new GitHubAppClient(undefined, logger);
+		: new GitHubAppClient(gitHubClientConfig, logger);
 }
 
 /**
@@ -88,7 +88,7 @@ export async function createInstallationClient(gitHubInstallationId: number, jir
 	if (await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)) {
 		return new GitHubInstallationClient(getInstallationId(gitHubInstallationId, gitHubClientConfig.baseUrl, gitHubClientConfig.appId), gitHubClientConfig, logger, gitHubClientConfig.baseUrl, gitHubClientConfig.serverId);
 	} else {
-		return new GitHubInstallationClient(getInstallationId(gitHubInstallationId), undefined, logger);
+		return new GitHubInstallationClient(getInstallationId(gitHubInstallationId), gitHubClientConfig, logger);
 	}
 }
 
@@ -99,5 +99,5 @@ export async function createUserClient(githubToken: string, jiraHost: string, lo
 	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
 	return await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)
 		? new GitHubUserClient(githubToken, gitHubClientConfig, logger, gitHubClientConfig.baseUrl)
-		: new GitHubUserClient(githubToken, undefined, logger);
+		: new GitHubUserClient(githubToken, gitHubClientConfig, logger);
 }

--- a/src/util/get-github-client-config.ts
+++ b/src/util/get-github-client-config.ts
@@ -76,7 +76,7 @@ export async function createAppClient(logger: Logger, jiraHost: string, gitHubAp
 	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
 	return await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)
 		? new GitHubAppClient(gitHubClientConfig, logger, gitHubClientConfig.baseUrl, gitHubClientConfig.appId.toString(), gitHubClientConfig.privateKey)
-		: new GitHubAppClient(gitHubClientConfig, logger);
+		: new GitHubAppClient(undefined, logger);
 }
 
 /**
@@ -88,7 +88,7 @@ export async function createInstallationClient(gitHubInstallationId: number, jir
 	if (await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)) {
 		return new GitHubInstallationClient(getInstallationId(gitHubInstallationId, gitHubClientConfig.baseUrl, gitHubClientConfig.appId), gitHubClientConfig, logger, gitHubClientConfig.baseUrl, gitHubClientConfig.serverId);
 	} else {
-		return new GitHubInstallationClient(getInstallationId(gitHubInstallationId), gitHubClientConfig, logger);
+		return new GitHubInstallationClient(getInstallationId(gitHubInstallationId), undefined, logger);
 	}
 }
 
@@ -99,5 +99,5 @@ export async function createUserClient(githubToken: string, jiraHost: string, lo
 	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
 	return await booleanFlag(BooleanFlags.GHE_SERVER, GHE_SERVER_GLOBAL, jiraHost)
 		? new GitHubUserClient(githubToken, gitHubClientConfig, logger, gitHubClientConfig.baseUrl)
-		: new GitHubUserClient(githubToken, gitHubClientConfig, logger);
+		: new GitHubUserClient(githubToken, undefined, logger);
 }

--- a/src/util/github-utils.test.ts
+++ b/src/util/github-utils.test.ts
@@ -2,11 +2,18 @@
 import { isUserAdminOfOrganization } from "./github-utils";
 import { GitHubUserClient } from "~/src/github/client/github-user-client";
 
+const GITHUB_CLOUD_CONFIG = {
+	hostname: "https://github.com",
+	baseUrl: "https://github.com",
+	apiUrl: "https://api.github.com",
+	graphqlUrl: "https://api.github.com/graphql"
+};
+
 describe("GitHub Utils", () => {
 	describe("isUserAdminOfOrganization", () => {
 		let githubUserClient: GitHubUserClient;
 		beforeEach(() => {
-			githubUserClient = new GitHubUserClient("token");
+			githubUserClient = new GitHubUserClient("token", GITHUB_CLOUD_CONFIG);
 		});
 
 		it("should return true if user is admin of a given organization", async () => {


### PR DESCRIPTION
**What's in this PR?**

Currently we have 2 places where we configure the client with duplicating code: 
 - `src/github/client/github-client.ts` and
 - `src/util/get-github-client-config.ts`

This refactoring will leave in only one place in `get-github-client-config` (after FF is removed). In that place, there's also access to `jiraHost` , which I need in order to configure the proxy (next step).

**Why**

Currently there's no way to configure outbound proxy based on `jiraHost`, because 
1. we don't have it in the place where we do configuration now (client)
2. even if we bring it over, we cannot use it because that's in a constructor and constructors cannot be async (the list of hosts that should be skipped are to be fetched from a FF)
3. this needs to be done in a common place so we could reuse it in GHE config screen, that doesn't use the client

**Added feature flags**
https://switcheroo.atlassian.com/changes/github-for-jira/use-githubconfig-in-base-client

**Affected issues**  
ARC-1643

**How has this been tested?**  
Staging

**Whats Next?**
Remove the FF
Add outbound proxy config based on FF value (jiraHost)