### PR TITLE
NONE: make REDISX tls configurable

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -121,4 +121,5 @@ export interface EnvVars {
 
 	REDISX_CACHE_PORT: string;
 	REDISX_CACHE_HOST: string;
+	REDISX_CACHE_TLS_ENABLED?: string;
 }

--- a/src/config/redis-info.ts
+++ b/src/config/redis-info.ts
@@ -12,6 +12,6 @@ export const getRedisInfo = (connectionName: string): IORedis.RedisOptions => ({
 	maxRetriesPerRequest: null,
 	enableReadyCheck: false,
 
-	tls: isNodeProd() ? { checkServerIdentity: () => undefined } : undefined,
+	tls: isNodeProd() || envVars.REDISX_CACHE_TLS_ENABLED ? { checkServerIdentity: () => undefined } : undefined,
 	connectionName
 });


### PR DESCRIPTION
**What's in this PR?**
Adding ability to turn on tls for redis

**Why**
Because currently it is ON for prod and OFF for dev, which means it is impossible to integrate a dev-running app with an encrypted-in-transit redis

**Added feature flags**
nah

**Affected issues**  
N/a

**How has this been tested?**  
Typing and prayers

**Whats Next?**
I hope that would suffice
