### PR TITLE
Additional logging on push transform

### DIFF
--- a/src/transforms/push.ts
+++ b/src/transforms/push.ts
@@ -108,7 +108,7 @@ export const processPush = async (github: GitHubInstallationClient, payload: Pus
 		jiraHost
 	});
 
-	log.info("Processing push");
+	log.info({ shas, shasCount: shas?.length }, "Processing push");
 
 	const gitHubAppId = payload.gitHubAppConfig?.gitHubAppId;
 


### PR DESCRIPTION
Splunk suggest excessive GitHub calls, I believe is on the mapping of the SHAs for push, GitHub docs say that there should only be 20 on the webhook payload, it looks like more so want to confirm it before I make the changes to limit it.
