### PR TITLE
NONE: calculate signature using rawBody instead of parsed payload

### DIFF
--- a/src/interfaces/common.ts
+++ b/src/interfaces/common.ts
@@ -47,6 +47,8 @@ declare global {
 					[key: string]: string;
 				}
 			};
+
+			rawBody?: string;
 		}
 	}
 }

--- a/src/routes/github/webhook/webhook-receiver-post.test.ts
+++ b/src/routes/github/webhook/webhook-receiver-post.test.ts
@@ -19,9 +19,9 @@ const NON_EXIST_GHES_UUID = "97da6b0e-ec61-11ec-8ea0-0242ac120003";
 const GHES_WEBHOOK_SECRET = "webhookSecret";
 const CLOUD_WEBHOOK_SECRET = envVars.WEBHOOK_SECRET;
 
-const injectRawBodyToReq = (res: any, req: any) => {
+const injectRawBodyToReq = (req: any) => {
 	req.rawBody = JSON.stringify(req.body);
-	return res;
+	return req;
 };
 
 describe("webhook-receiver-post", () => {
@@ -77,7 +77,7 @@ describe("webhook-receiver-post", () => {
 	it("should throw an error if github app not found", async () => {
 		req = createGHESReqForEvent("push", "", NON_EXIST_GHES_UUID);
 
-		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
+		await WebhookReceiverPost(injectRawBodyToReq(req), res);
 		expect(res.sendStatus).toBeCalledWith(400);
 
 	});
@@ -85,7 +85,7 @@ describe("webhook-receiver-post", () => {
 	it("should throw an error if signature doesn't match for GHE app", async () => {
 		req = createReqWithInvalidSignature("push", EXIST_GHES_UUID);
 
-		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
+		await WebhookReceiverPost(injectRawBodyToReq(req), res);
 		expect(res.status).toBeCalledWith(400);
 		expect(res.status().send).toBeCalledWith("signature does not match event payload and secret");
 
@@ -94,7 +94,7 @@ describe("webhook-receiver-post", () => {
 	it("should throw an error if signature doesn't match for GitHub cloud", async () => {
 		req = createReqWithInvalidSignature("push", undefined);
 
-		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
+		await WebhookReceiverPost(injectRawBodyToReq(req), res);
 		expect(res.status).toBeCalledWith(400);
 		expect(res.status().send).toBeCalledWith("signature does not match event payload and secret");
 
@@ -105,7 +105,7 @@ describe("webhook-receiver-post", () => {
 			req = createCloudReqForEvent("push");
 			const spy = jest.fn();
 			jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-			await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
+			await WebhookReceiverPost(injectRawBodyToReq(req), res);
 			expect(GithubWebhookMiddleware).toBeCalledWith(pushWebhookHandler);
 			expect(spy).toBeCalledWith(expect.objectContaining({
 				id: "100",
@@ -117,7 +117,7 @@ describe("webhook-receiver-post", () => {
 			req = createGHESReqForEvent("push", "", EXIST_GHES_UUID);
 			const spy = jest.fn();
 			jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-			await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
+			await WebhookReceiverPost(injectRawBodyToReq(req), res);
 			expect(GithubWebhookMiddleware).toBeCalledWith(pushWebhookHandler);
 			expect(spy).toBeCalledWith(expect.objectContaining({
 				id: "100",
@@ -131,7 +131,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("push", "", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
+		await WebhookReceiverPost(injectRawBodyToReq(req), res);
 		expect(GithubWebhookMiddleware).toBeCalledWith(pushWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -145,7 +145,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("issues", "opened", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
+		await WebhookReceiverPost(injectRawBodyToReq(req), res);
 		expect(GithubWebhookMiddleware).toBeCalledWith(issueWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -159,7 +159,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("pull_request", "opened", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
+		await WebhookReceiverPost(injectRawBodyToReq(req), res);
 		expect(GithubWebhookMiddleware).toBeCalledWith(pullRequestWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -173,7 +173,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("pull_request_review", "", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
+		await WebhookReceiverPost(injectRawBodyToReq(req), res);
 		expect(GithubWebhookMiddleware).toBeCalledWith(pullRequestWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -186,7 +186,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("create", "", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
+		await WebhookReceiverPost(injectRawBodyToReq(req), res);
 		expect(GithubWebhookMiddleware).toBeCalledWith(createBranchWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -199,7 +199,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("delete", "", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
+		await WebhookReceiverPost(injectRawBodyToReq(req), res);
 		expect(GithubWebhookMiddleware).toBeCalledWith(deleteBranchWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -212,7 +212,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("repository", "deleted", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
+		await WebhookReceiverPost(injectRawBodyToReq(req), res);
 		expect(GithubWebhookMiddleware).toBeCalledWith(deleteRepositoryWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -226,7 +226,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("workflow_run", "", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
+		await WebhookReceiverPost(injectRawBodyToReq(req), res);
 		expect(GithubWebhookMiddleware).toBeCalledWith(workflowWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -239,7 +239,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("deployment_status", "", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
+		await WebhookReceiverPost(injectRawBodyToReq(req), res);
 		expect(GithubWebhookMiddleware).toBeCalledWith(deploymentWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -252,7 +252,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("code_scanning_alert", "", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
+		await WebhookReceiverPost(injectRawBodyToReq(req), res);
 		expect(GithubWebhookMiddleware).toBeCalledWith(codeScanningAlertWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",

--- a/src/routes/github/webhook/webhook-receiver-post.test.ts
+++ b/src/routes/github/webhook/webhook-receiver-post.test.ts
@@ -19,11 +19,8 @@ const NON_EXIST_GHES_UUID = "97da6b0e-ec61-11ec-8ea0-0242ac120003";
 const GHES_WEBHOOK_SECRET = "webhookSecret";
 const CLOUD_WEBHOOK_SECRET = envVars.WEBHOOK_SECRET;
 
-const injectRawBodyToResLocal = (res: any, req: any) => {
-	if (!res.locals) {
-		res.locals = {};
-	}
-	res.locals.rawBody = JSON.stringify(req.body);
+const injectRawBodyToReq = (res: any, req: any) => {
+	req.rawBody = JSON.stringify(req.body);
 	return res;
 };
 
@@ -80,7 +77,7 @@ describe("webhook-receiver-post", () => {
 	it("should throw an error if github app not found", async () => {
 		req = createGHESReqForEvent("push", "", NON_EXIST_GHES_UUID);
 
-		await WebhookReceiverPost(req, injectRawBodyToResLocal(res, req));
+		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
 		expect(res.sendStatus).toBeCalledWith(400);
 
 	});
@@ -88,7 +85,7 @@ describe("webhook-receiver-post", () => {
 	it("should throw an error if signature doesn't match for GHE app", async () => {
 		req = createReqWithInvalidSignature("push", EXIST_GHES_UUID);
 
-		await WebhookReceiverPost(req, injectRawBodyToResLocal(res, req));
+		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
 		expect(res.status).toBeCalledWith(400);
 		expect(res.status().send).toBeCalledWith("signature does not match event payload and secret");
 
@@ -97,7 +94,7 @@ describe("webhook-receiver-post", () => {
 	it("should throw an error if signature doesn't match for GitHub cloud", async () => {
 		req = createReqWithInvalidSignature("push", undefined);
 
-		await WebhookReceiverPost(req, injectRawBodyToResLocal(res, req));
+		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
 		expect(res.status).toBeCalledWith(400);
 		expect(res.status().send).toBeCalledWith("signature does not match event payload and secret");
 
@@ -108,7 +105,7 @@ describe("webhook-receiver-post", () => {
 			req = createCloudReqForEvent("push");
 			const spy = jest.fn();
 			jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-			await WebhookReceiverPost(req, injectRawBodyToResLocal(res, req));
+			await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
 			expect(GithubWebhookMiddleware).toBeCalledWith(pushWebhookHandler);
 			expect(spy).toBeCalledWith(expect.objectContaining({
 				id: "100",
@@ -120,7 +117,7 @@ describe("webhook-receiver-post", () => {
 			req = createGHESReqForEvent("push", "", EXIST_GHES_UUID);
 			const spy = jest.fn();
 			jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-			await WebhookReceiverPost(req, injectRawBodyToResLocal(res, req));
+			await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
 			expect(GithubWebhookMiddleware).toBeCalledWith(pushWebhookHandler);
 			expect(spy).toBeCalledWith(expect.objectContaining({
 				id: "100",
@@ -134,7 +131,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("push", "", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToResLocal(res, req));
+		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
 		expect(GithubWebhookMiddleware).toBeCalledWith(pushWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -148,7 +145,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("issues", "opened", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToResLocal(res, req));
+		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
 		expect(GithubWebhookMiddleware).toBeCalledWith(issueWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -162,7 +159,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("pull_request", "opened", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToResLocal(res, req));
+		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
 		expect(GithubWebhookMiddleware).toBeCalledWith(pullRequestWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -176,7 +173,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("pull_request_review", "", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToResLocal(res, req));
+		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
 		expect(GithubWebhookMiddleware).toBeCalledWith(pullRequestWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -189,7 +186,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("create", "", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToResLocal(res, req));
+		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
 		expect(GithubWebhookMiddleware).toBeCalledWith(createBranchWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -202,7 +199,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("delete", "", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToResLocal(res, req));
+		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
 		expect(GithubWebhookMiddleware).toBeCalledWith(deleteBranchWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -215,7 +212,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("repository", "deleted", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToResLocal(res, req));
+		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
 		expect(GithubWebhookMiddleware).toBeCalledWith(deleteRepositoryWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -229,7 +226,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("workflow_run", "", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToResLocal(res, req));
+		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
 		expect(GithubWebhookMiddleware).toBeCalledWith(workflowWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -242,7 +239,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("deployment_status", "", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToResLocal(res, req));
+		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
 		expect(GithubWebhookMiddleware).toBeCalledWith(deploymentWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -255,7 +252,7 @@ describe("webhook-receiver-post", () => {
 		req = createGHESReqForEvent("code_scanning_alert", "", EXIST_GHES_UUID);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		await WebhookReceiverPost(req, injectRawBodyToResLocal(res, req));
+		await WebhookReceiverPost(req, injectRawBodyToReq(res, req));
 		expect(GithubWebhookMiddleware).toBeCalledWith(codeScanningAlertWebhookHandler);
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
@@ -264,6 +261,12 @@ describe("webhook-receiver-post", () => {
 		}));
 	});
 
+});
+
+describe("createHash", () => {
+	it("throws a Error if no data was provided", () => {
+		expect(() => createHash(undefined, "blah")).toThrow();
+	});
 });
 
 const createReqWithInvalidSignature = (event: string, uuid?: string) => {

--- a/src/routes/github/webhook/webhook-receiver-post.ts
+++ b/src/routes/github/webhook/webhook-receiver-post.ts
@@ -31,7 +31,7 @@ export const WebhookReceiverPost = async (request: Request, response: Response):
 	logger.info("Webhook received");
 	try {
 		const { webhookSecret, gitHubServerApp } = await getWebhookSecret(uuid);
-		const verification = createHash(response.locals.rawBody, webhookSecret);
+		const verification = createHash(request.rawBody, webhookSecret);
 
 		if (verification != signatureSHA256) {
 			logger.warn("Signature validation failed, returning 400");
@@ -119,7 +119,10 @@ const webhookRouter = async (context: WebhookContext) => {
 	}
 };
 
-export const createHash = (data: BinaryLike, secret: string): string => {
+export const createHash = (data: BinaryLike | undefined, secret: string): string => {
+	if (!data) {
+		throw new Error("No data to hash");
+	}
 	return `sha256=${createHmac("sha256", secret)
 		.update(data)
 		.digest("hex")}`;

--- a/src/routes/router.test.ts
+++ b/src/routes/router.test.ts
@@ -1,0 +1,30 @@
+import express from "express";
+import { RootRouter } from "routes/router";
+import { Request, Response } from "express";
+import supertest from "supertest";
+
+describe("router", () => {
+	let app;
+	let capturedRes;
+
+	beforeEach(() => {
+		app = express();
+		app.use(RootRouter);
+		capturedRes = undefined;
+		app.post("/test", (_: Request, res: Response) => {
+			capturedRes = res;
+			res.sendStatus(202);
+		});
+	});
+
+	it("should inject rawBody into json POST requests", async () => {
+		const BODY_WITH_SPACE_AT_THE_END = `{"hello": "world"} `;
+		await supertest(app)
+			.post("/test")
+			.set("content-type", "application/json")
+			.send(BODY_WITH_SPACE_AT_THE_END)
+			.expect(() => {
+				expect(capturedRes.locals.rawBody).toEqual(BODY_WITH_SPACE_AT_THE_END);
+			});
+	});
+});

--- a/src/routes/router.test.ts
+++ b/src/routes/router.test.ts
@@ -5,14 +5,14 @@ import supertest from "supertest";
 
 describe("router", () => {
 	let app;
-	let capturedRes;
+	let capturedReq;
 
 	beforeEach(() => {
 		app = express();
 		app.use(RootRouter);
-		capturedRes = undefined;
-		app.post("/test", (_: Request, res: Response) => {
-			capturedRes = res;
+		capturedReq = undefined;
+		app.post("/test", (req: Request, res: Response) => {
+			capturedReq = req;
 			res.sendStatus(202);
 		});
 	});
@@ -24,7 +24,7 @@ describe("router", () => {
 			.set("content-type", "application/json")
 			.send(BODY_WITH_SPACE_AT_THE_END)
 			.expect(() => {
-				expect(capturedRes.locals.rawBody).toEqual(BODY_WITH_SPACE_AT_THE_END);
+				expect(capturedReq.rawBody).toEqual(BODY_WITH_SPACE_AT_THE_END);
 			});
 	});
 });

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -27,8 +27,8 @@ RootRouter.use(Sentry.Handlers.requestHandler());
 RootRouter.use(urlencoded({ extended: false }));
 RootRouter.use(json({
 	limit: "30mb", //set limit according to github doc https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-object-common-properties
-	verify: (_: Request, res: Response, buf) => {
-		res.locals.rawBody = buf.toString();
+	verify: (req: Request, _: Response, buf) => {
+		req.rawBody = buf.toString();
 	}
 }));
 

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -28,14 +28,10 @@ RootRouter.use(urlencoded({ extended: false }));
 RootRouter.use(json({
 	limit: "30mb", //set limit according to github doc https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-object-common-properties
 	verify: (_: Request, res: Response, buf) => {
-		try {
-			res.locals.rawBody = buf.toString();
-		} catch (e) {
-			// eslint-disable-next-line no-console
-			console.error("bgvozdev debugging just to make sure this never fails. \"try-catch\" will be removed after the experiment");
-		}
+		res.locals.rawBody = buf.toString();
 	}
 }));
+
 RootRouter.use(cookieParser());
 
 // Add pertinent information to logger for all subsequent routes

--- a/test/utils/create-webhook-app.ts
+++ b/test/utils/create-webhook-app.ts
@@ -1,10 +1,9 @@
 import { BinaryLike, createHmac } from "crypto";
 import express, { Express } from "express";
-import { json } from "body-parser";
 import supertest from "supertest";
 import { v4 as uuid } from "uuid";
 import { envVars } from "config/env";
-import { WebhookReceiverPost } from "~/src/routes/github/webhook/webhook-receiver-post";
+import { RootRouter } from "routes/router";
 
 type Event = {
 	name: string,
@@ -18,8 +17,7 @@ export type WebhookApp = Express & {
 export const createWebhookApp = async (): Promise<WebhookApp> => {
 	/* eslint-disable @typescript-eslint/no-explicit-any */
 	const app: WebhookApp = express() as any;
-	app.use(json());
-	app.post("/github/webhooks", WebhookReceiverPost);
+	app.use(RootRouter);
 	app.receive = async (event: Event) => {
 		await supertest(app)
 			.post("/github/webhooks")


### PR DESCRIPTION
**What's in this PR?**
Calculate signature on rawBody, not the parsed payload

**Why**
Because parsing affects the content (e.g. removes spaces) and that affects the signature

**Added feature flags**
Not needed: we had tested it before + we have a pollinator run-once check in staging for webhooks

**How has this been tested?**  
splunk

**Whats Next?**
splunk