### PR TITLE
ARC-1688: map some errors to 400 instead of 500

### DIFF
--- a/src/routes/error-router.ts
+++ b/src/routes/error-router.ts
@@ -63,6 +63,10 @@ ErrorRouter.use((err: Error, req: Request, res: Response, next: NextFunction) =>
 		Forbidden: 403,
 		"Not Found": 404
 	};
+	errorCodes[Errors.MISSING_JIRA_HOST] = 400;
+	errorCodes[Errors.MISSING_GITHUB_TOKEN] = 400;
+	errorCodes[Errors.MISSING_GITHUB_APP_NAME] = 400;
+	errorCodes[Errors.MISSING_ISSUE_KEY] = 400;
 
 	const messages = {
 		[Errors.MISSING_JIRA_HOST]: "Session information missing - please enable all cookies in your browser settings.",


### PR DESCRIPTION
The SLO of the rendering of the GitHub config page is failing because there are too many "bad events". The logs show a lot of errors like `Error: Jira Host url is missing`. So, I mapped this error (and some others) to an HTTP status code `400` (instead of the default `500`). `400`s don't count as "bad events" in the SLO