### PR TITLE
ARC 1886 - [JST-827001] - Fixing Regex to support alphanumeric issue keys

### DIFF
--- a/src/jira/util/jira-client-util.test.ts
+++ b/src/jira/util/jira-client-util.test.ts
@@ -139,5 +139,38 @@ describe("Jira util", () => {
 			const result = util.addJiraIssueLinks(source, issues);
 			expect(result).toBe(rendered);
 		});
+
+		it("should linkify for issue keys with alphanumeric values", () => {
+			const { source, rendered } = loadFixture("issue-keys-with-alphanumeric-values");
+			const issues = [
+				{
+					key: "KEY-2018",
+					fields: {
+						summary: "First Issue"
+					}
+				},
+				{
+					key: "A1-2019",
+					fields: {
+						summary: "Second Issue"
+					}
+				},
+				{
+					key: "A1B2-2020",
+					fields: {
+						summary: "Third Issue"
+					}
+				},
+				{
+					key: "A1B2C3-2021",
+					fields: {
+						summary: "Fourth Issue"
+					}
+				}
+			];
+
+			const result = util.addJiraIssueLinks(source, issues);
+			expect(result).toBe(rendered);
+		});
 	});
 });

--- a/src/jira/util/jira-client-util.ts
+++ b/src/jira/util/jira-client-util.ts
@@ -1,6 +1,7 @@
 import { envVars }  from "config/env";
 import { getLogger } from "config/logger";
 import { JiraIssue } from "interfaces/jira";
+import { jiraIssueRegex } from "utils/jira-utils";
 
 const logger = getLogger("jira.util");
 
@@ -32,7 +33,7 @@ export const getJiraUtil = (jiraClient) => {
 	};
 
 	const addJiraIssueLinks = (text: string, issues: JiraIssue[]): string => {
-		const referenceRegex = /\[([A-Z]+-[0-9]+)\](?!\()/g;
+		const referenceRegex = jiraIssueRegex();
 		const issueMap = issues.reduce((acc, issue) => ({
 			...acc,
 			[issue.key]: issue
@@ -49,7 +50,7 @@ export const getJiraUtil = (jiraClient) => {
 				break;
 			}
 
-			const [, key] = match;
+			const [, , key] = match;
 			// If we already have a reference link, or the issue is not valid, skip it.
 			if (keys.includes(key) || !issueMap[key]) {
 				continue;

--- a/src/util/jira-utils.ts
+++ b/src/util/jira-utils.ts
@@ -73,6 +73,25 @@ let issueKeyRegexCharLimitFeature = false;
 onFlagChange(BooleanFlags.ISSUEKEY_REGEX_CHAR_LIMIT, async () => {
 	issueKeyRegexCharLimitFeature = await booleanFlag(BooleanFlags.ISSUEKEY_REGEX_CHAR_LIMIT);
 });
+
+/**
+ *  Based on the JIRA Ticket parser extended regex: ^\p{L}[\p{L}\p{Digit}_]{1,255}-\p{Digit}{1,255}$ (^|[^\p{L}\p{Nd}]) means that it must be at the start of the string
+ *  or be a non unicode-digit character (separator like space, new line, or special character like [) [\p{L}][\p{L}\p{Nd}_]{1,255} means that the id must start with a unicode letter,
+ *  then must be at least one more unicode-digit character up to 256 length to prefix the ID -\p{Nd}{1,255} means that it must be separated by a dash,
+ *  then at least 1 number character up to 256 length
+ */
+export const jiraIssueRegex = (): RegExp => {
+	if (issueKeyRegexCharLimitFeature) {
+		return /(^|[^A-Z\d])([A-Z][A-Z\d]{1,255}-[1-9]\d{0,255})/giu;
+	} else if (regexFixFeature) {
+		// Old regex which was working before trying to update it to the "correct" one
+		return /(^|[^A-Z\d])([A-Z][A-Z\d]+-[1-9]\d*)/giu;
+	}
+
+	return /(^|[^\p{L}\p{Nd}])([\p{L}][\p{L}\p{Nd}_]{1,255}-\p{Nd}{1,255})/giu;
+};
+
+
 /**
  * Parses strings for Jira issue keys for commit messages,
  * branches, and pull requests.
@@ -96,23 +115,8 @@ export const jiraIssueKeyParser = (str: string): string[] => {
 		return [];
 	}
 
-	// Based on the JIRA Ticket parser extended regex: ^\p{L}[\p{L}\p{Digit}_]{1,255}-\p{Digit}{1,255}$
-	// (^|[^\p{L}\p{Nd}]) means that it must be at the start of the string or be a non unicode-digit character (separator like space, new line, or special character like [)
-	// [\p{L}][\p{L}\p{Nd}_]{1,255} means that the id must start with a unicode letter, then must be at least one more unicode-digit character up to 256 length to prefix the ID
-	// -\p{Nd}{1,255} means that it must be separated by a dash, then at least 1 number character up to 256 length
-
-	// Regex given to us by sayans
-	let regex = /(^|[^\p{L}\p{Nd}])([\p{L}][\p{L}\p{Nd}_]{1,255}-\p{Nd}{1,255})/giu;
-
-	if (issueKeyRegexCharLimitFeature) {
-		regex = /(^|[^A-Z\d])([A-Z][A-Z\d]{1,255}-[1-9]\d{0,255})/giu;
-	} else if (regexFixFeature) {
-		// Old regex which was working before trying to update it to the "correct" one
-		regex = /(^|[^A-Z\d])([A-Z][A-Z\d]+-[1-9]\d*)/giu;
-	}
-
 	// Parse all issue keys from string then we UPPERCASE the matched string and remove duplicate issue keys
-	return uniq(Array.from(str.matchAll(regex), m => m[2].toUpperCase()));
+	return uniq(Array.from(str.matchAll(jiraIssueRegex()), m => m[2].toUpperCase()));
 };
 
 export const hasJiraIssueKey = (str: string): boolean => !isEmpty(jiraIssueKeyParser(str));

--- a/test/fixtures/text/issue-keys-with-alphanumeric-values.rendered.md
+++ b/test/fixtures/text/issue-keys-with-alphanumeric-values.rendered.md
@@ -1,0 +1,17 @@
+#### [KEY-2018]
+
+These issues must have links:
+- [A1-2019]
+- [A1B2-2020]
+- [A1B2C3-2021]
+
+Meanwhile these issues shouldn't have links:
+- [A11-2019]
+- [A11B22-2020]
+- [A11B2C33-2021]
+
+[KEY-2018]: http://example.com/browse/KEY-2018
+[A1-2019]: http://example.com/browse/A1-2019
+[A1B2-2020]: http://example.com/browse/A1B2-2020
+[A1B2C3-2021]: http://example.com/browse/A1B2C3-2021
+

--- a/test/fixtures/text/issue-keys-with-alphanumeric-values.source.md
+++ b/test/fixtures/text/issue-keys-with-alphanumeric-values.source.md
@@ -1,0 +1,11 @@
+#### [KEY-2018]
+
+These issues must have links:
+- [A1-2019]
+- [A1B2-2020]
+- [A1B2C3-2021]
+
+Meanwhile these issues shouldn't have links:
+- [A11-2019]
+- [A11B22-2020]
+- [A11B2C33-2021]


### PR DESCRIPTION
**What's in this PR?**
- Updating the Regex for `addJiraIssueLinks` to match with the Regex being used for `jiraIssueKeyParser`

**Why**
- The current Regex is outdated and does not support alphanumeric issue keys like `K1-1`.
- Raised up in a DOS ticket - [JST-827001](https://getsupport.atlassian.com/browse/JST-827001)

**How has this been tested?**  
- Added Test case
- Locally

**Whats Next?**
- Merge and notify the customer
