### PR TITLE
Trying to fix build duplicates

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -2,8 +2,11 @@ name: Push
 
 on:
   push:
+    branches:
+      - main
   pull_request:
-    types: [ opened ]
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
-
     steps:
       - uses: actions/checkout@v1
       - uses: volta-cli/action@v4
@@ -25,7 +24,6 @@ jobs:
 
   unit-test:
     runs-on: ubuntu-22.04
-
     steps:
       - uses: actions/checkout@v1
       - uses: volta-cli/action@v4

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -1,12 +1,12 @@
 name: Push
 
 on:
+  # Only build on main branch when pushed (when PR is merged)
   push:
     branches:
       - main
+  # Only build in PR on creation/update
   pull_request:
-    branches:
-      - main
 
 jobs:
   build:


### PR DESCRIPTION
**What's in this PR?**
Fix to prevent duplication of pull_request builds and push builds

**Why**
There was still some builds being duplicated between push/pull_request events which is not good as the e2e tests will conflict with each other

**How has this been tested?**  
visually
