### PR TITLE
NONE: try not to escape head/

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -22,7 +22,8 @@ export enum BooleanFlags {
 	GHE_SERVER = "ghe_server",
 	USE_REST_API_FOR_DISCOVERY = "use-rest-api-for-discovery",
 	TAG_BACKFILL_REQUESTS = "tag-backfill-requests",
-	CREATE_BRANCH = "create-branch"
+	CREATE_BRANCH = "create-branch",
+	USE_FIXED_GET_REF = "use-fixed-get-ref"
 }
 
 export enum StringFlags {

--- a/src/github/client/github-installation-client.ts
+++ b/src/github/client/github-installation-client.ts
@@ -142,6 +142,17 @@ export class GitHubInstallationClient extends GitHubClient {
 	};
 
 	/**
+	 * Returns a single head reference from Git.
+	 */
+	public getRefHead = async (owner: string, repo: string, branch: string): Promise<AxiosResponse<Octokit.GitGetRefResponse>> => {
+		return await this.get<Octokit.GitGetRefResponse>(`/repos/{owner}/{repo}/git/ref/head/{branch}`, {}, {
+			owner,
+			repo,
+			branch
+		});
+	};
+
+	/**
 	 * Get a page of repositories.
 	 */
 	public getRepositoriesPage = async (per_page = 1, cursor?: string): Promise<GetRepositoriesResponse> => {

--- a/src/transforms/transform-branch.ts
+++ b/src/transforms/transform-branch.ts
@@ -8,12 +8,17 @@ import { JiraBranchData, JiraCommit } from "src/interfaces/jira";
 import { getLogger } from "config/logger";
 import Logger from "bunyan";
 import { retry } from "ts-retry-promise";
+import { booleanFlag, BooleanFlags } from "config/feature-flags";
 
 const getLastCommit = async (github: GitHubInstallationClient, webhookPayload: WebhookPayloadCreate, issueKeys: string[]): Promise<JiraCommit> => {
 	// Even though webhook was triggered, it doesn't mean the reference to the branch is available in the API just yet.
 	// Retrying 5 times with a 1 second exponential backoff (1, 2, 4, 8, 16) before erroring out and retrying again later
 	const { data: { object: { sha } } } = await retry(async () => {
-		return await github.getRef(webhookPayload.repository.owner.login, webhookPayload.repository.name, `heads/${webhookPayload.ref}`);
+		if (await booleanFlag(BooleanFlags.USE_FIXED_GET_REF, false)) {
+			return await github.getRefHead(webhookPayload.repository.owner.login, webhookPayload.repository.name, webhookPayload.ref);
+		} else {
+			return await github.getRef(webhookPayload.repository.owner.login, webhookPayload.repository.name, `heads/${webhookPayload.ref}`);
+		}
 	}, { retries: 5, delay: 1000, backoff: "EXPONENTIAL" });
 	const { data: { commit, author, html_url: url } } = await github.getCommit(webhookPayload.repository.owner.login, webhookPayload.repository.name, sha);
 	return {


### PR DESCRIPTION
**What's in this PR?**
Trying to not encode "head/" in URL

**Why**
Since yesterday we see a lot of 404s when trying to fetch ref. This is an attempt to fix it in case the problem is with the percent encoding, because, according to docs, it shouldn't be escaped
<img width="660" alt="image" src="https://user-images.githubusercontent.com/20631664/192689988-51abd9a9-1ad1-4863-99ef-565469a2027a.png">


**Added feature flags**
USE_FIXED_GET_REF

**How has this been tested?**  
It is broken in prod anyway, we will see if it helps or not.

**Whats Next?**
not sure