### PR TITLE
changing changedFiles to changedFilesIfAvailable

### DIFF
--- a/src/github/client/github-client-interceptors.ts
+++ b/src/github/client/github-client-interceptors.ts
@@ -1,4 +1,4 @@
-import { InvalidPermissionsError, BlockedIpError, GithubClientError, GithubClientTimeoutError, RateLimitingError } from "./github-client-errors";
+import { BlockedIpError, GithubClientError, GithubClientTimeoutError, InvalidPermissionsError, RateLimitingError } from "./github-client-errors";
 import Logger from "bunyan";
 import { statsd } from "config/statsd";
 import { metricError } from "config/metric-names";
@@ -132,8 +132,8 @@ export const handleFailedRequest = (logger: Logger) =>
 			}
 			const isWarning = status && (status >= 300 && status < 500 && status !== 400);
 
-			if (isWarning){
-				logger.warn(errorMessage);
+			if (isWarning) {
+				logger.debug(errorMessage);
 			} else {
 				logger.error(errorMessage);
 			}

--- a/src/github/client/github-installation-client.ts
+++ b/src/github/client/github-installation-client.ts
@@ -319,7 +319,7 @@ export class GitHubInstallationClient extends GitHubClient {
 			return response.data.content;
 		} catch (err) {
 			if (err.status == 404) {
-				this.logger.warn({ err, owner, repo, path }, "could not find file in repo");
+				this.logger.debug({ err, owner, repo, path }, "could not find file in repo");
 				return undefined;
 			}
 			throw err;

--- a/src/github/client/github-queries.ts
+++ b/src/github/client/github-queries.ts
@@ -151,7 +151,7 @@ export const getCommitsQueryWithChangedFiles = `query ($owner: String!, $repo: S
                 message
                 oid
                 url
-                changedFiles
+                changedFilesIfAvailable: changedFiles
               }
             }
           }
@@ -255,7 +255,7 @@ export const getBranchesQueryWithChangedFiles = `query ($owner: String!, $repo: 
                   name
                 }
                 authoredDate
-                changedFiles
+                changedFilesIfAvailable: changedFiles
                 history(since: $commitSince, first: 50) {
                   nodes {
                     message

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -324,7 +324,8 @@ const doProcessInstallation = async (data: BackfillMessagePayload, sentry: Hub, 
 /**
  * Handles an error and takes action based on the error type and parameters
  */
-export const handleBackfillError = async (err,
+export const handleBackfillError = async (
+	err,
 	data: BackfillMessagePayload,
 	nextTask: Task,
 	subscription: Subscription,
@@ -375,7 +376,7 @@ export const handleBackfillError = async (err,
 		return;
 	}
 
-	logger.error({ err }, "Task failed, continuing with next task");
+	logger.warn({ errorMessage: err.message, task: nextTask }, "Task failed, continuing with next task");
 	await markCurrentRepositoryAsFailedAndContinue(subscription, nextTask, scheduleNextTask);
 };
 

--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -41,7 +41,7 @@ const getLastSuccessfulDeployCommitSha = async (
 			}
 		}
 	} catch (e) {
-		logger?.error(`Failed to get deployment statuses.`);
+		logger?.debug(`Failed to get deployment statuses.`);
 	}
 
 	// If there's no successful deployment on the list of deployments that GitHub returned us (max. 100) then we'll return the last one from the array, even if it's a failed one.

--- a/src/transforms/util/github-api-requests.ts
+++ b/src/transforms/util/github-api-requests.ts
@@ -37,7 +37,7 @@ export const getAllCommitsBetweenReferences = async (
 		commitSummaries = commitsDiff.data?.commits
 			?.map((c) => { return { sha: c.sha, message: c.commit.message }; });
 	} catch (err) {
-		logger?.error(
+		logger?.debug(
 			{ err, repo: payload.repo },
 			"Failed to compare commits on repo."
 		);

--- a/src/util/get-github-client-config.ts
+++ b/src/util/get-github-client-config.ts
@@ -56,11 +56,10 @@ const calculateProxyBaseUrl = async (jiraHost: string, gitHubBaseUrl: string | u
 			skipOutboundProxy = false;
 		}
 		if (skipOutboundProxy) {
-			logger.warn("Skip outbound proxy");
+			logger.debug({ gitHubBaseUrl, jiraHost }, "Skipping outbound proxy");
 			return undefined;
 		}
 	}
-	logger.info("Use outbound proxy");
 	return envVars.PROXY;
 };
 


### PR DESCRIPTION
**What's in this PR?**
changing `changedFiles` GraphQL property to `changedFilesIfAvailable` .

**Why**
`changedFiles` is deprecated as of January 1st and changing it to `changedFilesIfAvailable` should fix some 422s and 500s we've been seeing while backfilling large customers.

**Added feature flags**
None

**Affected issues**  
a few

**How has this been tested?**  
Updated tests that were already there

**Whats Next?**
Deploy and test backfilling on large customers currently blocked.
