### PR TITLE
Arc 1444 keep probot running on stop

### DIFF
--- a/src/worker/startup.ts
+++ b/src/worker/startup.ts
@@ -1,4 +1,3 @@
-import { probot } from "./app";
 import { sqsQueues } from "../sqs/queues";
 import { getLogger } from "config/logger";
 
@@ -24,8 +23,6 @@ export async function stop() {
 		return;
 	}
 	logger.info("Micros Lifecycle: Stopping queue processing");
-	// TODO: change this to `probot.close()` once we update probot to latest version
-	probot.httpServer?.close();
 
 	await sqsQueues.stop();
 


### PR DESCRIPTION
**What's in this PR?**
Stop the `stop the probot httpServer`

**Why**
For each deployment, we don't want the existing stack to stop the probot (WORKER) http server from receiving healthcheck request, in case we want to rollback, we still need the existing stack (healthcheck endpoint) to function.

**Added feature flags**
N/A

**Affected issues**  
ARC-1444

**How has this been tested?**  
ddev
Multiple deploy to make sure it still works
rollback and make sure old stack works

However, before this change, I can't make old stack (health endpoint) cease functioning during rollback to verify my theory. I suspect it is due to healthcheck in worker group is quite special, the stack may still work even that healthcheck endpoint is broken. Too much micros assumption here, can't 100% prove anything. But my gut feeling tells me we should keep the server running.

**Whats Next?**
N/A
