### PR TITLE
[Easy Karma] NONE: use redis from envVars

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -118,4 +118,7 @@ export interface EnvVars {
 	// Cryptor
 	CRYPTOR_URL: string;
 	CRYPTOR_SIDECAR_CLIENT_IDENTIFICATION_CHALLENGE: string;
+
+	REDISX_CACHE_PORT: string;
+	REDISX_CACHE_HOST: string;
 }

--- a/src/config/redis-info.ts
+++ b/src/config/redis-info.ts
@@ -1,9 +1,10 @@
 import IORedis from "ioredis";
 import { isNodeProd } from "utils/is-node-env";
+import { envVars } from "config/env";
 
 export const getRedisInfo = (connectionName: string): IORedis.RedisOptions => ({
-	port: Number(process.env.REDISX_CACHE_PORT) || 6379,
-	host: process.env.REDISX_CACHE_HOST || "127.0.0.1",
+	port: Number(envVars.REDISX_CACHE_PORT) || 6379,
+	host: envVars.REDISX_CACHE_HOST || "127.0.0.1",
 	db: 0,
 
 	// TODO find out if we still need these options


### PR DESCRIPTION
**What's in this PR?**
Pulling redis info from envVars so it can be overriden in .env file

**Why**
Cause now it is annoying to our customers: whoever spins the app in their network cannot override the settings

**Added feature flags**
N/a

**Affected issues**  
N/a

**How has this been tested?**  
Locally

**Whats Next?**
