### PR TITLE
ARC-936: Add new GHE pollinator check to POCO policy

### DIFF
--- a/etc/poco/bundle/extras-prod.json
+++ b/etc/poco/bundle/extras-prod.json
@@ -12,7 +12,8 @@
         "asap": {
           "issuers": [
 						"pollinator-check/d99d882f-74a9-4093-822a-9ddf38b5e523",
-						"pollinator-check/713bec45-18fb-48c7-b6c2-46e6e824caec"
+						"pollinator-check/713bec45-18fb-48c7-b6c2-46e6e824caec",
+						"pollinator-check/ccf05819-f0a7-4c55-8b42-8d3db0c11bce"
 					]
         }
       }


### PR DESCRIPTION
**What's in this PR?**
Just adding the new pollinator check uuid to the POCO policy

**Why**
Because pollinator needs to delete a repo 

**Added feature flags**
n/a

**Affected issues**  
ARC-936

**How has this been tested?**  
https://pollinator.prod.atl-paas.net/checks/ccf05819-f0a7-4c55-8b42-8d3db0c11bce

**Whats Next?**
Adding uuid for backfil test later