### PR TITLE
Remove the code access to old column

### DIFF
--- a/src/jira/verify-installation.test.ts
+++ b/src/jira/verify-installation.test.ts
@@ -16,10 +16,6 @@ describe("verify-installation", () => {
 			sharedSecret: "new-encrypted-shared-secret",
 			clientKey: "client-key"
 		});
-		//doing bellow so that the sharedSecret is "shared-secret",
-		//while the encryptedSharedSecret will be "new-encrypted-shared-secret"
-		//so that we can test the FF
-		installation.sharedSecret = "shared-secret";
 	});
 
 	function mockJiraResponse(status: number) {

--- a/src/middleware/jira-jwt-middleware.test.ts
+++ b/src/middleware/jira-jwt-middleware.test.ts
@@ -175,7 +175,7 @@ describe("#verifyJiraMiddleware", () => {
 
 	});
 
-	describe("decyrpting installation sharedSecret", ()=>{
+	describe("decyrpting installation encryptedSharedSecret", ()=>{
 		let installation: Installation;
 		beforeEach(()=>{
 			installation = {

--- a/src/models/installation.ts
+++ b/src/models/installation.ts
@@ -1,22 +1,12 @@
 import { BOOLEAN, DataTypes, DATE } from "sequelize";
 import { Subscription } from "./subscription";
-import { encrypted, getHashedKey, sequelize } from "models/sequelize";
+import { getHashedKey, sequelize } from "models/sequelize";
 import { EncryptedModel } from "models/encrypted-model";
 import { EncryptionSecretKeyEnum } from "utils/encryption-client";
-import { getLogger } from "config/logger";
-
-// TODO: this should not be there.  Should only check once a function is called
-if (!process.env.STORAGE_SECRET) {
-	throw new Error("STORAGE_SECRET is not defined.");
-}
-
-const logger = getLogger("model-installations");
 
 export class Installation extends EncryptedModel {
 	id: number;
 	jiraHost: string;
-	secrets: string;
-	sharedSecret: string;
 	encryptedSharedSecret: string;
 	clientKey: string;
 	updatedAt: Date;
@@ -126,11 +116,6 @@ Installation.init({
 		autoIncrement: true
 	},
 	jiraHost: DataTypes.STRING,
-	secrets: encrypted.vault("secrets"),
-	sharedSecret: encrypted.field("sharedSecret", {
-		type: DataTypes.STRING,
-		allowNull: true
-	}),
 	encryptedSharedSecret: {
 		type: DataTypes.TEXT,
 		allowNull: true
@@ -146,24 +131,12 @@ Installation.init({
 	hooks: {
 		beforeSave: async (instance: Installation, opts) => {
 			if (!opts.fields) return;
-			try {
-				await instance.encryptChangedSecretFields(opts.fields);
-			} catch (_) {
-				//Just catch and swallow the error, don't want to fail installations right now if cryptor fail for whatever reason
-				//TODO: monitor the prod behaviour and remove this catch along with other migration rollout in another PR.
-				logger.error(`Fail encrypting sharedSecret using cryptor`);
-			}
+			await instance.encryptChangedSecretFields(opts.fields);
 		},
 		beforeBulkCreate: async (instances: Installation[], opts) => {
 			for (const instance of instances) {
 				if (!opts.fields) return;
-				try {
-					await instance.encryptChangedSecretFields(opts.fields);
-				} catch (_) {
-					//Just catch and swallow the error, don't want to fail installations right now if cryptor fail for whatever reason
-					//TODO: monitor the prod behaviour and remove this catch along with other migration rollout in another PR.
-					logger.error(`Fail encrypting sharedSecret using cryptor`);
-				}
+				await instance.encryptChangedSecretFields(opts.fields);
 			}
 		}
 	},
@@ -173,6 +146,5 @@ Installation.init({
 export interface InstallationPayload {
 	host: string;
 	clientKey: string;
-	// secret: string;
 	sharedSecret: string;
 }

--- a/src/routes/github/setup/github-setup-router.test.ts
+++ b/src/routes/github/setup/github-setup-router.test.ts
@@ -111,9 +111,6 @@ describe("Github Setup", () => {
 		it("should return a 200 with the redirect url to the app if a valid domain is given and an installation already exists", async () => {
 			await Installation.create({
 				jiraHost,
-				//TODO: why? Comment this out make test works?
-				//setting both fields make sequelize confused as it internally storage is just the "secrets"
-				//secrets: "secret",
 				encryptedSharedSecret: "sharedSecret",
 				clientKey: "clientKey"
 			});

--- a/src/routes/jira/events/jira-events-install-post.test.ts
+++ b/src/routes/jira/events/jira-events-install-post.test.ts
@@ -21,8 +21,6 @@ describe("Webhook: /events/installed", () => {
 			jiraHost: body.baseUrl,
 			clientKey: body.clientKey,
 			enabled: true,
-			secrets: "def234",
-			sharedSecret: body.sharedSecret,
 			subscriptions: jest.fn().mockResolvedValue([])
 		};
 

--- a/src/routes/jira/events/jira-events-uninstall-post.test.ts
+++ b/src/routes/jira/events/jira-events-uninstall-post.test.ts
@@ -24,8 +24,6 @@ describe("Webhook: /events/uninstalled", () => {
 			jiraHost: "https://test-host.jira.com",
 			clientKey: getHashedKey("abc123"),
 			enabled: true,
-			secrets: "def234",
-			sharedSecret: "ghi345",
 			uninstall: jest
 				.fn()
 				.mockName("uninstall")


### PR DESCRIPTION
**What's in this PR?**
Remove the code access to old Installation secrets column

**Why**
So that we can deprecate the sequelize encrypt

**Added feature flags**
N/A
The col is not being read/write any more (two FF to managed this). This is just to clean up the code.

**Affected issues**  
ARC-1354

**How has this been tested?**  
Not yet except unit test.

**Whats Next?**
