### PR TITLE
[QUICK-FIX] - Added an ID for console errors

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import { elapsedTimeMetrics } from "config/statsd";
 import sslify from "express-sslify";
 import helmet from "helmet";
 import { RootRouter } from "routes/router";
+import { v4 as newUUID } from "uuid";
 
 export const getFrontendApp = (octokitApp: App): Express => {
 	const app = express();
@@ -26,6 +27,15 @@ export const getFrontendApp = (octokitApp: App): Express => {
 
 	// Add github client middleware which uses the octokit app
 	app.use(getGithubClientMiddleware(octokitApp));
+
+	//Error handling
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	app.use((err, req, res, _next) => {
+		const traceId = newUUID();
+		req.log.error({ err }, "Failed: " + err.message);
+		res.status(500).send("Failed: ", traceId);
+	});
+
 
 	// Add all routes
 	app.use(RootRouter);

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -1,6 +1,7 @@
 import Logger, { createLogger, LogLevel, Serializers, Stream } from "bunyan";
 import { isArray, isString, merge, omit } from "lodash";
 import { SafeRawLogStream, UnsafeRawLogStream } from "utils/logger-utils";
+import { v4 as newUUID } from "uuid";
 
 function censorUrl(url) {
 	if (!url) {
@@ -110,6 +111,7 @@ interface LoggerOptions {
 export const getLogger = (name: string, options: LoggerOptions = {}): Logger => {
 	return createLogger(merge<Logger.LoggerOptions, LoggerOptions>({
 		name,
+		id: newUUID(),
 		streams: [
 			loggerStreamSafe(),
 			loggerStreamUnsafe()


### PR DESCRIPTION
**What's in this PR?**
- Added a `UUID` for console errors in `logger.ts`
- Added a custom error handler for the errors caught by **Express JS**.
  - Added a `UUID` as `traceId`. The user only receives this `traceId` and from our end we can easily search the Splunk logs using this `traceId`

**Why**
- For better readability in Splunk(and other logging tools maybe)

**Whats Next?**
- Not much, just merge and go...