### PR TITLE
noissue: Set min workers to 5 and max to 15

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -513,8 +513,8 @@ environmentOverrides:
       - name: Worker
         scaling:
           instance: c5.2xlarge
-          min: 3
-          max: 35 # keep in sync with PGBOUNCER_DEFAULT_POOL_SIZE # Temp update from 15 to 35 while backfilling
+          min: 5
+          max: 15 # keep in sync with PGBOUNCER_DEFAULT_POOL_SIZE
           metrics: *CpuMemAndQueuesScalingRules
     alarms:
       overrides:


### PR DESCRIPTION
**What's in this PR?**
Setting min workers to 5 and max to 15 (back from 35 since backfilling is done)

**Why**
Because 3 is not enough and 35 is too much (was a temporary change)

**Added feature flags**
n/a

**Affected issues**  
n/a