### PR TITLE
Fix build duplication in PR

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -1,6 +1,9 @@
 name: Push
 
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
+    types: [ opened ]
 
 jobs:
   build:


### PR DESCRIPTION
Running pull_request event only when we first open it to prevent duplicate builds

**What's in this PR?**
Quick fix to github workflow to prevent duplication of actions across push and pr

**Why**
Duplicate build are redundent and take longer to finish, costs more.

**Added feature flags**
none

**Affected issues**  
none

**How has this been tested?**  
manually

**Whats Next?**
nothing
