### PR TITLE
udpate track source to one level up

### DIFF
--- a/src/util/analytics-client.ts
+++ b/src/util/analytics-client.ts
@@ -64,6 +64,9 @@ export const sendAnalytics: {
 			sendEvent(analyticsNodeClient.sendTrackEvent({
 				...baseAttributes,
 				trackEvent: {
+					source: attributes["source"],
+					action: attributes["action"] || attributes.name,
+					actionSubject: attributes["actionSubject"] || attributes.name,
 					attributes
 				}
 			}));

--- a/src/util/analytics-client.ts
+++ b/src/util/analytics-client.ts
@@ -41,9 +41,10 @@ export const sendAnalytics: {
 
 	logger.debug({ eventType }, "Sending analytics");
 
+	const name = attributes.name || "";
 	switch (eventType) {
 		case "screen":
-			sendEvent(analyticsNodeClient.sendScreenEvent({
+			sendEvent(eventType, name, analyticsNodeClient.sendScreenEvent({
 				...baseAttributes,
 				name: attributes.name,
 				screenEvent: {
@@ -53,7 +54,7 @@ export const sendAnalytics: {
 			}));
 			break;
 		case "ui":
-			sendEvent(analyticsNodeClient.sendUIEvent({
+			sendEvent(eventType, name, analyticsNodeClient.sendUIEvent({
 				...baseAttributes,
 				uiEvent: {
 					attributes
@@ -61,7 +62,7 @@ export const sendAnalytics: {
 			}));
 			break;
 		case "track":
-			sendEvent(analyticsNodeClient.sendTrackEvent({
+			sendEvent(eventType, name, analyticsNodeClient.sendTrackEvent({
 				...baseAttributes,
 				trackEvent: {
 					source: attributes["source"],
@@ -72,7 +73,7 @@ export const sendAnalytics: {
 			}));
 			break;
 		case "operational":
-			sendEvent(analyticsNodeClient.sendOperationalEvent({
+			sendEvent(eventType, name, analyticsNodeClient.sendOperationalEvent({
 				...baseAttributes,
 				operationalEvent: {
 					attributes
@@ -85,8 +86,8 @@ export const sendAnalytics: {
 	}
 };
 
-const sendEvent = (promise: Promise<unknown>) => {
+const sendEvent = (eventType: string, name: unknown, promise: Promise<unknown>) => {
 	promise.catch((error) => {
-		logger.warn(`Cannot sendAnalytics event: ${error}`);
+		logger.warn(`Cannot sendAnalytics event ${eventType} - ${name}, error: ${error}`);
 	});
 };

--- a/src/util/analytics-client.ts
+++ b/src/util/analytics-client.ts
@@ -16,9 +16,10 @@ export const sendAnalytics: {
 	(eventType: "ui" | "operational", attributes: Record<string, unknown>);
 } = (eventType: string, attributes: Record<string, unknown> = {}): void => {
 
-	logger.info(analyticsClient ? "Found analytics client." : `No analytics client found.`);
+	logger.debug(analyticsClient ? "Found analytics client." : `No analytics client found.`);
 
 	if (!analyticsClient || !isNodeProd()) {
+		logger.warn("No analyticsClient or skipping sending analytics");
 		return;
 	}
 
@@ -65,9 +66,9 @@ export const sendAnalytics: {
 			sendEvent(eventType, name, analyticsNodeClient.sendTrackEvent({
 				...baseAttributes,
 				trackEvent: {
-					source: attributes["source"],
-					action: attributes["action"] || attributes.name,
-					actionSubject: attributes["actionSubject"] || attributes.name,
+					source: attributes.source,
+					action: attributes.action || attributes.name,
+					actionSubject: attributes.actionSubject || attributes.name,
 					attributes
 				}
 			}));


### PR DESCRIPTION
**What's in this PR?**
Move track even source one level up.
Also add more detail

**Why**
To match the doc and fix the error of `Cannot sendAnalytics event: Error: Value trackEvent.source cannot be undefined`

This is what splunk complain about
<img width="581" alt="image" src="https://user-images.githubusercontent.com/105693507/207180193-4f69dce0-a65d-45bb-b959-1c838c8e42cd.png">

This is what the doc said: https://bitbucket.org/atlassian/analytics-node-client/src/v3.1.1/
<img width="635" alt="image" src="https://user-images.githubusercontent.com/105693507/207180024-e84c343a-becf-4996-8673-8831c4fb7af7.png">


**Added feature flags**
N/A

**Affected issues**  
ARC-1857

**How has this been tested?**  
N/A

**Whats Next?**
N/A
