### PR TITLE
[QUICKFIX] - Error link fixed for non-connected repos

### DIFF
--- a/src/models/subscription.test.ts
+++ b/src/models/subscription.test.ts
@@ -248,10 +248,12 @@ describe("Subscription", () => {
 				expect(repo1Sub?.jiraClientKey).toBe("myClientKey_ghe_1");
 				expect(repo2Sub?.jiraClientKey).toBe("myClientKey_ghe_2");
 			});
-			it("should return undefined for unknown given repo name and owner", async () => {
+			it("should return first subscription of the repo owner for unknown given repo name", async () => {
 				const repoRandomSub = await Subscription.findForRepoNameAndOwner("repo-unknown", "atlassian", jiraHost);
+				expect(repoRandomSub?.jiraClientKey).toBe("myClientKey");
+			});
+			it("should return undefined for unknown given repo name and owner", async () => {
 				const repoRandom2Sub = await Subscription.findForRepoNameAndOwner("repo-2", "atlassian2", jiraHost);
-				expect(repoRandomSub?.jiraClientKey).toBe(undefined);
 				expect(repoRandom2Sub?.jiraClientKey).toBe(undefined);
 			});
 		});

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -167,15 +167,18 @@ export class Subscription extends Model {
 				repoName
 			}
 		});
+		let replacements = { jiraHost, repoOwner } as any;
+
 		// Check if the repo exists in our DB
 		if (repo.length) {
 			query += "AND rss.\"repoName\" = :repoName";
+			replacements = { ...replacements, repoName };
 		}
 
 		const results = await this.sequelize!.query(
 			query,
 			{
-				replacements: { jiraHost, repoOwner, repoName },
+				replacements,
 				type: QueryTypes.SELECT
 			}
 		);


### PR DESCRIPTION
**What's in this PR?**
- Condition added for `findForRepoNameAndOwner` for case where the repo names doesn't exist in our DB.
  - This is for the case when the repo is not synced, meaning does not exist in RepoSyncState, but the repo owner would probably exist. So simply returning the subscription for the repo owner.

**Why**
- To avoid the undefined error when repo names doesn't exist

**How has this been tested?**  
- Test cases

**Whats Next?**
- Merging