### PR TITLE
ARC-1817 improve failed SQS logging and add DLQ alarms

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -655,7 +655,7 @@ environmentOverrides:
             MetricName: ApproximateNumberOfMessagesVisible
             Namespace: AWS/SQS
             Description: "Message count for backfill dead letter queue too high!"
-            Threshold: 5000 # number is initially high until we start bringing numbers down
+            Threshold: 50 # number is initially high until we start bringing numbers down
             Priority: Low
             Dimensions:
               - Name: QueueName
@@ -672,7 +672,7 @@ environmentOverrides:
             MetricName: ApproximateNumberOfMessagesVisible
             Namespace: AWS/SQS
             Description: "Message count for push dead letter queue too high!"
-            Threshold: 5000 # number is initially high until we start bringing numbers down
+            Threshold: 500 # number is initially high until we start bringing numbers down
             Priority: Low
             Dimensions:
               - Name: QueueName
@@ -689,7 +689,7 @@ environmentOverrides:
             MetricName: ApproximateNumberOfMessagesVisible
             Namespace: AWS/SQS
             Description: "Message count for deployment dead letter queue too high!"
-            Threshold: 5000 # number is initially high until we start bringing numbers down
+            Threshold: 4000 # number is initially high until we start bringing numbers down
             Priority: Low
             Dimensions:
               - Name: QueueName

--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -655,13 +655,13 @@ environmentOverrides:
             MetricName: ApproximateNumberOfMessagesVisible
             Namespace: AWS/SQS
             Description: "Message count for backfill dead letter queue too high!"
-            Threshold: 40 #~ Autoscaling Threshold x 2. So we'll be alerted if autoscaling failed to fix the piling messages
+            Threshold: 5000 # number is initially high until we start bringing numbers down
             Priority: Low
             Dimensions:
               - Name: QueueName
                 Value: { "Ref": "QueueName" }
-            EvaluationPeriods: 10
-            Period: 600
+            EvaluationPeriods: 5
+            Period: 300
             ComparisonOperator: GreaterThanThreshold
             Statistic: Maximum
 
@@ -672,13 +672,13 @@ environmentOverrides:
             MetricName: ApproximateNumberOfMessagesVisible
             Namespace: AWS/SQS
             Description: "Message count for push dead letter queue too high!"
-            Threshold: 500 #~ Autoscaling Threshold x 2. So we'll be alerted if autoscaling failed to fix the piling messages
+            Threshold: 5000 # number is initially high until we start bringing numbers down
             Priority: Low
             Dimensions:
               - Name: QueueName
                 Value: { "Ref": "QueueName" }
-            EvaluationPeriods: 10
-            Period: 600
+            EvaluationPeriods: 5
+            Period: 300
             ComparisonOperator: GreaterThanThreshold
             Statistic: Maximum
 
@@ -689,13 +689,13 @@ environmentOverrides:
             MetricName: ApproximateNumberOfMessagesVisible
             Namespace: AWS/SQS
             Description: "Message count for deployment dead letter queue too high!"
-            Threshold: 500 #~ Autoscaling Threshold x 2. So we'll be alerted if autoscaling failed to fix the piling messages
+            Threshold: 5000 # number is initially high until we start bringing numbers down
             Priority: Low
             Dimensions:
               - Name: QueueName
                 Value: { "Ref": "QueueName" }
-            EvaluationPeriods: 10
-            Period: 600
+            EvaluationPeriods: 5
+            Period: 300
             ComparisonOperator: GreaterThanThreshold
             Statistic: Maximum
 
@@ -706,13 +706,13 @@ environmentOverrides:
             MetricName: ApproximateNumberOfMessagesVisible
             Namespace: AWS/SQS
             Description: "Message count for branch dead letter queue too high!"
-            Threshold: 500 #~ Autoscaling Threshold x 2. So we'll be alerted if autoscaling failed to fix the piling messages
+            Threshold: 5000 # number is initially high until we start bringing numbers down
             Priority: Low
             Dimensions:
               - Name: QueueName
                 Value: { "Ref": "QueueName" }
-            EvaluationPeriods: 10
-            Period: 600
+            EvaluationPeriods: 5
+            Period: 300
             ComparisonOperator: GreaterThanThreshold
             Statistic: Maximum
 

--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -672,7 +672,7 @@ environmentOverrides:
             MetricName: ApproximateNumberOfMessagesVisible
             Namespace: AWS/SQS
             Description: "Message count for push dead letter queue too high!"
-            Threshold: 500 # number is initially high until we start bringing numbers down
+            Threshold: 100 # number is initially high until we start bringing numbers down
             Priority: Low
             Dimensions:
               - Name: QueueName
@@ -689,7 +689,7 @@ environmentOverrides:
             MetricName: ApproximateNumberOfMessagesVisible
             Namespace: AWS/SQS
             Description: "Message count for deployment dead letter queue too high!"
-            Threshold: 4000 # number is initially high until we start bringing numbers down
+            Threshold: 5000 # number is initially high until we start bringing numbers down
             Priority: Low
             Dimensions:
               - Name: QueueName
@@ -706,7 +706,7 @@ environmentOverrides:
             MetricName: ApproximateNumberOfMessagesVisible
             Namespace: AWS/SQS
             Description: "Message count for branch dead letter queue too high!"
-            Threshold: 5000 # number is initially high until we start bringing numbers down
+            Threshold: 1000 # number is initially high until we start bringing numbers down
             Priority: Low
             Dimensions:
               - Name: QueueName

--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -647,6 +647,75 @@ environmentOverrides:
             Period: 300
             ComparisonOperator: GreaterThanThreshold
             Statistic: Maximum
+
+      - type: sqs
+        name: backfill_dlq
+        alarms:
+          AlarmOnTooManyMessages:
+            MetricName: ApproximateNumberOfMessagesVisible
+            Namespace: AWS/SQS
+            Description: "Message count for backfill dead letter queue too high!"
+            Threshold: 40 #~ Autoscaling Threshold x 2. So we'll be alerted if autoscaling failed to fix the piling messages
+            Priority: Low
+            Dimensions:
+              - Name: QueueName
+                Value: { "Ref": "QueueName" }
+            EvaluationPeriods: 10
+            Period: 600
+            ComparisonOperator: GreaterThanThreshold
+            Statistic: Maximum
+
+      - type: sqs
+        name: push_dlq
+        alarms:
+          AlarmOnTooManyMessages:
+            MetricName: ApproximateNumberOfMessagesVisible
+            Namespace: AWS/SQS
+            Description: "Message count for push dead letter queue too high!"
+            Threshold: 500 #~ Autoscaling Threshold x 2. So we'll be alerted if autoscaling failed to fix the piling messages
+            Priority: Low
+            Dimensions:
+              - Name: QueueName
+                Value: { "Ref": "QueueName" }
+            EvaluationPeriods: 10
+            Period: 600
+            ComparisonOperator: GreaterThanThreshold
+            Statistic: Maximum
+
+      - type: sqs
+        name: deployment_dlq
+        alarms:
+          AlarmOnTooManyMessages:
+            MetricName: ApproximateNumberOfMessagesVisible
+            Namespace: AWS/SQS
+            Description: "Message count for deployment dead letter queue too high!"
+            Threshold: 500 #~ Autoscaling Threshold x 2. So we'll be alerted if autoscaling failed to fix the piling messages
+            Priority: Low
+            Dimensions:
+              - Name: QueueName
+                Value: { "Ref": "QueueName" }
+            EvaluationPeriods: 10
+            Period: 600
+            ComparisonOperator: GreaterThanThreshold
+            Statistic: Maximum
+
+      - type: sqs
+        name: branch_dlq
+        alarms:
+          AlarmOnTooManyMessages:
+            MetricName: ApproximateNumberOfMessagesVisible
+            Namespace: AWS/SQS
+            Description: "Message count for branch dead letter queue too high!"
+            Threshold: 500 #~ Autoscaling Threshold x 2. So we'll be alerted if autoscaling failed to fix the piling messages
+            Priority: Low
+            Dimensions:
+              - Name: QueueName
+                Value: { "Ref": "QueueName" }
+            EvaluationPeriods: 10
+            Period: 600
+            ComparisonOperator: GreaterThanThreshold
+            Statistic: Maximum
+
       - name: github-server-app-secrets
         type: cryptor
         attributes:

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -94,6 +94,7 @@ interface LoggerOptions {
 	serializers?: Serializers;
 	src?: boolean;
 	filterHttpRequests?: boolean;
+	unsafe?: boolean;
 }
 
 export const getLogger = (name: string, options: LoggerOptions = {}): Logger => {

--- a/src/sqs/sqs.ts
+++ b/src/sqs/sqs.ts
@@ -252,7 +252,7 @@ export class SqsQueue<MessagePayload> {
 			message,
 			payload,
 			log: listenerContext.log.child({
-				id: message.MessageId,
+				messageId: message.MessageId,
 				executionId: uuidv4(),
 				queue: this.queueName
 			}),
@@ -284,7 +284,9 @@ export class SqsQueue<MessagePayload> {
 	}
 
 	private async handleSqsMessageExecutionError(err, context: SQSMessageContext<MessagePayload>) {
+		const unsafeLogger = getLogger("message-error-handler-unsafe", { level: "warn", unsafe: true });
 		try {
+			unsafeLogger.warn({ err, context }, "Failed message");
 			const errorHandlingResult = await this.errorHandler(err, context);
 
 			if (errorHandlingResult.isFailure) {
@@ -304,10 +306,12 @@ export class SqsQueue<MessagePayload> {
 				context.log.warn("Deleting the message because it has reached the maximum amount of retries");
 				await this.deleteMessage(context);
 			} else {
+				unsafeLogger.error({ errorHandlingResult, err, context }, "SQS message visibility timeout changed");
 				await this.changeVisibilityTimeoutIfNeeded(errorHandlingResult, context.message, context.log);
 			}
 		} catch (errorHandlingException) {
-			context.log.error({ err: errorHandlingException, originalError: err }, "Error while performing error handling");
+			unsafeLogger.error({ err: errorHandlingException, originalError: err , context }, "Error while performing error handling on SQS message");
+			context.log.error({ err: errorHandlingException, originalError: err }, "Error while performing error handling on SQS message");
 		}
 	}
 

--- a/src/util/logger-utils.test.ts
+++ b/src/util/logger-utils.test.ts
@@ -130,6 +130,17 @@ describe("Logger Utils", () => {
 				expect(process.stdout.write).not.toHaveBeenCalled();
 			});
 
+			it("should write log when tagged unsafe", async () => {
+				const testMessage = {
+					msg: "More messaging",
+					unsafe: true,
+					orgName: "ORG",
+					level: INFO
+				};
+				await stream._write(testMessage, encoding, next);
+				expect(process.stdout.write).toHaveBeenCalled();
+			});
+
 			it("should not serialize sensitive data", async () => {
 				const testMessage = {
 					msg: "MEOW",

--- a/src/util/logger-utils.test.ts
+++ b/src/util/logger-utils.test.ts
@@ -107,6 +107,17 @@ describe("Logger Utils", () => {
 				expect(getLogObject(stdoutSpy.mock).orgName).toBe("3340de80aa35aaa011bafb7c45d96514175f57790cb7bc9567a22d644631f1ef");
 			});
 
+			it("should not log unsafe data to standard logger", async () => {
+				const testMessage = {
+					msg: "More messaging",
+					unsafe: true,
+					orgName: "ORG",
+					level: INFO
+				};
+				await stream._write(testMessage, encoding, next);
+				expect(process.stdout.write).not.toHaveBeenCalled();
+			});
+
 		});
 
 		describe("unsafe logger", () => {

--- a/src/util/logger-utils.ts
+++ b/src/util/logger-utils.ts
@@ -50,6 +50,10 @@ class RawLogStream extends Writable {
 export class SafeRawLogStream extends RawLogStream {
 
 	public async _write(record: ChunkData, encoding: BufferEncoding, next: Callback): Promise<void> {
+		// Skip unsafe data
+		if (record.unsafe) {
+			return next();
+		}
 		const hashedRecord = this.hashSensitiveData(record);
 		await super._write(hashedRecord, encoding, next);
 	}

--- a/src/util/logger-utils.ts
+++ b/src/util/logger-utils.ts
@@ -69,10 +69,13 @@ export class SafeRawLogStream extends RawLogStream {
 
 export class UnsafeRawLogStream extends RawLogStream {
 
-	public async _write(record: ChunkData, encoding: BufferEncoding, next: Callback): Promise<void> {
+	private isAboveDebug = (record: ChunkData) => {
+		return !record.level || isNaN(record.level) || record.level > DEBUG;
+	};
 
-		// Skip any log above DEBUG level
-		if (!record.level || isNaN(record.level) || record.level > DEBUG) {
+	public async _write(record: ChunkData, encoding: BufferEncoding, next: Callback): Promise<void> {
+		// Skip any log above DEBUG level that isn't tagged unsafe
+		if (this.isAboveDebug(record) && !record.unsafe) {
 			return next();
 		}
 		// Tag the record do it gets indexed to the _unsafe logging environment


### PR DESCRIPTION
**What's in this PR?**
Updated the SQS message attribute to be messageId so its more obvious when Splunking

Sent DLQ errors to the unsafe logging environment so we can use legit data

create DLQ alarms - low prio and the numbers are best guess at this point.

**Why**
We had trouble last time we had an outage with error handling on SQS and was lacking details of the messages



**How has this been tested?**  
Testing Alarms in stage(forced with a lower threshold)
Tested that unsafe logs containing UGC/PII only show up in [env]-unsafe Splunk partition.

**Whats Next?**
When the world collapses and we need to know what some of the failed messages are we wont have a shake our fists.