### PR TITLE
ARC-1810 remove decrypted ghe app secrets from res.locals

### DIFF
--- a/src/middleware/github-server-app-middleware.test.ts
+++ b/src/middleware/github-server-app-middleware.test.ts
@@ -100,20 +100,7 @@ describe("github-server-app-middleware", () => {
 			webhookSecret: "encrypted:mywebhooksecret",
 			privateKey: "encrypted:myprivatekey",
 			installationId: JIRA_INSTALLATION_ID,
-			decrypt: async (s: any) => s,
-
-			getDecryptedGitHubClientSecret: () => {
-				return Promise.resolve("myghsecret");
-			},
-
-			getDecryptedPrivateKey: () => {
-				return Promise.resolve("myprivatekey");
-			},
-
-			getDecryptedWebhookSecret: () => {
-				return Promise.resolve("mywebhooksecret");
-			}
-
+			decrypt: async (s: any) => s
 		};
 
 		installation = {
@@ -141,8 +128,5 @@ describe("github-server-app-middleware", () => {
 			clientId: "lvl.1234",
 			hostname: "http://myinternalserver.com"
 		}));
-		expect(await res.locals.gitHubAppConfig.getDecryptedGitHubClientSecret()).toBe("myghsecret");
-		expect(await res.locals.gitHubAppConfig.getDecryptedPrivateKey()).toBe("myprivatekey");
-		expect(await res.locals.gitHubAppConfig.getDecryptedWebhookSecret()).toBe("mywebhooksecret");
 	});
 });

--- a/src/middleware/github-server-app-middleware.test.ts
+++ b/src/middleware/github-server-app-middleware.test.ts
@@ -134,15 +134,15 @@ describe("github-server-app-middleware", () => {
 		expect(next).toBeCalledTimes(1);
 
 		expect(res.locals.gitHubAppId).toBe(GIT_HUB_SERVER_APP_ID);
-		expect(res.locals.gitHubAppConfig).toEqual({
+		expect(res.locals.gitHubAppConfig).toEqual(expect.objectContaining({
 			gitHubAppId: GIT_HUB_SERVER_APP_ID,
 			appId: GIT_HUB_SERVER_APP_APP_ID,
 			uuid: UUID,
 			clientId: "lvl.1234",
-			gitHubClientSecret: "myghsecret",
-			hostname: "http://myinternalserver.com",
-			privateKey: "myprivatekey",
-			webhookSecret: "mywebhooksecret"
-		});
+			hostname: "http://myinternalserver.com"
+		}));
+		expect(await res.locals.gitHubAppConfig.getDecryptedGitHubClientSecret()).toBe("myghsecret");
+		expect(await res.locals.gitHubAppConfig.getDecryptedPrivateKey()).toBe("myprivatekey");
+		expect(await res.locals.gitHubAppConfig.getDecryptedWebhookSecret()).toBe("mywebhooksecret");
 	});
 });

--- a/src/middleware/github-server-app-middleware.test.ts
+++ b/src/middleware/github-server-app-middleware.test.ts
@@ -121,12 +121,12 @@ describe("github-server-app-middleware", () => {
 		expect(next).toBeCalledTimes(1);
 
 		expect(res.locals.gitHubAppId).toBe(GIT_HUB_SERVER_APP_ID);
-		expect(res.locals.gitHubAppConfig).toEqual(expect.objectContaining({
+		expect(res.locals.gitHubAppConfig).toEqual({
 			gitHubAppId: GIT_HUB_SERVER_APP_ID,
 			appId: GIT_HUB_SERVER_APP_APP_ID,
 			uuid: UUID,
 			clientId: "lvl.1234",
 			hostname: "http://myinternalserver.com"
-		}));
+		});
 	});
 });

--- a/src/middleware/github-server-app-middleware.ts
+++ b/src/middleware/github-server-app-middleware.ts
@@ -2,7 +2,6 @@ import { NextFunction, Request, Response } from "express";
 import { GitHubServerApp } from "models/github-server-app";
 import { Installation } from "models/installation";
 import { envVars } from "config/env";
-import { keyLocator } from "../github/client/key-locator";
 import { GITHUB_CLOUD_BASEURL } from "utils/get-github-client-config";
 
 export const GithubServerAppMiddleware = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
@@ -43,10 +42,7 @@ export const GithubServerAppMiddleware = async (req: Request, res: Response, nex
 			appId: gitHubServerApp.appId,
 			uuid: gitHubServerApp.uuid,
 			hostname: gitHubServerApp.gitHubBaseUrl,
-			clientId: gitHubServerApp.gitHubClientId,
-			getDecryptedGitHubClientSecret: async () => gitHubServerApp.getDecryptedGitHubClientSecret(),
-			getDecryptedWebhookSecret: async () => gitHubServerApp.getDecryptedWebhookSecret(),
-			getDecryptedPrivateKey: async () =>  gitHubServerApp.getDecryptedPrivateKey()
+			clientId: gitHubServerApp.gitHubClientId
 		};
 	} else {
 		req.log.info("Defining GitHub app config for GitHub Cloud.");
@@ -55,10 +51,7 @@ export const GithubServerAppMiddleware = async (req: Request, res: Response, nex
 			appId: envVars.APP_ID,
 			uuid: undefined, //undefined for cloud
 			hostname: GITHUB_CLOUD_BASEURL,
-			clientId: envVars.GITHUB_CLIENT_ID,
-			getDecryptedGitHubClientSecret: async () => envVars.GITHUB_CLIENT_SECRET,
-			getDecryptedWebhookSecret: async () => envVars.WEBHOOK_SECRET,
-			getDecryptedPrivateKey: async () => keyLocator(undefined)
+			clientId: envVars.GITHUB_CLIENT_ID
 		};
 	}
 

--- a/src/middleware/github-server-app-middleware.ts
+++ b/src/middleware/github-server-app-middleware.ts
@@ -44,9 +44,9 @@ export const GithubServerAppMiddleware = async (req: Request, res: Response, nex
 			uuid: gitHubServerApp.uuid,
 			hostname: gitHubServerApp.gitHubBaseUrl,
 			clientId: gitHubServerApp.gitHubClientId,
-			gitHubClientSecret: await gitHubServerApp.getDecryptedGitHubClientSecret(),
-			webhookSecret: await gitHubServerApp.getDecryptedWebhookSecret(),
-			privateKey: await gitHubServerApp.getDecryptedPrivateKey()
+			getDecryptedGitHubClientSecret: async () => gitHubServerApp.getDecryptedGitHubClientSecret(),
+			getDecryptedWebhookSecret: async () => gitHubServerApp.getDecryptedWebhookSecret(),
+			getDecryptedPrivateKey: async () =>  gitHubServerApp.getDecryptedPrivateKey()
 		};
 	} else {
 		req.log.info("Defining GitHub app config for GitHub Cloud.");
@@ -56,9 +56,9 @@ export const GithubServerAppMiddleware = async (req: Request, res: Response, nex
 			uuid: undefined, //undefined for cloud
 			hostname: GITHUB_CLOUD_BASEURL,
 			clientId: envVars.GITHUB_CLIENT_ID,
-			gitHubClientSecret: envVars.GITHUB_CLIENT_SECRET,
-			webhookSecret: envVars.WEBHOOK_SECRET,
-			privateKey: await keyLocator(undefined)
+			getDecryptedGitHubClientSecret: async () => envVars.GITHUB_CLIENT_SECRET,
+			getDecryptedWebhookSecret: async () => envVars.WEBHOOK_SECRET,
+			getDecryptedPrivateKey: async () => keyLocator(undefined)
 		};
 	}
 

--- a/src/models/github-server-app.test.ts
+++ b/src/models/github-server-app.test.ts
@@ -23,6 +23,37 @@ describe("GitHubServerApp", () => {
 		expect(savedGitHubServerApp?.gitHubAppName).toEqual("My GitHub Server App");
 	});
 
+	describe("GHES function", () => {
+		it("should NOT update missing columns if it is not specified in the request body", async () => {
+
+			await GitHubServerApp.install(payload);
+
+			const payLoadWithoutSomeColumns = {
+				uuid: uuid,
+				appId: 123,
+				privateKey: undefined //some specified as with undefined
+				//some specified as missing the key ( so undefined as well )
+			};
+
+			await GitHubServerApp.updateGitHubAppByUUID(payLoadWithoutSomeColumns);
+
+			const app = await GitHubServerApp.findForUuid(uuid);
+
+			expect(app).toBeDefined();
+			expect(app).toEqual(expect.objectContaining({
+				uuid: uuid,
+				appId: 123,
+				gitHubAppName: "My GitHub Server App",
+				gitHubBaseUrl: "http://myinternalserver.com",
+				gitHubClientId: "lvl.1234",
+				gitHubClientSecret: "encrypted:myghsecret",
+				webhookSecret: "encrypted:mywebhooksecret",
+				privateKey: "encrypted:myprivatekey",
+				installationId: 10
+			}));
+		});
+	});
+
 	describe("cryptor", () => {
 		//--------- helpers
 		const defaults = (uuid: string, surfix?: string) => ({
@@ -292,21 +323,21 @@ describe("GitHubServerApp", () => {
 	it("getDecryptedPrivateKey should return decrypted value", async () => {
 		await GitHubServerApp.install(payload);
 		const savedGitHubServerApp = await GitHubServerApp.findForUuid(uuid);
-		expect(await savedGitHubServerApp!.privateKey).toEqual("encrypted:myprivatekey");
+		expect(savedGitHubServerApp!.privateKey).toEqual("encrypted:myprivatekey");
 		expect(await savedGitHubServerApp!.getDecryptedPrivateKey()).toEqual("myprivatekey");
 	});
 
 	it("getDecryptedGitHubClientSecret should return decrypted value", async () => {
 		await GitHubServerApp.install(payload);
 		const savedGitHubServerApp = await GitHubServerApp.findForUuid(uuid);
-		expect(await savedGitHubServerApp!.gitHubClientSecret).toEqual("encrypted:myghsecret");
+		expect(savedGitHubServerApp!.gitHubClientSecret).toEqual("encrypted:myghsecret");
 		expect(await savedGitHubServerApp!.getDecryptedGitHubClientSecret()).toEqual("myghsecret");
 	});
 
 	it("getDecryptedWebhookSecret should return decrypted value", async () => {
 		await GitHubServerApp.install(payload);
 		const savedGitHubServerApp = await GitHubServerApp.findForUuid(uuid);
-		expect(await savedGitHubServerApp!.webhookSecret).toEqual("encrypted:mywebhooksecret");
+		expect(savedGitHubServerApp!.webhookSecret).toEqual("encrypted:mywebhooksecret");
 		expect(await savedGitHubServerApp!.getDecryptedWebhookSecret()).toEqual("mywebhooksecret");
 	});
 });

--- a/src/models/github-server-app.ts
+++ b/src/models/github-server-app.ts
@@ -23,6 +23,19 @@ export interface GitHubServerAppPayload {
 	installationId: number;
 }
 
+export interface GitHubServerAppUpdatePayload {
+	uuid: string;
+	appId: number;
+	gitHubBaseUrl?: string;
+	gitHubClientId?: string;
+	gitHubClientSecret?: string;
+	webhookSecret?: string;
+	privateKey?: string;
+	gitHubAppName?: string;
+	installationId?: number;
+}
+
+
 export class GitHubServerApp extends EncryptedModel {
 	id: number;
 	uuid: string;
@@ -157,7 +170,7 @@ export class GitHubServerApp extends EncryptedModel {
 		});
 	}
 
-	static async updateGitHubAppByUUID(payload: GitHubServerAppPayload): Promise<void> {
+	static async updateGitHubAppByUUID(payload: GitHubServerAppUpdatePayload): Promise<void> {
 		const {
 			uuid,
 			appId,

--- a/src/routes/github/github-oauth-router.ts
+++ b/src/routes/github/github-oauth-router.ts
@@ -79,9 +79,11 @@ const GithubOAuthCallbackGet = async (req: Request, res: Response, next: NextFun
 	if (!code) return next("Missing OAuth Code");
 
 	const { jiraHost, gitHubAppConfig } = res.locals;
-	const { hostname, clientId, gitHubClientSecret, uuid } = gitHubAppConfig;
+	const { hostname, clientId, uuid } = gitHubAppConfig;
 	req.log.info({ jiraHost }, "Jira Host attempting to auth with GitHub");
 	req.log.debug(`extracted jiraHost from redirect url: ${jiraHost}`);
+
+	const gitHubClientSecret = await gitHubAppConfig.getDecryptedGitHubClientSecret();
 
 	logger.info(`${createHashWithSharedSecret(gitHubClientSecret)} is used`);
 

--- a/src/routes/github/github-router.test.ts
+++ b/src/routes/github/github-router.test.ts
@@ -115,9 +115,7 @@ describe("GitHub router", () => {
 							githubToken: VALID_TOKEN,
 							jiraHost,
 							gitHubAppConfig: expect.objectContaining({
-								appId: envVars.APP_ID,
-								gitHubClientSecret: envVars.GITHUB_CLIENT_SECRET,
-								webhookSecret: envVars.WEBHOOK_SECRET
+								appId: envVars.APP_ID
 							})
 						})
 					}),
@@ -131,9 +129,7 @@ describe("GitHub router", () => {
 						githubToken: VALID_TOKEN,
 						jiraHost,
 						gitHubAppConfig: expect.objectContaining({
-							appId: envVars.APP_ID,
-							gitHubClientSecret: envVars.GITHUB_CLIENT_SECRET,
-							webhookSecret: envVars.WEBHOOK_SECRET
+							appId: envVars.APP_ID
 						})
 					}));
 			});
@@ -191,10 +187,7 @@ describe("GitHub router", () => {
 							gitHubAppId: gitHubAppId,
 							gitHubAppConfig: expect.objectContaining({
 								appId: GITHUB_SERVER_APP_ID,
-								uuid: GITHUB_SERVER_APP_UUID,
-								gitHubClientSecret: "gitHubClientSecret",
-								webhookSecret: "webhookSecret",
-								privateKey: "privateKey"
+								uuid: GITHUB_SERVER_APP_UUID
 							})
 						})
 					}),

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-put.test.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-put.test.ts
@@ -67,6 +67,46 @@ describe("PUT /jira/connect/enterprise/app/:uuid", () => {
 			})
 			.send(payload)
 			.expect(202);
+
+	});
+
+	it("should use existing privateKey if new privateKey is not passed in as body", async () => {
+
+		let existingApp = await GitHubServerApp.create({
+			uuid,
+			appId: 1,
+			gitHubAppName: "my awesome app",
+			gitHubBaseUrl: "http://myinternalinstance.com",
+			gitHubClientId: "lvl.1n23j12389wndd",
+			gitHubClientSecret: "secret",
+			webhookSecret: "anothersecret",
+			privateKey: "privatekey",
+			installationId: installation.id
+		});
+
+		const payload ={
+			gitHubAppName: "my-app",
+			webhookSecret: `secret`,
+			appId: "1",
+			gitHubClientId: "Iv1.msdnf2893rwhdbf",
+			gitHubClientSecret: "secret",
+			uuid,
+			gitHubBaseUrl: "http://testserver.com",
+			//privateKey: "new private key not passed in",
+			jiraHost
+		};
+
+		await supertest(app)
+			.put(`/jira/connect/enterprise/app/${uuid}`)
+			.query({
+				jwt
+			})
+			.send(payload)
+			.expect(202);
+
+		existingApp = await GitHubServerApp.findByPk(existingApp.id);
+
+		expect(await existingApp.getDecryptedPrivateKey()).toBe("privatekey");
 	});
 
 	it("should return 202 when correct uuid and installation id are passed, with partial data", async () => {

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-put.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-put.ts
@@ -17,7 +17,7 @@ export const JiraConnectEnterpriseAppPut = async (
 
 		const updatedAppPayload = { ...req.body };
 		if (!updatedAppPayload.privateKey) {
-			updatedAppPayload.privateKey = await verifiedApp.getDecryptedPrivateKey(); // will be encrypted on save
+			updatedAppPayload.privateKey = undefined;
 		}
 
 		await GitHubServerApp.updateGitHubAppByUUID(req.body);

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-put.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-put.ts
@@ -17,7 +17,7 @@ export const JiraConnectEnterpriseAppPut = async (
 
 		const updatedAppPayload = { ...req.body };
 		if (!updatedAppPayload.privateKey) {
-			updatedAppPayload.privateKey = verifiedApp.privateKey; // will be encrypted on save
+			updatedAppPayload.privateKey = await verifiedApp.getDecryptedPrivateKey(); // will be encrypted on save
 		}
 
 		await GitHubServerApp.updateGitHubAppByUUID(req.body);

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-router.test.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-router.test.ts
@@ -52,8 +52,7 @@ describe("JiraConnectEnterpriseAppRouter", () => {
 				.expect(200);
 			expect(capturedGHEAppConfig).toEqual(expect.objectContaining({
 				uuid: GHE_APP_UUID,
-				appId: 1,
-				privateKey: "private-key"
+				appId: 1
 			}));
 		});
 		it("should throw error for invalid uuid", async () => {

--- a/src/sqs/sqs.types.ts
+++ b/src/sqs/sqs.types.ts
@@ -170,9 +170,6 @@ export type GitHubAppConfig = {
 	gitHubBaseUrl: string, // GITHUB_CLOUD_BASEURL for cloud
 	gitHubApiUrl: string,
 	uuid: string | undefined,
-	//gitHubClientSecret: string,
-	//webhookSecret: string,
-	//privateKey: string
 }
 
 //refer from https://docs.github.com/en/rest/repos/repos#get-a-repository


### PR DESCRIPTION
**What's in this PR?**
Remove the decrypted secrets in `res.locals.gitHubAppConfig` to avoid risk that it might be deserialized and sent to somewhere like in the splunk or worse frontend.

Replace those secrets with a closure method.

**Why**
It is generally dangerous have something secrets in the json object hanging around for long. 

**Added feature flags**
N/A

**Affected issues**  
ARC-1810

**How has this been tested?**  
Unit test
Tested on Stage.

**Whats Next?**
1. Need more proper typings on the `res.locals`. Already have some ideas. Will raise a PR soon.
2. Also remove the decrypted secrets in `gitHubClient` as well. 
