### PR TITLE
noissue: Remove ff send-code-scanning-alerts-as-remote-links

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -16,7 +16,6 @@ export enum BooleanFlags {
 	ASSOCIATE_PR_TO_ISSUES_IN_BODY = "associate-pr-to-issues-in-body",
 	VERBOSE_LOGGING = "verbose-logging",
 	LOG_UNSAFE_DATA = "log-unsafe-data",
-	SEND_CODE_SCANNING_ALERTS_AS_REMOTE_LINKS = "send-code-scanning-alerts-as-remote-links",
 	REGEX_FIX = "regex-fix",
 	USE_NEW_GITHUB_CLIENT_FOR_INSTALLATION_API = "use-new-github-client-for-installation-api",
 	RETRY_ALL_ERRORS = "retry-all-errors",

--- a/src/github/code-scanning-alert.ts
+++ b/src/github/code-scanning-alert.ts
@@ -1,5 +1,4 @@
 import { transformCodeScanningAlert } from "../transforms/transform-code-scanning-alert";
-import { booleanFlag, BooleanFlags } from "config/feature-flags";
 import { emitWebhookProcessedMetrics } from "utils/webhook-utils";
 import { WebhookContext } from "../routes/github/webhook/webhook-context";
 
@@ -8,9 +7,6 @@ export const codeScanningAlertWebhookHandler = async (context: WebhookContext, j
 		gitHubInstallationId,
 		jiraHost: jiraClient.baseURL
 	});
-	if (!(await booleanFlag(BooleanFlags.SEND_CODE_SCANNING_ALERTS_AS_REMOTE_LINKS, false, jiraClient.baseUrl))) {
-		return;
-	}
 
 	const jiraPayload = await transformCodeScanningAlert(context, gitHubInstallationId, jiraClient.baseUrl);
 


### PR DESCRIPTION
**What's in this PR?**
Removing send-code-scanning-alerts-as-remote-links FF

**Why**
Because it has been out in prod for ages and I want my name out of the Board of Shame

**Added feature flags**

**Affected issues**  
_Jira Issues_

**How has this been tested?**  
_Include how to test if applicable_

**Whats Next?**
