### PR TITLE
Track stats for total commits pushed and commits with jira issue key

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ That being said, here are the steps needed to create a Pull Request for us to re
 1. [Sign the CLA first!](#contributor-license-agreement)
 1. Fork the repository.
 1. Do your changes either on the main branch or create a new one.
-1. Make sure the tests pass on your machine with `yarn test` and the build works with `yarn run build`.  If you're adding new functionality, please add tests to reflect this.
+1. Make sure the tests pass on your machine with `yarn test` and the build works with `yarn run precommit`.  If you're adding new functionality, please add tests to reflect this.
 1. Commit and Push your changes - verify it passes all checks.
 1. Submit your pull request with a detailed message about what's changed.
 1. Wait for us to review and answer questions/make changes where requested.

--- a/src/github/push.ts
+++ b/src/github/push.ts
@@ -6,6 +6,9 @@ import { GitHubPushData } from "interfaces/github";
 import { WebhookContext } from "routes/github/webhook/webhook-context";
 import { Subscription } from "models/subscription";
 import { getInstallationId } from "./client/installation-id";
+import { sendAnalytics } from "utils/analytics-client";
+import { AnalyticsEventTypes, AnalyticsTrackEventsEnum, AnalyticsTrackSource } from "interfaces/common";
+import { getCloudOrServerFromGitHubAppId } from "../util/get-cloud-or-server";
 
 
 export const pushWebhookHandler = async (context: WebhookContext, jiraClient, _util, gitHubInstallationId: number, subscription: Subscription): Promise<void> => {
@@ -27,8 +30,20 @@ export const pushWebhookHandler = async (context: WebhookContext, jiraClient, _u
 		installation: context.payload?.installation
 	};
 
+	const jiraHost = jiraClient.baseURL;
+	const gitHubAppId = context.gitHubAppConfig?.gitHubAppId;
+	const gitHubProduct = getCloudOrServerFromGitHubAppId(context.gitHubAppConfig?.gitHubAppId);
+	sendAnalytics(AnalyticsEventTypes.TrackEvent, {
+		name: AnalyticsTrackEventsEnum.CommitsPushedTrackEventName,
+		source: !gitHubAppId ? AnalyticsTrackSource.Cloud : AnalyticsTrackSource.GitHubEnterprise,
+		gitHubProduct,
+		jiraHost,
+		totalCommitCount: context.payload?.commits?.length || 0,
+		commitWithJiraIssueKeyCount: payload.commits?.length || 0,
+	});
+
 	context.log = context.log.child({
-		jiraHost: jiraClient.baseURL,
+		jiraHost,
 		gitHubInstallationId
 	});
 

--- a/src/github/push.ts
+++ b/src/github/push.ts
@@ -39,7 +39,7 @@ export const pushWebhookHandler = async (context: WebhookContext, jiraClient, _u
 		gitHubProduct,
 		jiraHost,
 		totalCommitCount: context.payload?.commits?.length || 0,
-		commitWithJiraIssueKeyCount: payload.commits?.length || 0,
+		commitWithJiraIssueKeyCount: payload.commits?.length || 0
 	});
 
 	context.log = context.log.child({

--- a/src/interfaces/common.ts
+++ b/src/interfaces/common.ts
@@ -45,7 +45,8 @@ export enum AnalyticsTrackEventsEnum {
 	ConnectToOrgTrackEventName = "connectOrg",
 	DisconnectToOrgTrackEventName = "disconnectOrg",
 	ManualRestartBackfillTrackEventName = "manualRestartBackfill",
-	RemoveGitHubServerTrackEventName = "removeGitHubServer"
+	RemoveGitHubServerTrackEventName = "removeGitHubServer",
+	CommitsPushedTrackEventName = "commitsPushed"
 }
 
 export enum AnalyticsTrackSource {


### PR DESCRIPTION
**What's in this PR?**
Sends an analytic event to track the total commits pushed and number of commits containing the jira issue key in the commit message.

I'm not sure if such an event is useful for the backfilled commits.

**Why**
Context: We are planning to associate commits to services in Jira Service Management(JSM) most probably via deployment association to services. This will help JSM users to find the root cause fast during incident investigation.

Reason: We need stats on percentage of commits not stored in Open Toolchain due to lack of jira issue keys in the commit message. This stat will help us decide if we should plan additional work to store commits without issue keys in the future. 

**Added feature flags**
None.

**Affected issues**  
None. This was discussed in Atlassian slack: https://atlassian.slack.com/archives/CFG3W7TKJ/p1673239842789059

**How has this been tested?** 
I've tested the following cases on local using debugger:
1. Push a commit with jira issue key.
2. Push a commit without jira issue key.
3. Push multiple commits where only one of them contains issue key.

I couldn't test it end-to-end on local because analytic events are not sent to any source in a non-prod environment. Appreciate any help in testing this end-to-end before merging to prod.

**Whats Next?**
* I need to register this event in Atlassian event registry.
* I may request a similar change for BitBucket integration as well.
* Analyse the data for 2+ weeks to make the decision mentioned above.