### PR TITLE
Revert "ARC-1351: Remove OAuth scopes for the user's access_token"

### DIFF
--- a/src/routes/github/github-oauth-router.ts
+++ b/src/routes/github/github-oauth-router.ts
@@ -11,7 +11,7 @@ import { createHashWithSharedSecret } from "utils/encryption";
 
 const logger = getLogger("github-oauth");
 const appUrl = envVars.APP_URL;
-const scopes = ["repo"];
+const scopes = ["user", "repo"];
 const callbackPath = "/callback";
 
 const getRedirectUrl = async (req, res, state) => {

--- a/src/routes/github/github-router.test.ts
+++ b/src/routes/github/github-router.test.ts
@@ -95,7 +95,7 @@ describe("GitHub router", () => {
 						const resultUrl = response.headers.location;
 						const resultUrlWithoutState = resultUrl.split("&state")[0];// Ignoring state here cause state is different everytime
 						const redirectUrl = `${envVars.APP_URL}/github/callback`;
-						const expectedUrlWithoutState = `https://github.com/login/oauth/authorize?client_id=${envVars.GITHUB_CLIENT_ID}&scope=repo&redirect_uri=${encodeURIComponent(redirectUrl)}`;
+						const expectedUrlWithoutState = `https://github.com/login/oauth/authorize?client_id=${envVars.GITHUB_CLIENT_ID}&scope=user%20repo&redirect_uri=${encodeURIComponent(redirectUrl)}`;
 						expect(resultUrlWithoutState).toEqual(expectedUrlWithoutState);
 					});
 			});
@@ -168,7 +168,7 @@ describe("GitHub router", () => {
 						const resultUrl = response.headers.location;
 						const resultUrlWithoutState = resultUrl.split("&state")[0];// Ignoring state here cause state is different everytime
 						const redirectUrl = `${envVars.APP_URL}/github/${GITHUB_SERVER_APP_UUID}/callback`;
-						const expectedUrlWithoutState = `${gheUrl}/login/oauth/authorize?client_id=${GITHUB_SERVER_CLIENT_ID}&scope=repo&redirect_uri=${encodeURIComponent(redirectUrl)}`;
+						const expectedUrlWithoutState = `${gheUrl}/login/oauth/authorize?client_id=${GITHUB_SERVER_CLIENT_ID}&scope=user%20repo&redirect_uri=${encodeURIComponent(redirectUrl)}`;
 						expect(resultUrlWithoutState).toEqual(expectedUrlWithoutState);
 					});
 			});


### PR DESCRIPTION
Reverts atlassian/github-for-jira#1615

Seeing `Error creating branch` in staging, so we do need `repo` scope for listing repositories and `user` scope for creating branches.