### PR TITLE
Arc 1802 fix cross site ghe deletion

### DIFF
--- a/src/models/github-server-app.ts
+++ b/src/models/github-server-app.ts
@@ -151,9 +151,9 @@ export class GitHubServerApp extends EncryptedModel {
 		});
 	}
 
-	static async uninstallServer(gitHubBaseUrl: string): Promise<void> {
+	static async uninstallServer(gitHubBaseUrl: string, installationId: number): Promise<void> {
 		await this.destroy({
-			where: { gitHubBaseUrl }
+			where: { gitHubBaseUrl, installationId }
 		});
 	}
 

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-delete.test.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-delete.test.ts
@@ -10,12 +10,14 @@ describe("DELETE /jira/connect/enterprise", () => {
 	const GITHUB_BASE_URL_1 = "http://myinternalinstance.com";
 	const GITHUB_BASE_URL_2 = "http://myinternalinstance-part2.com";
 
+	let installation1: Installation;
 	let installationId1: number;
+	let installation2: Installation;
 	let installationId2: number;
 
 	beforeEach(async () => {
 		//Three GHE app for first installation for JIRA_HOST_1
-		const installation1 = await Installation.install({
+		installation1 = await Installation.install({
 			clientKey: "clientKey1",
 			host: JIRA_HOST_1,
 			sharedSecret: "12345"
@@ -55,7 +57,7 @@ describe("DELETE /jira/connect/enterprise", () => {
 			installationId: installationId1
 		});
 		//One GHE app for first installation for JIRA_HOST_1
-		const installation2 = await Installation.install({
+		installation2 = await Installation.install({
 			clientKey: "clientKey2",
 			host: JIRA_HOST_2,
 			sharedSecret: "78990"
@@ -98,7 +100,7 @@ describe("DELETE /jira/connect/enterprise", () => {
 		const send = jest.fn();
 		const res = {
 			locals: {
-				jiraHost: JIRA_HOST_2
+				installation: installation2
 			},
 			status: jest.fn(() => ({ send }))
 		};

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-delete.test.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-delete.test.ts
@@ -1,54 +1,113 @@
 import { GitHubServerApp } from "models/github-server-app";
+import { Installation } from "models/installation";
+import { getLogger } from "config/logger";
+import { JiraConnectEnterpriseDelete } from "./jira-connect-enterprise-delete";
 
 describe("DELETE /jira/connect/enterprise", () => {
-	const installationId = 72;
+
+	const JIRA_HOST_1 = "https://111.atlassian.net";
+	const JIRA_HOST_2 = "https://222.atlassian.net";
+	const GITHUB_BASE_URL_1 = "http://myinternalinstance.com";
+	const GITHUB_BASE_URL_2 = "http://myinternalinstance-part2.com";
+
+	let installationId1: number;
+	let installationId2: number;
 
 	beforeEach(async () => {
+		//Three GHE app for first installation for JIRA_HOST_1
+		const installation1 = await Installation.install({
+			clientKey: "clientKey1",
+			host: JIRA_HOST_1,
+			sharedSecret: "12345"
+		});
+		installationId1 = installation1.id;
 		await GitHubServerApp.create({
 			uuid: "c97806fc-c433-4ad5-b569-bf5191590be2",
 			appId: 1,
 			gitHubAppName: "my awesome app1",
-			gitHubBaseUrl: "http://myinternalinstance.com",
+			gitHubBaseUrl: GITHUB_BASE_URL_1,
 			gitHubClientId: "lvl.1n23j12389wndd",
 			gitHubClientSecret: "secret1",
 			webhookSecret: "anothersecret1",
 			privateKey: "privatekey1",
-			installationId
+			installationId: installationId1
 		});
 		await GitHubServerApp.create({
 			uuid: "9eaf28d5-fe18-42d8-a76d-eba80adc2295",
 			appId: 2,
 			gitHubAppName: "my awesome app 2",
-			gitHubBaseUrl: "http://myinternalinstance.com",
+			gitHubBaseUrl: GITHUB_BASE_URL_1,
 			gitHubClientId: "lvl.1n23j12389wnde",
 			gitHubClientSecret: "secret2",
 			webhookSecret: "anothersecret2",
 			privateKey: "privatekey2",
-			installationId
+			installationId: installationId1
 		});
 		await GitHubServerApp.create({
 			uuid: "7eaf28d5-fe12-42d8-a76d-eba80adc227a",
 			appId: 3,
 			gitHubAppName: "my awesome app 3",
-			gitHubBaseUrl: "http://myinternalinstance-part2.com",
+			gitHubBaseUrl: GITHUB_BASE_URL_2,
 			gitHubClientId: "lvl.1n23j12389wndf",
 			gitHubClientSecret: "secret3",
 			webhookSecret: "anothersecret3",
 			privateKey: "privatekey3",
-			installationId
+			installationId: installationId1
+		});
+		//One GHE app for first installation for JIRA_HOST_1
+		const installation2 = await Installation.install({
+			clientKey: "clientKey2",
+			host: JIRA_HOST_2,
+			sharedSecret: "78990"
+		});
+		installationId2 = installation2.id;
+		await GitHubServerApp.create({
+			uuid: "22e568d5-fe12-42d8-a76d-eba4aabc223d",
+			appId: 1,
+			gitHubAppName: "my awesome app 1",
+			gitHubBaseUrl: GITHUB_BASE_URL_2,
+			gitHubClientId: "lvl.1n23j12389wndf",
+			gitHubClientSecret: "secret3",
+			webhookSecret: "anothersecret3",
+			privateKey: "privatekey3",
+			installationId: installationId2
 		});
 	});
 
 	it("should delete all gh apps for a server", async () => {
-		const allServersForInstallationId = await GitHubServerApp.findForInstallationId(installationId);
+		const allServersForInstallationId = await GitHubServerApp.findForInstallationId(installationId1);
 		expect(allServersForInstallationId && allServersForInstallationId.length).toBe(3);
 
-		await GitHubServerApp.uninstallServer("http://myinternalinstance.com");
+		await GitHubServerApp.uninstallServer(GITHUB_BASE_URL_1);
 
-		const deletedServerApps = await GitHubServerApp.getAllForGitHubBaseUrlAndInstallationId("http://myinternalinstance.com", installationId);
-		const storedServer = await GitHubServerApp.getAllForGitHubBaseUrlAndInstallationId("http://myinternalinstance-part2.com", installationId);
+		const deletedServerApps = await GitHubServerApp.getAllForGitHubBaseUrlAndInstallationId(GITHUB_BASE_URL_1, installationId1);
+		const storedServer = await GitHubServerApp.getAllForGitHubBaseUrlAndInstallationId(GITHUB_BASE_URL_2, installationId1);
 
 		expect(deletedServerApps && deletedServerApps.length).toBe(0);
 		expect(storedServer && storedServer.length).toBe(1);
+	});
+
+	it("should NOT able to delete other jiraHost ghe app", async () => {
+
+		const req = {
+			log: getLogger("test"),
+			body: {
+				serverUrl: GITHUB_BASE_URL_2
+			}
+		};
+		const res = {
+			status: jest.fn(() => ({
+				send: jest.fn()
+			}))
+		};
+		const next = jest.fn();
+
+		//delete some GHE apps
+		await JiraConnectEnterpriseDelete(req as any, res as any, next);
+		expect(res.status).toHaveBeenCalled();
+
+		//assert on remaining apps
+		const allServers = await GitHubServerApp.findAll();
+		expect(allServers.length).toBe(2);
 	});
 });

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-delete.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-delete.ts
@@ -1,6 +1,5 @@
 import { NextFunction, Request, Response } from "express";
 import { GitHubServerApp } from "models/github-server-app";
-import { Installation } from "models/installation";
 
 export const JiraConnectEnterpriseDelete = async (
 	req: Request,
@@ -11,11 +10,7 @@ export const JiraConnectEnterpriseDelete = async (
 
 		req.log.debug("Received Jira Connect Enterprise Server DELETE request");
 
-		const { jiraHost }  = res.locals;
-		const installation = await Installation.getForHost(jiraHost);
-		if (!installation) {
-			throw new Error(`Installation not found for jiraHost ${jiraHost}`);
-		}
+		const { installation }  = res.locals;
 
 		await GitHubServerApp.uninstallServer(req.body.serverUrl, installation.id);
 

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-delete.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-delete.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { GitHubServerApp } from "models/github-server-app";
+import { Installation } from "models/installation";
 
 export const JiraConnectEnterpriseDelete = async (
 	req: Request,
@@ -7,9 +8,16 @@ export const JiraConnectEnterpriseDelete = async (
 	next: NextFunction
 ): Promise<void> => {
 	try {
+
 		req.log.debug("Received Jira Connect Enterprise Server DELETE request");
 
-		await GitHubServerApp.uninstallServer(req.body.serverUrl);
+		const { jiraHost }  = res.locals;
+		const installation = await Installation.getForHost(jiraHost);
+		if (!installation) {
+			throw new Error(`Installation not found for jiraHost ${jiraHost}`);
+		}
+
+		await GitHubServerApp.uninstallServer(req.body.serverUrl, installation.id);
 
 		res.status(200).send({ success: true });
 		req.log.debug("Jira Connect Enterprise Server successfully deleted.");

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-delete.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-delete.ts
@@ -7,7 +7,6 @@ export const JiraConnectEnterpriseDelete = async (
 	next: NextFunction
 ): Promise<void> => {
 	try {
-
 		req.log.debug("Received Jira Connect Enterprise Server DELETE request");
 
 		const { installation }  = res.locals;


### PR DESCRIPTION
**What's in this PR?**
🔐 🐞 Add a new where clause when deleting GHE apps.

**Why**
Currently it seems when user disconnect a GHE server from a jiraHost, all other jiraHosts that also has connection to the same server will be disconnected as well.

**Added feature flags**
N/A

**Affected issues**  
ARC-1802

**How has this been tested?**  
Unit test.

**Whats Next?**
Use can also delete ANY GHE apps as long as they know the uuid (which is public on the url anyway), need to fix that as well.
