### PR TITLE
ARC-1873 Making the uninstall non-blocking on app property which might not be set

### DIFF
--- a/src/routes/jira/events/jira-events-uninstall-post.ts
+++ b/src/routes/jira/events/jira-events-uninstall-post.ts
@@ -19,7 +19,8 @@ export const JiraEventsUninstallPost = async (req: Request, res: Response): Prom
 
 	const jiraClient = await getJiraClient(installation.jiraHost, undefined, undefined, req.log);
 
-	await jiraClient.appProperties.delete();
+	// Don't wait for promise as it might fail if the property is not set
+	jiraClient.appProperties.delete();
 	await installation.uninstall();
 
 	req.log.info("App uninstalled on Jira.");


### PR DESCRIPTION
**What's in this PR?**
very small change to not prevent uninstall on app-properties issue

**Why**
Because it might not be set, it might fail and prevent the installation from being uninstalled

**Added feature flags**

**Affected issues**  
ARC-1873
