### PR TITLE
ARC-1606 Display user details

### DIFF
--- a/src/routes/github/create-branch/github-create-branch-get.test.ts
+++ b/src/routes/github/create-branch/github-create-branch-get.test.ts
@@ -42,6 +42,9 @@ describe("GitHub Create Branch Get", () => {
 			githubNock
 				.post("/graphql", { query: GetRepositoriesQuery, variables: { per_page: 20 } })
 				.reply(200, { data: { viewer: { repositories: { edges: [] } } } });
+			githubNock
+				.get("/user")
+				.reply(200, { data: { login: "test-account" } });
 
 			await supertest(app)
 				.get("/github/create-branch").set(

--- a/src/routes/github/create-branch/github-create-branch-get.ts
+++ b/src/routes/github/create-branch/github-create-branch-get.ts
@@ -29,6 +29,7 @@ export const GithubCreateBranchGet = async (req: Request, res: Response, next: N
 
 	const gitHubUserClient = await createUserClient(githubToken, jiraHost, req.log, gitHubAppConfig.gitHubAppId);
 	const response = await gitHubUserClient.getUserRepositories();
+	const gitHubUser = (await gitHubUserClient.getUser()).data.login;
 
 	res.render("github-create-branch.hbs", {
 		csrfToken: req.csrfToken(),
@@ -39,7 +40,8 @@ export const GithubCreateBranchGet = async (req: Request, res: Response, next: N
 			key
 		},
 		servers,
-		repos: response.viewer.repositories.edges
+		repos: response.viewer.repositories.edges,
+		gitHubUser
 	});
 
 	req.log.debug(`Github Create Branch Page rendered page`);

--- a/src/routes/github/create-branch/github-create-branch-router.ts
+++ b/src/routes/github/create-branch/github-create-branch-router.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { GithubCreateBranchGet } from "routes/github/create-branch/github-create-branch-get";
 import { GithubCreateBranchPost } from "routes/github/create-branch/github-create-branch-post";
 import { GithubBranchesGet } from "~/src/routes/github/create-branch/github-branches-get";
+import { GithubRemoveSession } from "~/src/routes/github/create-branch/github-remove-session";
 
 export const GithubCreateBranchRouter = Router();
 
@@ -10,3 +11,5 @@ GithubCreateBranchRouter.route("/")
 	.post(GithubCreateBranchPost);
 
 GithubCreateBranchRouter.get("/owners/:owner/repos/:repo/branches", GithubBranchesGet);
+
+GithubCreateBranchRouter.get("/change-github-login", GithubRemoveSession);

--- a/src/routes/github/create-branch/github-remove-session.test.ts
+++ b/src/routes/github/create-branch/github-remove-session.test.ts
@@ -1,0 +1,34 @@
+import { GithubRemoveSession } from "~/src/routes/github/create-branch/github-remove-session";
+
+describe("GitHub Remove Session", () => {
+
+	let req, res;
+	beforeEach(async () => {
+
+		req = {
+			session: {
+				githubToken: "abc-token"
+			}
+		};
+
+		res = {
+			sendStatus: jest.fn(),
+			send: jest.fn(),
+			locals: {
+				gitHubAppConfig: {}
+			}
+		};
+	});
+
+	it.each(["gitHubAppConfig"])("Should 401 when missing required fields", (attribute) => {
+		delete res.locals[attribute];
+		GithubRemoveSession(req, res);
+		expect(res.sendStatus).toHaveBeenCalledWith(401);
+	});
+
+	it("Should remove githubToken from session", () => {
+		GithubRemoveSession(req, res);
+		expect(req.session.githubToken).toBeUndefined();
+	});
+
+});

--- a/src/routes/github/create-branch/github-remove-session.ts
+++ b/src/routes/github/create-branch/github-remove-session.ts
@@ -1,0 +1,15 @@
+import { Request, Response } from "express";
+
+
+export const GithubRemoveSession = (req: Request, res: Response) => {
+	const { gitHubAppConfig } = res.locals;
+
+	if (!gitHubAppConfig) {
+		res.sendStatus(401);
+		return;
+	}
+
+	req.session.githubToken = undefined;
+	res.send({ baseUrl: gitHubAppConfig.hostname });
+
+};

--- a/static/css/github-create-branch.css
+++ b/static/css/github-create-branch.css
@@ -67,3 +67,9 @@
 .gitHubCreateBranch__serverError .errorMessageBox__container {
   align-items: center;
 }
+.gitHubCreateBranch__userDetails {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  margin: 16px 23px 0px 0px;
+}

--- a/static/js/github-create-branch.js
+++ b/static/js/github-create-branch.js
@@ -72,6 +72,11 @@ $(document).ready(() => {
     window.close();
   });
 
+  $('#changeLogin').click(function (event) {
+    event.preventDefault();
+    changeGitHubLogin();
+  });
+
 });
 
 const loadBranches = () => {
@@ -182,4 +187,19 @@ const toggleLoaderInInput = (inputDOM, state) => {
   } else {
     container.find(loader).remove();
   }
+};
+
+const changeGitHubLogin = () => {
+  $.ajax({
+    type: "GET",
+    url: `/github/create-branch/change-github-login`,
+    success: (data) => {
+      window.open(data.baseUrl, "_blank"); 
+    },
+    error: (error) => {
+      console.log(error);
+    }
+
+  });
+
 };

--- a/views/github-create-branch.hbs
+++ b/views/github-create-branch.hbs
@@ -22,6 +22,10 @@
 <input type="hidden" id="_csrf" name="_csrf" value="{{csrfToken}}" />
 <input type="hidden" id="jiraHost" name="jiraHost" value="{{jiraHost}}" />
 
+<div class="gitHubCreateBranch__userDetails">
+  <div>GitHub account: <b>{{gitHubUser}}</b></div>
+  <div><a href="#" id="changeLogin">Change GitHub login</a></div>
+</div>
 <section class="gitHubCreateBranch">
   <div class="headerImage">
     <img src="/public/assets/jira-and-github.png" alt="Jira and GitHub logos" />


### PR DESCRIPTION
**What's in this PR?**
Display logged-in GitHub user details with an option to change GitHub login. 
When `Change GitHub login` link is clicked, it will clear the `GitHub` token from session and opens up GitHub cloud or enterprise site in a new window to logout from the portal itself.

**Affected issues**  
[ARC-1606]

**How has this been tested?**  
Local



[ARC-1606]: https://softwareteams.atlassian.net/browse/ARC-1606