### PR TITLE
ARC-1682 Manual source branch

### DIFF
--- a/src/github/client/github-user-client.ts
+++ b/src/github/client/github-user-client.ts
@@ -137,7 +137,7 @@ export class GitHubUserClient extends GitHubClient {
 			});
 	}
 
-	public async getBranches(owner: string, repo: string, per_page = 20, cursor?: string): Promise<getBranchesNameResponse> {
+	public async getReferences(owner: string, repo: string, per_page = 20, cursor?: string): Promise<getBranchesNameResponse> {
 		try {
 			const response = await this.graphql<getBranchesNameResponse>(getBranchesNameQuery, {}, {
 				owner,

--- a/src/routes/github/create-branch/github-branches-get.ts
+++ b/src/routes/github/create-branch/github-branches-get.ts
@@ -17,7 +17,7 @@ export const GithubBranchesGet = async (req: Request, res: Response): Promise<vo
 
 	try {
 		const gitHubUserClient = await createUserClient(githubToken, jiraHost, req.log, gitHubAppConfig.gitHubAppId);
-		const branches = await gitHubUserClient.getBranches(owner, repo, 100);
+		const branches = await gitHubUserClient.getReferences(owner, repo, 100);
 		res.send(branches);
 	} catch (err) {
 		req.log.error({ err }, "Error while fetching branches");

--- a/static/js/github-create-branch.js
+++ b/static/js/github-create-branch.js
@@ -83,6 +83,7 @@ const loadBranches = () => {
     type: "GET",
     url: `/github/create-branch/owners/${repo.owner}/repos/${repo.name}/branches`,
     success: (data) => {
+      const allBranchesfetched = data?.repository?.refs?.totalCount === data?.repository?.refs?.edges.length;
       $("#ghParentBranch").auiSelect2({
         data: () => {
           data.repository.refs.edges.forEach((item) => {
@@ -94,7 +95,16 @@ const loadBranches = () => {
           }
         },
         formatSelection: item => item.node.name,
-        formatResult: item => item.node.name
+        formatResult: item => item.node.name,
+        createSearchChoice: (term) => {
+          if (allBranchesfetched) {
+            return null;
+          }
+          return {
+            node: { name: term },
+            id: term
+          }
+        }
       });
       $("#ghParentBranch").select2("val", data.repository.defaultBranchRef.name);
       toggleSubmitDisabled(false);
@@ -124,9 +134,13 @@ const createBranchPost = () => {
       // On success, we close the tab so the user returns to original screen
       window.close();
     })
-    .fail((err) => {
+    .fail((error) => {
       toggleSubmitDisabled(false);
-      showErrorMessage("Please make sure all the details you entered are correct.")
+      if (error.responseJSON && error.responseJSON.err) {
+        showErrorMessage(error.responseJSON.err);
+      } else {
+        showErrorMessage("Please make sure all the details you entered are correct.")
+      }
     });
 }
 


### PR DESCRIPTION
**What's in this PR?**
We're showing only first 100 branches in `create-branch` page. This will give a user flexibility to provide the source branch
in case repo has more than 100 branches and the intended branch not in the drop down list. 

<img width="615" alt="Screen Shot 2022-09-16 at 11 32 37 am" src="https://user-images.githubusercontent.com/14277763/190570549-e25eda68-2905-4d64-aa9b-303a6c6e65ed.png">

Show error in case of invalid source branch
<img width="619" alt="Screen Shot 2022-09-16 at 11 33 12 am" src="https://user-images.githubusercontent.com/14277763/190570630-f79b1aee-7075-423d-ba8c-bd46261531c5.png">


**Why**
To support use case with more than 100 branches

**Affected issues**  
[ARC-1682]

**How has this been tested?**  
Local


[ARC-1682]: https://softwareteams.atlassian.net/browse/ARC-1682