### PR TITLE
ARC 1602 - Help link and popup for repo search help

### DIFF
--- a/static/css/github-create-branch.css
+++ b/static/css/github-create-branch.css
@@ -96,9 +96,11 @@
   display: none;
   margin: 4px 0 0;
 }
+
 .no-repo-link:hover {
   text-decoration: underline;
 }
+
 .configure-link {
   margin: 8px 0;
   display: inline-block;

--- a/static/css/github-create-branch.css
+++ b/static/css/github-create-branch.css
@@ -99,3 +99,7 @@
 .no-repo-link:hover {
   text-decoration: underline;
 }
+.configure-link {
+  margin: 8px 0;
+  display: inline-block;
+}

--- a/static/css/github-create-branch.css
+++ b/static/css/github-create-branch.css
@@ -91,3 +91,11 @@
   color: #DE350B;
   font-size: 0.9rem;
 }
+
+.no-repo-container {
+  display: none;
+  margin: 4px 0 0;
+}
+.no-repo-link:hover {
+  text-decoration: underline;
+}

--- a/static/js/github-create-branch.js
+++ b/static/js/github-create-branch.js
@@ -14,6 +14,16 @@ $(document).ready(() => {
     placeholder: "Select a repository",
     data: totalRepos,
     dropdownCssClass: "ghRepo-dropdown", // this classname is used for displaying spinner
+    createSearchChoice: (term) => {
+      const exists = queriedRepos.find(repo => repo.id.indexOf(term) > 1);
+
+      if (!exists) {
+        return {
+          text: term,
+          id: term
+        }
+      }
+    },
     _ajaxQuery: Select2.query.ajax({
       dataType: "json",
       quietMillis: 500,
@@ -68,7 +78,11 @@ $(document).ready(() => {
   });
 
   $("#ghRepo").on("change", () => {
-    loadBranches();
+    if(queriedRepos.length) {
+      loadBranches();
+    } else {
+      showNoReposMessage();
+    }
   });
 
   $("#createBranchForm").on("aui-valid-submit", (event) => {
@@ -89,6 +103,10 @@ $(document).ready(() => {
   });
 
 });
+
+const showNoReposMessage = () => {
+  $(".no-repo-container").show();
+};
 
 const loadBranches = () => {
   showLoaderOnSelect2Input("ghParentBranch", true);

--- a/static/js/github-create-branch.js
+++ b/static/js/github-create-branch.js
@@ -79,9 +79,10 @@ $(document).ready(() => {
 
   $("#ghRepo").on("change", () => {
     if(queriedRepos.length) {
+      $(".no-repo-container").hide();
       loadBranches();
     } else {
-      showNoReposMessage();
+      $(".no-repo-container").show();
     }
   });
 
@@ -103,10 +104,6 @@ $(document).ready(() => {
   });
 
 });
-
-const showNoReposMessage = () => {
-  $(".no-repo-container").show();
-};
 
 const loadBranches = () => {
   showLoaderOnSelect2Input("ghParentBranch", true);

--- a/views/github-create-branch.hbs
+++ b/views/github-create-branch.hbs
@@ -53,6 +53,16 @@
       {{#each repos}}
         <div class="hidden default-repos">{{node.full_name}}</div>
       {{/each}}
+
+      <div class="no-repo-container">
+        <a data-aui-trigger aria-controls="show-no-repo-popup" href="#show-no-repo-popup" class="no-repo-link">
+          Can't find the repository you're looking for?
+        </a>
+        <aui-inline-dialog id="show-no-repo-popup" alignment="bottom left" responds-to="hover">
+          <div>You need to configure your GitHub repositories to your Jira site to see them here.</div>
+          <div>Configure GitHub Integration</div>
+        </aui-inline-dialog>
+      </div>
     </div>
     <div class="field-group">
       <aui-label for="branch">Branch from</aui-label>

--- a/views/github-create-branch.hbs
+++ b/views/github-create-branch.hbs
@@ -60,6 +60,7 @@
         </a>
         <aui-inline-dialog id="show-no-repo-popup" alignment="bottom left" responds-to="hover">
           <div>You need to configure your GitHub repositories to your Jira site to see them here.</div>
+          <!--TODO: Add URL after confirmation-->
           <a href="#" class="configure-link">Configure GitHub Integration</a>
         </aui-inline-dialog>
       </div>

--- a/views/github-create-branch.hbs
+++ b/views/github-create-branch.hbs
@@ -60,7 +60,7 @@
         </a>
         <aui-inline-dialog id="show-no-repo-popup" alignment="bottom left" responds-to="hover">
           <div>You need to configure your GitHub repositories to your Jira site to see them here.</div>
-          <div>Configure GitHub Integration</div>
+          <a href="#" class="configure-link">Configure GitHub Integration</a>
         </aui-inline-dialog>
       </div>
     </div>


### PR DESCRIPTION
**What's in this PR?**
- Added a help link and popup when users types in a repo that is unavailable

**Why**
- Better user experience

**How has this been tested?**  
- Locally

**Video**

https://user-images.githubusercontent.com/13076255/194064752-1cfb1627-5131-4236-a4d7-e3f8aec54bbb.mov


