### PR TITLE
ARC-1608 Get branches endpoint

### DIFF
--- a/src/github/client/github-queries.ts
+++ b/src/github/client/github-queries.ts
@@ -218,6 +218,20 @@ export type getBranchesResponse = {
 	}
 };
 
+export type getBranchesNameResponse = {
+	repository: {
+		refs: {
+      totalCount: number,
+			edges: {
+				cursor: string;
+				node: {
+					name: string;
+				}
+			}[]
+		}
+	}
+};
+
 export const getBranchesQueryWithChangedFiles = `query ($owner: String!, $repo: String!, $per_page: Int!, $commitSince: GitTimestamp, $cursor: String) {
     repository(owner: $owner, name: $repo) {
       refs(first: $per_page, refPrefix: "refs/heads/", after: $cursor) {
@@ -309,6 +323,23 @@ export const getBranchesQueryWithoutChangedFiles = `query ($owner: String!, $rep
             }
           }
         }
+      }
+    }
+  }`;
+
+export const  getBranchesNameQuery = `query ($owner: String!, $repo: String!, $per_page: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      refs(first: $per_page, refPrefix: "refs/heads/", after: $cursor) {
+        totalCount
+        edges {
+          cursor
+          node {
+            name
+          }
+        }
+      }
+      defaultBranchRef {
+        name
       }
     }
   }`;

--- a/src/github/client/github-user-client.ts
+++ b/src/github/client/github-user-client.ts
@@ -7,6 +7,7 @@ import { urlParamsMiddleware } from "utils/axios/url-params-middleware";
 import { GITHUB_ACCEPT_HEADER } from "utils/get-github-client-config";
 import { CreateReferenceBody } from "~/src/github/client/github-client.types";
 import { GitHubClient, GitHubConfig } from "./github-client";
+import { getBranchesNameQuery, getBranchesNameResponse } from "~/src/github/client/github-queries";
 
 /**
  * A GitHub client that supports authentication as a GitHub User.
@@ -86,6 +87,21 @@ export class GitHubUserClient extends GitHubClient {
 				owner,
 				repo
 			});
+	}
+
+	public async getBranches(owner: string, repo: string, per_page = 20, cursor?: string): Promise<getBranchesNameResponse> {
+		try {
+			const response = await this.graphql<getBranchesNameResponse>(getBranchesNameQuery, {}, {
+				owner,
+				repo,
+				per_page,
+				cursor
+			});
+			return response.data.data;
+		} catch (err) {
+			this.logger.error({ err }, "Could not fetch branches");
+			throw err;
+		}
 	}
 
 }

--- a/src/routes/github/create-branch/github-branches-get.test.ts
+++ b/src/routes/github/create-branch/github-branches-get.test.ts
@@ -36,7 +36,7 @@ describe("GitHub Branches Get", () => {
 		expect(res.send).toBeCalledWith(allBranches);
 	});
 
-	it.each(["githubToken", "jiraHost", "gitHubAppConfig"])("Should 401 without permission attributes", async (attribute) => {
+	it.each(["githubToken", "gitHubAppConfig"])("Should 401 without permission attributes", async (attribute) => {
 		delete res.locals[attribute];
 		await GithubBranchesGet(req, res);
 		expect(res.sendStatus).toHaveBeenCalledWith(401);
@@ -65,7 +65,7 @@ const setupNock = (req) => {
 			"data": {
 				"repository": {
 					"refs": {
-						"totalCount": 5,
+						"totalCount": 3,
 						"edges": [
 							{
 								"cursor": "MQ",
@@ -89,44 +89,11 @@ const setupNock = (req) => {
 				}
 			}
 		});
-
-	githubNock
-		.post("/graphql", {
-			query: getBranchesNameQuery,
-			variables: {
-				owner: req.params.owner,
-				repo: req.params.repo,
-				per_page: 100,
-				cursor: "Mw"
-			}
-		})
-		.reply(200, {
-			"data": {
-				"repository": {
-					"refs": {
-						"totalCount": 5,
-						"edges": [
-							{
-								"cursor": "Mk",
-								"node": {
-									"name": "sample-patch-4"
-								}
-							},
-							{
-								"cursor": "Mz",
-								"node": {
-									"name": "sample-patch-5"
-								}
-							}]
-					}
-				}
-			}
-		});
 };
 const allBranches = {
 	"repository": {
 		"refs": {
-			"totalCount": 5,
+			"totalCount": 3,
 			"edges": [
 				{
 					"cursor": "MQ",
@@ -144,17 +111,6 @@ const allBranches = {
 					"cursor": "Mw",
 					"node": {
 						"name": "sample-patch-3"
-					}
-				}, {
-					"cursor": "Mk",
-					"node": {
-						"name": "sample-patch-4"
-					}
-				},
-				{
-					"cursor": "Mz",
-					"node": {
-						"name": "sample-patch-5"
 					}
 				}]
 		}

--- a/src/routes/github/create-branch/github-branches-get.test.ts
+++ b/src/routes/github/create-branch/github-branches-get.test.ts
@@ -1,0 +1,162 @@
+
+import { getLogger } from "config/logger";
+import { getBranchesNameQuery } from "~/src/github/client/github-queries";
+import { GithubBranchesGet } from "~/src/routes/github/create-branch/github-branches-get";
+
+describe("GitHub Branches Get", () => {
+
+	let req, res;
+	beforeEach(async () => {
+
+		req = {
+			log: getLogger("request"),
+			params: {
+				owner: "ARC",
+				repo: "repo-1"
+			}
+		};
+
+		res = {
+			sendStatus: jest.fn(),
+			send: jest.fn(),
+			status: jest.fn(),
+			json: jest.fn(),
+			locals: {
+				jiraHost,
+				githubToken: "abc-token",
+				gitHubAppConfig: {}
+			}
+		};
+	});
+
+	it("Should fetch branches", async () => {
+
+		setupNock(req);
+		await GithubBranchesGet(req, res);
+		expect(res.send).toBeCalledWith(allBranches);
+	});
+
+	it.each(["githubToken", "jiraHost", "gitHubAppConfig"])("Should 401 without permission attributes", async (attribute) => {
+		delete res.locals[attribute];
+		await GithubBranchesGet(req, res);
+		expect(res.sendStatus).toHaveBeenCalledWith(401);
+	});
+
+	it.each(["owner", "repo"])("Should 400 when missing required fields", async (attribute) => {
+		res.status.mockReturnValue(res);
+		delete req.params[attribute];
+		await GithubBranchesGet(req, res);
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+});
+
+const setupNock = (req) => {
+	githubNock
+		.post("/graphql", {
+			query: getBranchesNameQuery,
+			variables: {
+				owner: req.params.owner,
+				repo: req.params.repo,
+				per_page: 100
+			}
+		})
+		.reply(200, {
+			"data": {
+				"repository": {
+					"refs": {
+						"totalCount": 5,
+						"edges": [
+							{
+								"cursor": "MQ",
+								"node": {
+									"name": "sample-patch-1"
+								}
+							},
+							{
+								"cursor": "Mg",
+								"node": {
+									"name": "sample-patch-2"
+								}
+							},
+							{
+								"cursor": "Mw",
+								"node": {
+									"name": "sample-patch-3"
+								}
+							}]
+					}
+				}
+			}
+		});
+
+	githubNock
+		.post("/graphql", {
+			query: getBranchesNameQuery,
+			variables: {
+				owner: req.params.owner,
+				repo: req.params.repo,
+				per_page: 100,
+				cursor: "Mw"
+			}
+		})
+		.reply(200, {
+			"data": {
+				"repository": {
+					"refs": {
+						"totalCount": 5,
+						"edges": [
+							{
+								"cursor": "Mk",
+								"node": {
+									"name": "sample-patch-4"
+								}
+							},
+							{
+								"cursor": "Mz",
+								"node": {
+									"name": "sample-patch-5"
+								}
+							}]
+					}
+				}
+			}
+		});
+};
+const allBranches = {
+	"repository": {
+		"refs": {
+			"totalCount": 5,
+			"edges": [
+				{
+					"cursor": "MQ",
+					"node": {
+						"name": "sample-patch-1"
+					}
+				},
+				{
+					"cursor": "Mg",
+					"node": {
+						"name": "sample-patch-2"
+					}
+				},
+				{
+					"cursor": "Mw",
+					"node": {
+						"name": "sample-patch-3"
+					}
+				}, {
+					"cursor": "Mk",
+					"node": {
+						"name": "sample-patch-4"
+					}
+				},
+				{
+					"cursor": "Mz",
+					"node": {
+						"name": "sample-patch-5"
+					}
+				}]
+		}
+	}
+};

--- a/src/routes/github/create-branch/github-branches-get.ts
+++ b/src/routes/github/create-branch/github-branches-get.ts
@@ -1,0 +1,40 @@
+import { Request, Response } from "express";
+import { createUserClient } from "~/src/util/get-github-client-config";
+
+export const GithubBranchesGet = async (req: Request, res: Response): Promise<void> => {
+	const { githubToken, jiraHost, gitHubAppConfig } = res.locals;
+
+	if (!githubToken || !jiraHost || !gitHubAppConfig) {
+		res.sendStatus(401);
+		return;
+	}
+
+	const { owner, repo } = req.params;
+	if (!owner || !repo) {
+		res.status(400).json({ err: "Missing required data." });
+		return;
+	}
+
+	try {
+		const gitHubUserClient = await createUserClient(githubToken, jiraHost, req.log, gitHubAppConfig.gitHubAppId);
+		let allBranchesFetched = false;
+		let allBranches;
+		let cursor;
+		while (!allBranchesFetched) {
+			const response = await gitHubUserClient.getBranches(owner, repo, 100, cursor);
+			if (allBranches) {
+				allBranches.repository.refs.edges = allBranches.repository.refs.edges.concat(response.repository.refs.edges);
+			} else {
+				allBranches = response;
+			}
+			cursor = allBranches.repository.refs.edges[allBranches.repository.refs.edges.length - 1].cursor;
+			if (allBranches.repository.refs.edges.length >= response.repository.refs.totalCount) {
+				allBranchesFetched = true;
+			}
+		}
+		res.send(allBranches);
+	} catch (err) {
+		req.log.error({ err }, "Error while fetching branches");
+		res.sendStatus(500);
+	}
+};

--- a/src/routes/github/create-branch/github-create-branch-router.ts
+++ b/src/routes/github/create-branch/github-create-branch-router.ts
@@ -1,9 +1,12 @@
 import { Router } from "express";
 import { GithubCreateBranchGet } from "routes/github/create-branch/github-create-branch-get";
 import { GithubCreateBranchPost } from "routes/github/create-branch/github-create-branch-post";
+import { GithubBranchesGet } from "~/src/routes/github/create-branch/github-branches-get";
 
 export const GithubCreateBranchRouter = Router();
 
 GithubCreateBranchRouter.route("/")
 	.get(GithubCreateBranchGet)
 	.post(GithubCreateBranchPost);
+
+GithubCreateBranchRouter.get("/owners/:owner/repos/:repo/branches", GithubBranchesGet);


### PR DESCRIPTION
**What's in this PR?**
Implented an endpint that return all the branches for a given `org` and `repo`

**Why**
This endpoint will be used to display branches in drop down for create-branch UI.

**Affected issues**  
[ARC-1608]

**How has this been tested?**  
Unit test cases added



[ARC-1608]: https://softwareteams.atlassian.net/browse/ARC-1608