### PR TITLE
ARC-1742- Update success page to stay big mode

### DIFF
--- a/static/js/github-create-branch.js
+++ b/static/js/github-create-branch.js
@@ -107,10 +107,6 @@ $(document).ready(() => {
     changeGitHubLogin();
   });
 
-  $("#copyGitCheckout").click(function () {
-    navigator.clipboard.writeText("git checkout " + $("#branchNameText").val());
-  });
-
   $("#openGitBranch").click(function () {
     const repo = getRepoDetails();
     window.open(`${$("#gitHubHostname").val()}/${repo.owner}/${repo.name}/tree/${$("#branchNameText").val()}`);
@@ -228,13 +224,7 @@ const showSuccessScreen = (repo) => {
   $(".gitHubCreateBranch__spinner").hide();
   $(".headerImageLogo").attr("src", "/public/assets/jira-github-connection-success.svg");
   $(".gitHubCreateBranch__header").html("GitHub branch created");
-  $(".gitHubCreateBranch__subHeader").html(`Branch created in ${repo.owner}/${repo.name}`);
-  setTimeout(showSuccessWithActions, 1500);
-};
-
-const showSuccessWithActions = () => {
-  $(".headerImageLogo").removeClass("headerImageLogo-lg");
-  $(".headerImageLogo").attr("src", "/public/assets/jira-and-github.png");
+  $(".gitHubCreateBranch__subHeader").html(`Branch <b>${$("#branchNameText").val()}</b> created in ${repo.owner}/${repo.name}`);
   $(".gitHubCreateBranch__createdLinks").css("display", "flex");
 };
 

--- a/views/github-create-branch.hbs
+++ b/views/github-create-branch.hbs
@@ -42,8 +42,7 @@
   </div>
 
   <div class="gitHubCreateBranch__createdLinks">
-    <div class="aui-button aui-button-light" id="copyGitCheckout">Copy git checkout</div>
-    <a class="aui-button aui-button-light" id="openGitBranch">View branch in GitHub <i class="aui-icon aui-iconfont-open"></i></a>
+    <a class="aui-button aui-button-label" id="openGitBranch">View branch in GitHub <i class="aui-icon aui-iconfont-open"></i></a>
   </div>
 
   <form id="createBranchForm" class="aui top-label" data-ghe-uuid="{{uuid}}">


### PR DESCRIPTION
**What's in this PR?**
- Updated the final success page after creating a branch.
- Removed the copy code part

**Why**
- Copy code(copy to clipboard) doesn't work with iframes. 

**How has this been tested?**  
- Test

**Videos**

https://user-images.githubusercontent.com/13076255/196085161-0bd5f3c0-4e6d-414a-b385-5c0d2a54edb0.mov

