### PR TITLE
pass jirahost as part of body on create branch post

### DIFF
--- a/src/routes/github/create-branch/github-create-branch-post.ts
+++ b/src/routes/github/create-branch/github-create-branch-post.ts
@@ -61,9 +61,10 @@ const getErrorMessages = (statusCode: number, url?: string): string => {
 };
 
 export const GithubCreateBranchPost = async (req: Request, res: Response): Promise<void> => {
-	const { githubToken, jiraHost, gitHubAppConfig } = res.locals;
-	const { owner, repo, sourceBranchName, newBranchName } = req.body;
+	const { githubToken, gitHubAppConfig } = res.locals;
+	const { owner, repo, sourceBranchName, newBranchName, jiraHostEncoded } = req.body;
 
+	const jiraHost = decodeURIComponent(jiraHostEncoded);
 	if (!githubToken) {
 		res.sendStatus(401);
 		return;

--- a/static/js/github-create-branch.js
+++ b/static/js/github-create-branch.js
@@ -200,9 +200,11 @@ const createBranchPost = () => {
   }
   const repo = getRepoDetails();
   const newBranchName = $("#branchNameText").val();
+  const jiraHost = $("#jiraHost").val();
   const data = {
     owner: repo.owner,
     repo: repo.name,
+		jiraHostEncoded: encodeURIComponent(jiraHost),
     sourceBranchName: $("#ghParentBranch").select2("val"),
     newBranchName,
     _csrf: $("#_csrf").val(),


### PR DESCRIPTION
**What's in this PR?**
Pass the jirahost as part of the create branch post

**Why**
There is a possible scenario when you get in a tangle and we still cant rely on the session jirahost, so have pass this then when the jwt story is played we can rely on it again

