### PR TITLE
Update github-create-branch.hbs

### DIFF
--- a/views/github-create-branch.hbs
+++ b/views/github-create-branch.hbs
@@ -63,11 +63,15 @@
     </div>
     <div class="field-group">
       <aui-label for="branch-name">Branch name</aui-label>
-      <input class="text full-width-field" id="branchNameText" type="text" data-aui-validation-field required name="branch-name"
-        placeholder="Enter branch name" data-aui-validation-pattern="\w*{{issue.key}}\w*"
+      <input class="text full-width-field" 
+        id="branchNameText"
+        value="{{issue.branchName}}"
+        type="text"
+        placeholder="Enter branch name" 
+        data-aui-validation-field required name="branch-name"
+        data-aui-validation-pattern="\w*{{issue.key}}\w*"
         data-aui-validation-required-msg="This field is required."
-        data-aui-validation-pattern-msg="The issue key does not match the selected issue." />
-        value="{{issue.branchName}}" placeholder="Enter branch name"/>
+        data-aui-validation-pattern-msg="The issue key does not match the selected issue."/>
     </div>
 
         <div class="gitHubCreateBranch__serverError">


### PR DESCRIPTION
Fixed double closed tag

Was a bug with tag closing twice after conflict resolve
data-aui-validation-pattern-msg="The issue key does not match the selected issue." />
value="{{issue.branchName}}" placeholder="Enter branch name"/>
