### PR TITLE
add else clause

### DIFF
--- a/src/routes/jira/jira-get.ts
+++ b/src/routes/jira/jira-get.ts
@@ -125,11 +125,7 @@ const renderJiraCloud = async (res: Response, req: Request): Promise<void> => {
 	const { installations, successfulConnections, failedConnections } = await getConnectionsAndInstallations(subscriptions, req);
 	const hasConnections = !!installations.total;
 
-	if (!hasConnections) {
-		await saveConfiguredAppProperties(jiraHost, undefined, undefined, req, "false");
-	} else {
-		await saveConfiguredAppProperties(jiraHost, undefined, undefined, req, "true");
-	}
+	await saveConfiguredAppProperties(jiraHost, undefined, undefined, req, hasConnections ? "true" : "false");
 
 	res.render("jira-configuration.hbs", {
 		host: jiraHost,
@@ -191,11 +187,7 @@ const renderJiraCloudAndEnterpriseServer = async (res: Response, req: Request): 
 
 	const hasConnections =  !!(installations.total || gheServers?.length);
 
-	if (!hasConnections) {
-		await saveConfiguredAppProperties(jiraHost, undefined, undefined, req, "false");
-	} else {
-		await saveConfiguredAppProperties(jiraHost, undefined, undefined, req, "true");
-	}
+	await saveConfiguredAppProperties(jiraHost, undefined, undefined, req, hasConnections ? "true" : "false");
 
 	res.render("jira-configuration-new.hbs", {
 		host: jiraHost,

--- a/src/routes/jira/jira-get.ts
+++ b/src/routes/jira/jira-get.ts
@@ -127,6 +127,8 @@ const renderJiraCloud = async (res: Response, req: Request): Promise<void> => {
 
 	if (!hasConnections) {
 		await saveConfiguredAppProperties(jiraHost, undefined, undefined, req, "false");
+	} else {
+		await saveConfiguredAppProperties(jiraHost, undefined, undefined, req, "true");
 	}
 
 	res.render("jira-configuration.hbs", {
@@ -191,6 +193,8 @@ const renderJiraCloudAndEnterpriseServer = async (res: Response, req: Request): 
 
 	if (!hasConnections) {
 		await saveConfiguredAppProperties(jiraHost, undefined, undefined, req, "false");
+	} else {
+		await saveConfiguredAppProperties(jiraHost, undefined, undefined, req, "true");
 	}
 
 	res.render("jira-configuration-new.hbs", {


### PR DESCRIPTION
**What's in this PR?**
Addition of an else clause to add `isConfigured: true` for any customers that land on our config page and have existing connections.

**Why**
Because I forgot to do it in my last pr :coneofshame:

**How has this been tested?**  
Locally

