### PR TITLE
SALTBAE-337 Add service association to deployments

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -24,7 +24,8 @@ export enum BooleanFlags {
 	CREATE_BRANCH = "create-branch",
 	SEND_PR_COMMENTS_TO_JIRA = "send-pr-comments-to-jira_zy5ib",
 	USE_REPO_ID_TRANSFORMER = "use-repo-id-transformer",
-	USE_OUTBOUND_PROXY_FOR_OUATH_ROUTER = "use-outbound-proxy-for-oauth-router"
+	USE_OUTBOUND_PROXY_FOR_OUATH_ROUTER = "use-outbound-proxy-for-oauth-router",
+	SERVICE_ASSOCIATIONS_FOR_DEPLOYMENTS = "service-associations-for-deployments"
 }
 
 export enum StringFlags {

--- a/src/interfaces/common.ts
+++ b/src/interfaces/common.ts
@@ -70,5 +70,9 @@ export interface Config {
 			staging?: string[];
 			production?: string[];
 		}
+
+		services?: {
+			ids?: string[];
+		}
 	}
 }

--- a/src/interfaces/jira.ts
+++ b/src/interfaces/jira.ts
@@ -160,7 +160,7 @@ export interface JiraPullRequestBulkSubmitData extends BulkSubmitRepositoryInfo 
 }
 
 export interface JiraAssociation {
-	associationType: "issueKeys" | "issueIdOrKeys" | "commit";
+	associationType: "issueKeys" | "issueIdOrKeys" | "commit" | "serviceIdOrKeys";
 	values: string[] | JiraCommitKey[];
 }
 

--- a/src/services/user-config-service.test.ts
+++ b/src/services/user-config-service.test.ts
@@ -3,6 +3,16 @@ import { RepoSyncState } from "models/reposyncstate";
 import { Subscription } from "models/subscription";
 import { getRepoConfig, updateRepoConfig } from "services/user-config-service";
 import { getInstallationId } from "~/src/github/client/installation-id";
+import { when } from "jest-when";
+import { booleanFlag, BooleanFlags } from "config/feature-flags";
+
+jest.mock("config/feature-flags");
+
+const turnFF_OnOff_service = (newStatus: boolean) => {
+	when(jest.mocked(booleanFlag))
+		.calledWith(BooleanFlags.SERVICE_ASSOCIATIONS_FOR_DEPLOYMENTS, expect.anything())
+		.mockResolvedValue(newStatus);
+};
 
 describe("User Config Service", () => {
 	const gitHubInstallationId = 1234;
@@ -24,12 +34,19 @@ describe("User Config Service", () => {
 		"      - \"Produktion\"\n" +
 		"      - \"produção\"\n" +
 		"      - \"продакшн\"\n" +
-		"      - \"PROD-*\"";
+		"      - \"PROD-*\"\n" +
+		"  services:\n" +
+		"    ids:\n" +
+		"      - \"test-id-1\"\n" +
+		"      - \"test-id-2\"\n" +
+		"      - \"test-id-3\"\n" +
+		"      - \"test-id-4\"";
 
 	const configFileContentBase64 = Buffer.from(configFileContent).toString("base64");
 
 
 	beforeEach(async () => {
+		turnFF_OnOff_service(false);
 		subscription = await Subscription.create({
 			gitHubInstallationId,
 			jiraHost,
@@ -81,6 +98,16 @@ describe("User Config Service", () => {
 		const config = await getRepoConfig(subscription, getInstallationId(gitHubInstallationId), repoSyncState.repoId, repoSyncState.repoOwner, repoSyncState.repoName);
 		expect(config).toBeTruthy();
 		expect(config?.deployments?.environmentMapping?.development).toHaveLength(4);
+	});
+
+	it("should get service ids behind ff", async () => {
+		turnFF_OnOff_service(true);
+		githubUserTokenNock(gitHubInstallationId);
+		givenGitHubReturnsConfigFile();
+		await updateRepoConfig(subscription, repoSyncState.repoId, getInstallationId(gitHubInstallationId), ["random.yml", "ignored.yml", ".jira/config.yml"]);
+		const config = await getRepoConfig(subscription, getInstallationId(gitHubInstallationId), repoSyncState.repoId, repoSyncState.repoOwner, repoSyncState.repoName);
+		expect(config).toBeTruthy();
+		expect(config?.deployments?.services?.ids).toHaveLength(4);
 	});
 
 	it("should get config directly from GitHub when we don't have a record of the repo", async () => {

--- a/src/transforms/transform-deployment.test.ts
+++ b/src/transforms/transform-deployment.test.ts
@@ -36,6 +36,16 @@ const mockConfig = {
 	}
 };
 
+const mockGetRepoConfig = () => {
+	when(getRepoConfig).calledWith(
+		expect.anything(),
+		expect.anything(),
+		expect.anything(),
+		expect.anything(),
+		expect.anything()
+	).mockResolvedValue(mockConfig);
+};
+
 const turnOnGHESFF = () => {
 	when(jest.mocked(booleanFlag))
 		.calledWith(BooleanFlags.GHE_SERVER, expect.anything(), expect.anything())
@@ -233,13 +243,7 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 				}
 				);
 
-			when(getRepoConfig).calledWith(
-				expect.anything(),
-				expect.anything(),
-				expect.anything(),
-				expect.anything(),
-				expect.anything()
-			).mockResolvedValue(mockConfig);
+			mockGetRepoConfig();
 
 			const jiraPayload = await transformDeployment(gitHubClient, deployment_status_staging.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
 
@@ -355,76 +359,175 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 			]));
 		});
 
-		it(`supports branch and merge workflows, sending zero commits in deployment when 500 issues`, async () => {
+		// The number of values counted across all associationTypes (issueKeys, issueIdOrKeys and serviceIdOrKeys) must not exceed a limit of 500.
+		// https://developer.atlassian.com/cloud/jira/software/rest/api-group-deployments/#api-rest-deployments-0-1-bulk-post
+		describe("limits to 500 total", () => {
+			beforeEach(() => {
+				//If we use old GH Client we won't call the API because we pass already "authenticated" client to the test method
+				githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
+				githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
+				githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
+				githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 
-			//If we use old GH Client we won't call the API because we pass already "authenticated" client to the test method
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
+				// Mocking all GitHub API Calls
+				// Get commit
+				githubNock.get(`/repos/${owner.login}/${repoName}/commits/${deployment_status.payload.deployment.sha}`)
+					.reply(200, {
+						...owner,
+						commit: {
+							message: "testing"
+						}
+					});
 
-			// Mocking all GitHub API Calls
-			// Get commit
-			githubNock.get(`/repos/${owner.login}/${repoName}/commits/${deployment_status.payload.deployment.sha}`)
-				.reply(200, {
-					...owner,
-					commit: {
-						message: "testing"
-					}
-				});
+				// List deployments
+				githubNock.get(`/repos/${owner.login}/${repoName}/deployments?environment=Production&per_page=10`)
+					.reply(200,
+						[
+							{
+								id: 1,
+								environment: "Production",
+								sha: "6e87a40179eb7ecf5094b9c8d690db727472d5bc"
+							}
+						]
+					);
 
-			// List deployments
-			githubNock.get(`/repos/${owner.login}/${repoName}/deployments?environment=Production&per_page=10`)
-				.reply(200,
-					[
+				// List deployments statuses
+				githubNock.get(`/repos/${owner.login}/${repoName}/deployments/1/statuses?per_page=100`)
+					.reply(200, [
 						{
 							id: 1,
-							environment: "Production",
-							sha: "6e87a40179eb7ecf5094b9c8d690db727472d5bc"
+							state: "pending"
+						},
+						{
+							id: 2,
+							state: "success"
 						}
-					]
-				);
+					]);
+			});
 
-			// List deployments statuses
-			githubNock.get(`/repos/${owner.login}/${repoName}/deployments/1/statuses?per_page=100`)
-				.reply(200, [
+			it(`crops issue keys (505) to 500 (5 issue keys must be left aside)`, async () => {
+
+				// make message with 500 issue ids to prove there isn't room in the submission for any associated commits
+				const commitMessage = "ABC-" + [...Array(505).keys()].join(" ABC-");
+
+				// Compare commits
+				githubNock.get(`/repos/${owner.login}/${repoName}/compare/6e87a40179eb7ecf5094b9c8d690db727472d5bc...${deployment_status.payload.deployment.sha}`)
+					.reply(200, {
+						commits: [
+							{
+								commit: {
+									message: commitMessage
+								},
+								sha: "6e87a40179eb7ecf5094b9c8d690db727472d5bc1"
+							}
+						]
+					});
+
+				const jiraPayload = await transformDeployment(gitHubClient, deployment_status.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
+
+				// make expected issue id array
+				const expectedIssueIds = [...Array(500).keys()].map(number => "ABC-" + number);
+
+				expect(jiraPayload).toMatchObject(buildJiraPayload([
 					{
-						id: 1,
-						state: "pending"
+						associationType: "issueIdOrKeys",
+						values: expectedIssueIds
+					}
+				]));
+			});
+
+			it(`crops issue keys (499) and services (2) to 500 (one service must be left aside)`, async () => {
+				await turnFF_OnOff_service(true);
+
+				// make message with 500 issue ids to prove there isn't room in the submission for any associated commits
+				const commitMessage = "ABC-" + [...Array(499).keys()].join(" ABC-");
+
+				// Compare commits
+				githubNock.get(`/repos/${owner.login}/${repoName}/compare/6e87a40179eb7ecf5094b9c8d690db727472d5bc...${deployment_status.payload.deployment.sha}`)
+					.reply(200, {
+						commits: [
+							{
+								commit: {
+									message: commitMessage
+								},
+								sha: "6e87a40179eb7ecf5094b9c8d690db727472d5bc1"
+							}
+						]
+					});
+
+				mockGetRepoConfig();
+
+				const jiraPayload = await transformDeployment(gitHubClient, deployment_status.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
+
+				// make expected issue id array
+
+				expect(jiraPayload).toMatchObject(buildJiraPayload([
+					{
+						associationType: "issueIdOrKeys",
+						values: [...Array(499).keys()].map(number => "ABC-" + number)
 					},
 					{
-						id: 2,
-						state: "success"
+						associationType: "serviceIdOrKeys",
+						values: ["service-id-1"] // 'service-id-2' should not be expected
 					}
-				]);
+				]));
+			});
 
-			// make message with 500 issue ids to prove there isn't room in the submission for any associated commits
-			const commitMessage = "ABC-" + [...Array(500).keys()].join(" ABC-");
+			it(`crops issue keys (497), service ids (2) and commits (2) to 500 (one commit must be left aside)`, async () => {
+				await turnFF_OnOff_service(true);
 
-			// Compare commits
-			githubNock.get(`/repos/${owner.login}/${repoName}/compare/6e87a40179eb7ecf5094b9c8d690db727472d5bc...${deployment_status.payload.deployment.sha}`)
-				.reply(200, {
-					commits: [
-						{
-							commit: {
-								message: commitMessage
+				// make message with 500 issue ids to prove there isn't room in the submission for any associated commits
+				const commitMessage = "ABC-" + [...Array(497).keys()].join(" ABC-");
+
+				// Compare commits
+				githubNock.get(`/repos/${owner.login}/${repoName}/compare/6e87a40179eb7ecf5094b9c8d690db727472d5bc...${deployment_status.payload.deployment.sha}`)
+					.reply(200, {
+						commits: [
+							{
+								commit: {
+									message: commitMessage
+								},
+								sha: "expected"
 							},
-							sha: "6e87a40179eb7ecf5094b9c8d690db727472d5bc1"
-						}
-					]
-				});
+							{
+								commit: {
+									message: commitMessage
+								},
+								sha: "notexpected"
+							}
+						]
+					});
 
-			const jiraPayload = await transformDeployment(gitHubClient, deployment_status.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
+				when(getRepoConfig).calledWith(
+					expect.anything(),
+					expect.anything(),
+					expect.anything(),
+					expect.anything(),
+					expect.anything()
+				).mockResolvedValue(mockConfig);
 
-			// make expected issue id array
-			const expectedIssueIds = [...Array(500).keys()].map(number => "ABC-" + number);
+				const jiraPayload = await transformDeployment(gitHubClient, deployment_status.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
 
-			expect(jiraPayload).toMatchObject(buildJiraPayload([
-				{
-					associationType: "issueIdOrKeys",
-					values: expectedIssueIds
-				}
-			]));
+				expect(jiraPayload).toMatchObject(buildJiraPayload([
+					{
+						associationType: "issueIdOrKeys",
+						values: [...Array(497).keys()].map(number => "ABC-" + number)
+					},
+					{
+						associationType: "serviceIdOrKeys",
+						values: ["service-id-1", "service-id-2"]
+					},
+					{
+						associationType: "commit",
+						values: [
+							{
+								repositoryId: "65",
+								commitHash: "expected"
+							}
+						]
+					}
+				]));
+			});
 		});
 
 		it(`uses user config to map environment`, async () => {
@@ -489,13 +592,7 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 					]
 				});
 
-			when(getRepoConfig).calledWith(
-				expect.anything(),
-				expect.anything(),
-				expect.anything(),
-				expect.anything(),
-				expect.anything()
-			).mockResolvedValue(mockConfig);
+			mockGetRepoConfig();
 
 			const jiraPayload = await transformDeployment(gitHubClient, deployment_status_staging.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
 			expect(jiraPayload?.deployments[0].environment.type).toBe("development");

--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -16,6 +16,7 @@ import { Subscription } from "models/subscription";
 import minimatch from "minimatch";
 import { getRepoConfig } from "services/user-config-service";
 import { TransformedRepositoryId, transformRepositoryId } from "~/src/transforms/transform-repository-id";
+import { booleanFlag, BooleanFlags } from "config/feature-flags";
 
 const MAX_ASSOCIATIONS_PER_ENTITY = 500;
 
@@ -167,27 +168,42 @@ export const mapEnvironment = (environment: string, config?: Config): string => 
 	return Object.keys(environmentMapping).find(key => isEnvironment(environmentMapping[key])) || "unmapped";
 };
 
+
 // Maps issue ids and commit summaries to an array of associations (one for issue ids, and one for commits).
 // Returns undefined when there are no issue ids to map.
-const mapJiraIssueIdsAndCommitsToAssociationArray = (
+const mapJiraIssueIdsCommitsAndServicesToAssociationArray = async (
 	issueIds: string[],
 	transformedRepositoryId: TransformedRepositoryId,
-	commitSummaries?: CommitSummary[]
-): JiraAssociation[] | undefined => {
+	commitSummaries?: CommitSummary[],
+	config?: Config
+): Promise<JiraAssociation[] | undefined> => {
 
-	if (!issueIds?.length) {
-		return undefined;
+	const associations: JiraAssociation[] = [];
+	let totalAssociationCount = 0;
+	if (issueIds?.length) {
+		associations.push(
+			{
+				associationType: "issueIdOrKeys",
+				values: issueIds
+			}
+		);
+		totalAssociationCount += issueIds.length;
 	}
 
-	const associations: JiraAssociation[] = [
-		{
-			associationType: "issueIdOrKeys",
-			values: issueIds
+	if (await booleanFlag(BooleanFlags.SERVICE_ASSOCIATIONS_FOR_DEPLOYMENTS, false)) {
+		if (config?.deployments?.services?.ids) {
+			associations.push(
+				{
+					associationType: "serviceIdOrKeys",
+					values: config.deployments.services.ids
+				}
+			);
+			totalAssociationCount += config.deployments.services.ids.length;
 		}
-	];
+	}
 
 	if (commitSummaries?.length) {
-		const maximumCommitsToSubmit = MAX_ASSOCIATIONS_PER_ENTITY - issueIds.length;
+		const maximumCommitsToSubmit = MAX_ASSOCIATIONS_PER_ENTITY - totalAssociationCount;
 		const commitKeys = commitSummaries
 			.slice(0, maximumCommitsToSubmit)
 			.map((commitSummary) => {
@@ -224,16 +240,6 @@ export const transformDeployment = async (githubInstallationClient: GitHubInstal
 		logger
 	);
 
-	const allCommitsMessages = extractMessagesFromCommitSummaries(commitSummaries);
-	const associations = mapJiraIssueIdsAndCommitsToAssociationArray(
-		jiraIssueKeyParser(`${deployment.ref}\n${message}\n${allCommitsMessages}`),
-		await transformRepositoryId(payload.repository.id, githubInstallationClient.baseUrl),
-		commitSummaries
-	);
-
-	if (!associations?.length) {
-		return undefined;
-	}
 
 	let config: Config | undefined;
 
@@ -252,7 +258,20 @@ export const transformDeployment = async (githubInstallationClient: GitHubInstal
 		}, "could not find subscription - not using user config to map environments!");
 	}
 
+	const allCommitsMessages = extractMessagesFromCommitSummaries(commitSummaries);
+	const associations = await mapJiraIssueIdsCommitsAndServicesToAssociationArray(
+		jiraIssueKeyParser(`${deployment.ref}\n${message}\n${allCommitsMessages}`),
+		await transformRepositoryId(payload.repository.id, githubInstallationClient.baseUrl),
+		commitSummaries,
+		config
+	);
+
+	if (!associations?.length) {
+		return undefined;
+	}
+
 	const environment = mapEnvironment(deployment_status.environment, config);
+
 	if (environment === "unmapped") {
 		logger?.info({
 			environment: deployment_status.environment,

--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -181,21 +181,27 @@ const mapJiraIssueIdsCommitsAndServicesToAssociationArray = async (
 	const associations: JiraAssociation[] = [];
 	let totalAssociationCount = 0;
 	if (issueIds?.length) {
+		const maximumIssuesToSubmit = MAX_ASSOCIATIONS_PER_ENTITY - totalAssociationCount;
+		const issues = issueIds
+			.slice(0, maximumIssuesToSubmit);
 		associations.push(
 			{
 				associationType: "issueIdOrKeys",
-				values: issueIds
+				values: issues
 			}
 		);
-		totalAssociationCount += issueIds.length;
+		totalAssociationCount += issues.length;
 	}
 
 	if (await booleanFlag(BooleanFlags.SERVICE_ASSOCIATIONS_FOR_DEPLOYMENTS, false)) {
 		if (config?.deployments?.services?.ids) {
+			const maximumServicesToSubmit = MAX_ASSOCIATIONS_PER_ENTITY - totalAssociationCount;
+			const services = config.deployments.services.ids
+				.slice(0, maximumServicesToSubmit);
 			associations.push(
 				{
 					associationType: "serviceIdOrKeys",
-					values: config.deployments.services.ids
+					values: services
 				}
 			);
 			totalAssociationCount += config.deployments.services.ids.length;


### PR DESCRIPTION
**What's in this PR?**
Service association for deployments has been added. 

**Why**
We need to add a support service association for Deployments that has been created by GitHub. In order to use those at multiple features at JSM. 

**Added feature flags**
-

**Affected issues**  
[SALTBAE-337](https://jdog.jira-dev.com/browse/SALTBAE-337)

**How has this been tested?**  
Locally
Unit Test cases also added. 

**Whats Next?**
We're going to add Deployment Gating capability for GitHub Deployments. 
