### PR TITLE
Temporarily reduce alert priority of deployment alert

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -647,7 +647,7 @@ environmentOverrides:
             Namespace: AWS/SQS
             Description: "Message count for deployment queue too high! Follow the runbook: https://hello.atlassian.net/wiki/spaces/PF/pages/1550488861/HOWTO+Respond+to+Too+Many+Messages+on+the+Queue+Alert"
             Threshold: 500 #~ Autoscaling Threshold x 2. So we'll be alerted if autoscaling failed to fix the piling messages
-            Priority: High
+            Priority: Low
             Dimensions:
               - Name: QueueName
                 Value: { "Ref": "QueueName" }


### PR DESCRIPTION
Reduce alert priority for deployment message count alert while we solve the issue so Rachelle can nap at nighttime
