### PR TITLE
prTitle and prRef are now hashed - removed payload dump on log

### DIFF
--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -224,7 +224,6 @@ const doProcessInstallation = async (data: BackfillMessagePayload, sentry: Hub, 
 			} catch (err) {
 				const log = logger.child({
 					err,
-					payload: data,
 					repository,
 					cursor,
 					task

--- a/src/util/logger-utils.ts
+++ b/src/util/logger-utils.ts
@@ -4,7 +4,7 @@ import bformat from "bunyan-format";
 import { DEBUG } from "bunyan";
 import { createHashWithSharedSecret } from "utils/encryption";
 
-const SENSITIVE_DATA_FIELDS = ["jiraHost", "orgName", "repoName", "userGroup", "userGroup", "aaid", "username"];
+const SENSITIVE_DATA_FIELDS = ["jiraHost", "orgName", "repoName", "userGroup", "userGroup", "aaid", "username", "prTitle", "prRef"];
 // For any Micros env we want the logs to be in JSON format.
 // Otherwise, if local development, we want human readable logs.
 const outputMode = process.env.MICROS_ENV ? "json" : "short";


### PR DESCRIPTION
**What's in this PR?**
Adding prTitle and prRef to the sensitive data list

Removing a complete payload object in a log

**Why**
prTitle and prRef is UGC and needs to be hidden

an entire payload it too much logging! we need to be targeted, payload is ok during debug but not as a default, we cannot always be sure what is in it and could potentially leak PII/UGC

**Added feature flags**
nope

**Affected issues**  
nope

**How has this been tested?**  
locally only, changes are minor enough that I feel this is sufficient.

**Whats Next?**
Keep hunting for UGC!