### PR TITLE
ARC 1752 - Shows search text instead of no results found on repo search

### DIFF
--- a/static/js/github-create-branch.js
+++ b/static/js/github-create-branch.js
@@ -18,17 +18,8 @@ $(document).ready(() => {
   $("#ghRepo").auiSelect2({
     placeholder: "Select a repository",
     data: totalRepos,
+    formatNoMatches: () => "No search results",
     dropdownCssClass: "ghRepo-dropdown", // this classname is used for displaying spinner
-    createSearchChoice: (term) => {
-      const exists = queriedRepos.find(repo => repo.id.indexOf(term) > 1);
-
-      if (!exists) {
-        return {
-          text: term,
-          id: term
-        }
-      }
-    },
     _ajaxQuery: Select2.query.ajax({
       dataType: "json",
       quietMillis: 500,
@@ -73,6 +64,11 @@ $(document).ready(() => {
     }
   })
     .on("select2-close", () => {
+      if ($("#ghRepo").val().length) {
+        $(".no-repo-container").hide();
+      } else {
+        $(".no-repo-container").show();
+      }
       showLoaderInsideSelect2Dropdown("ghRepo", false);
     });
 
@@ -82,12 +78,7 @@ $(document).ready(() => {
   });
 
   $("#ghRepo").on("change", () => {
-    if(queriedRepos.length) {
-      $(".no-repo-container").hide();
-      loadBranches();
-    } else {
-      $(".no-repo-container").show();
-    }
+    loadBranches();
   });
 
   $("#createBranchForm").on("aui-valid-submit", (event) => {

--- a/views/github-create-branch.hbs
+++ b/views/github-create-branch.hbs
@@ -61,8 +61,7 @@
         </a>
         <aui-inline-dialog id="show-no-repo-popup" alignment="bottom left" responds-to="hover">
           <div>You need to configure your GitHub repositories to your Jira site to see them here.</div>
-          <!--TODO: Add URL after confirmation-->
-          <a href="#" class="configure-link">Configure GitHub Integration</a>
+          <a href="{{jiraHost}}/plugins/servlet/ac/com.github.integration.production/github-post-install-page" target="_blank" class="configure-link">Configure GitHub Integration</a>
         </aui-inline-dialog>
       </div>
     </div>

--- a/views/github-create-branch.hbs
+++ b/views/github-create-branch.hbs
@@ -61,7 +61,7 @@
         </a>
         <aui-inline-dialog id="show-no-repo-popup" alignment="bottom left" responds-to="hover">
           <div>You need to configure your GitHub repositories to your Jira site to see them here.</div>
-          <a href="{{jiraHost}}/plugins/servlet/ac/com.github.integration.production/github-post-install-page" target="_blank" class="configure-link">Configure GitHub Integration</a>
+          <a href="{{jiraHost}}/plugins/servlet/ac/com.github.integration.production/github-post-install-page" target="_blank" class="configure-link">Configure GitHub integration</a>
         </aui-inline-dialog>
       </div>
     </div>


### PR DESCRIPTION
**What's in this PR?**
- Selection of unavailable repositories has been removed.
- Condition for displaying **Configure GitHub Integration** has been updated.
  - True only when the input has no value selected and the user types in a repo that is not available.
- **No results text** updated to **No search results**.
- Link added for **Configure GitHub Integration**.

**Why**
- Discussed during the catchup.

**How has this been tested?**  
- Local

**Video**

https://user-images.githubusercontent.com/13076255/196088442-d4bd0078-b1df-4e77-8899-2854640033a5.mov

