### PR TITLE
ARC-936 fix a bug for GHE restart backfill not having jiraHost

### DIFF
--- a/views/jira-configuration-new.hbs
+++ b/views/jira-configuration-new.hbs
@@ -180,6 +180,7 @@
               <div class="jiraConfiguration__cloudConnections">
                 {{> jira-configuration-table
                     id=id
+                    host=host
                     elementIdPrefix="ghCloud-"
                     html_url=html_url
                     csrfToken=csrfToken
@@ -252,6 +253,7 @@
                           {{#if app.installations.total}}
                             {{> jira-configuration-table
                                 id=id
+                                host=../../host
                                 hideAvatar=true
                                 elementIdPrefix="gheServer-"
                                 html_url=html_url


### PR DESCRIPTION
**What's in this PR?**
Fix the rendering bug that missing jiraHost.

**Why**
The rendering of `{{../host}}` inside the partial view is not working for GHE as it is one level deeper.
Explicitly passing the host variable (when calling the partial view) to make it more consistent for partial to use that var.

N/A
**Added feature flags**

**Affected issues**  
ARC-936

**How has this been tested?**  
Install local app into prod.

**Whats Next?**
Continue pollinator GHE backfill test.

**The button**
![Screen Shot 2022-12-07 at 1 26 30 pm](https://user-images.githubusercontent.com/105693507/206073371-4b528629-111e-42c8-912c-54c285507229.png)

**Before**
![Screen Shot 2022-12-07 at 1 18 29 pm](https://user-images.githubusercontent.com/105693507/206073390-0d05618c-22e1-43c6-b8fd-a5ad187eb5e8.png)

**After**
![Screen Shot 2022-12-07 at 1 26 34 pm](https://user-images.githubusercontent.com/105693507/206073403-195cdabc-9882-4cde-8289-01d3df99c8cf.png)


