### PR TITLE
Arc 1662 increase payload limit for enterprise

### DIFF
--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -25,7 +25,9 @@ RootRouter.use(Sentry.Handlers.requestHandler());
 
 // Parse URL-encoded bodies for Jira configuration requests
 RootRouter.use(urlencoded({ extended: false }));
-RootRouter.use(json());
+RootRouter.use(json({
+	limit: "30mb" //set limit according to github doc https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-object-common-properties
+}));
 RootRouter.use(cookieParser());
 
 // Add pertinent information to logger for all subsequent routes


### PR DESCRIPTION
**What's in this PR?**
Set the express json parse size to 50mb for ddev/stg/prod

**Why**
When we cut over to use new webhook route, the default size limit 1mb is not enough according to [github cloud](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads) and [enterpriser server doc](https://docs.github.com/en/enterprise-server@3.3/developers/webhooks-and-events/webhooks/webhook-events-and-payloads).

![image](https://user-images.githubusercontent.com/105693507/196065661-de72a202-762c-4695-8ab8-b5c59735e6ec.png)

**Added feature flags**
N/A

**Affected issues**  
ARC-1662

**How has this been tested?**  
Unit test.

**Whats Next?**
Test on stage and cut over prod traffic for webhook
