### PR TITLE
ignore yarnrc in prod

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -13,7 +13,8 @@ COPY . /app
 WORKDIR /app
 
 # Installing packages
-RUN yarn install --frozen-lockfile --force
+RUN rm .yarnrc
+RUN yarn install --frozen-lockfile
 RUN yarn list
 
 # Building TypeScript files


### PR DESCRIPTION
**What's in this PR?**
Small change to the Dockerfile for prod to ignore the yarnrc file.

**Why**
Analytics are currently broken but work if we remove the .yarnrc file. We can't simply rip this out otherwise anyone who doesn't have access to SOX packages won't be able to run the app locally. 

**Affected issues**  
ARC-1644

**How has this been tested?**  
Deployed to staging and checked our logs to make sure the analytics client exists.

<img width="823" alt="Screen Shot 2022-09-02 at 3 51 08 pm" src="https://user-images.githubusercontent.com/37155488/188068078-f9134b6c-9022-4481-b12e-9f4dc58fd1eb.png">

**What's Next?**
This is a temporary fix. @mboudreau is going to keep digging into the issue.