### PR TITLE
Fix GH enterprise listing 

### DIFF
--- a/src/routes/github/create-branch/github-create-branch-options-get.ts
+++ b/src/routes/github/create-branch/github-create-branch-options-get.ts
@@ -41,11 +41,12 @@ const getGitHubServers = async (jiraHost: string) => {
 	const subscriptions = await Subscription.getAllForHost(jiraHost);
 	const ghCloudSubscriptions = subscriptions.filter(subscription => !subscription.gitHubAppId);
 	const gheServerSubscriptions = subscriptions.filter(subscription => subscription.gitHubAppId);
+	const uniqueGithubAppIds = new Set(gheServerSubscriptions.map(gheServerSubscription => gheServerSubscription.gitHubAppId));
 
 	const gheServerInfos = new Array<{ uuid: string, baseUrl: string, appName: string }>();
-	for (const subscription of gheServerSubscriptions) {
-		if (subscription.gitHubAppId) {
-			const gitHubServerApp = await GitHubServerApp.getForGitHubServerAppId(subscription.gitHubAppId);
+	for (const gitHubAppId of uniqueGithubAppIds) {
+		if (gitHubAppId) {
+			const gitHubServerApp = await GitHubServerApp.getForGitHubServerAppId(gitHubAppId);
 			if (gitHubServerApp) {
 				gheServerInfos.push({
 					"uuid": gitHubServerApp.uuid,


### PR DESCRIPTION
**What's in this PR?**
If same app is installed on multiple orgs, it shows same app multiple times in GHE instance drop down.
<img width="716" alt="Screen Shot 2022-10-13 at 12 56 28 pm" src="https://user-images.githubusercontent.com/14277763/195536748-8022ef59-f7a8-4ce7-9410-30f8bdc42718.png">

Fix the issue by filtering out duplicate githubAppIds.

**How has this been tested?**  
Local
