### PR TITLE
temp update scaling rules for a max of 35 instacnces

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -515,7 +515,7 @@ environmentOverrides:
         scaling:
           instance: c5.2xlarge
           min: 3
-          max: 15 # keep in sync with PGBOUNCER_DEFAULT_POOL_SIZE
+          max: 35 # keep in sync with PGBOUNCER_DEFAULT_POOL_SIZE # Temp update from 15 to 35 while backfilling
           metrics: *CpuMemAndQueuesScalingRules
     alarms:
       overrides:


### PR DESCRIPTION
**What's in this PR?**
While we backfill all the pull we dont want to reset the instances every release !! so temporarily adding it so we can fish backfill in peace.

**Whats Next?**
revert to 15 on backfill completion