### PR TITLE
ARC-1728 - Success Page after creating a branch

### DIFF
--- a/src/routes/github/create-branch/github-create-branch-get.ts
+++ b/src/routes/github/create-branch/github-create-branch-get.ts
@@ -47,6 +47,7 @@ export const GithubCreateBranchGet = async (req: Request, res: Response, next: N
 			key
 		},
 		repos,
+		hostname: gitHubAppConfig.hostname,
 		uuid: gitHubAppConfig.uuid,
 		gitHubUser
 	});

--- a/static/css/github-create-branch.css
+++ b/static/css/github-create-branch.css
@@ -126,3 +126,8 @@
   margin: 8px 0;
   display: inline-block;
 }
+
+.gitHubCreateBranch__createdLinks {
+  display: none;
+  justify-content: space-evenly;
+}

--- a/static/js/github-create-branch.js
+++ b/static/js/github-create-branch.js
@@ -107,6 +107,14 @@ $(document).ready(() => {
     changeGitHubLogin();
   });
 
+  $("#copyGitCheckout").click(function () {
+    navigator.clipboard.writeText("git checkout -b " + $("#branchNameText").val());
+  });
+
+  $("#openGitBranch").click(function () {
+    const repo = getRepoDetails();
+    window.open(`${$("#gitHubHostname").val()}/${repo.owner}/${repo.name}/tree/${$("#branchNameText").val()}`);
+  });
 });
 
 const loadBranches = () => {
@@ -199,7 +207,7 @@ const createBranchPost = () => {
   showLoading();
   $.post(url, data)
     .done(() => {
-      showSuccessScreen(repo, newBranchName);
+      showSuccessScreen(repo);
     })
     .fail((error) => {
       toggleSubmitDisabled(false);
@@ -214,12 +222,18 @@ const showLoading = () => {
   $(".gitHubCreateBranch__spinner").show();
 };
 
-const showSuccessScreen = (repo, newBranchName) => {
+const showSuccessScreen = (repo) => {
   $(".gitHubCreateBranch__spinner").hide();
   $(".headerImageLogo").attr("src", "/public/assets/jira-github-connection-success.svg");
   $(".gitHubCreateBranch__header").html("GitHub branch created");
   $(".gitHubCreateBranch__subHeader").html(`Branch created in ${repo.owner}/${repo.name}`);
-  // TODO: Redirect to the success screen with options, needs to be done after ARC-1727[https://softwareteams.atlassian.net/browse/ARC-1727]
+  setTimeout(showSuccessWithActions, 1500);
+};
+
+const showSuccessWithActions = () => {
+  $(".headerImageLogo").removeClass("headerImageLogo-lg");
+  $(".headerImageLogo").attr("src", "/public/assets/jira-and-github.png");
+  $(".gitHubCreateBranch__createdLinks").css("display", "flex");
 };
 
 const hideLoading = () => {

--- a/static/js/github-create-branch.js
+++ b/static/js/github-create-branch.js
@@ -13,7 +13,7 @@ $(document).ready(() => {
   let url = "/github/repository";
   if(uuid) {
     url = `/github/${uuid}/repository`;
-  } 
+  }
   $("#ghRepo").auiSelect2({
     placeholder: "Select a repository",
     data: totalRepos,
@@ -108,7 +108,7 @@ $(document).ready(() => {
   });
 
   $("#copyGitCheckout").click(function () {
-    navigator.clipboard.writeText("git checkout -b " + $("#branchNameText").val());
+    navigator.clipboard.writeText("git checkout " + $("#branchNameText").val());
   });
 
   $("#openGitBranch").click(function () {

--- a/views/github-create-branch.hbs
+++ b/views/github-create-branch.hbs
@@ -21,6 +21,7 @@
 <body>
 <input type="hidden" id="_csrf" name="_csrf" value="{{csrfToken}}" />
 <input type="hidden" id="jiraHost" name="jiraHost" value="{{jiraHost}}" />
+<input type="hidden" id="gitHubHostname" name="hostname" value="{{hostname}}" />
 
 <div class="gitHubCreateBranch__userDetails">
   <div>GitHub account: <b>{{gitHubUser}}</b></div>
@@ -35,6 +36,11 @@
   <div class="gitHubCreateBranch__title">
     <div class="gitHubCreateBranch__header">Create GitHub Branch</div>
     <div class="gitHubCreateBranch__subHeader skeleton skeleton-element">Creating a branch for <b>{{issue.key}}</b></div>
+  </div>
+
+  <div class="gitHubCreateBranch__createdLinks">
+    <div class="aui-button aui-button-light" id="copyGitCheckout">Copy git checkout</div>
+    <a class="aui-button aui-button-light" id="openGitBranch">View branch in GitHub <i class="aui-icon aui-iconfont-open"></i></a>
   </div>
 
   <form id="createBranchForm" class="aui top-label" data-ghe-uuid="{{uuid}}">


### PR DESCRIPTION
**What's in this PR?**
- Added the final success state in the same page using jQuery. This is not done in a separate route as intended previously, because:
  - Creating a new route means redirect, which means we lose the animating flow.
  - There’s not much value in creating a separate route for this.
- After the branch has been created successfully, added a 1.5 second timeout to show the action links.

**Why**
- Following the UI with the smooth animation 😎 

**How has this been tested?**  
- Local
- Staging

**Video**

https://user-images.githubusercontent.com/13076255/195258732-f6528e8d-aab3-48da-80e2-94c754bd53cf.mov

