### PR TITLE
ARC-1945: Get reviewers email before sending PR review to Jira.

### DIFF
--- a/src/github/pull-request.test.ts
+++ b/src/github/pull-request.test.ts
@@ -89,6 +89,7 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 		githubUserTokenNock(gitHubInstallationId);
 		githubUserTokenNock(gitHubInstallationId);
 		githubUserTokenNock(gitHubInstallationId);
+		githubUserTokenNock(gitHubInstallationId);
 		githubNock.get("/users/test-pull-request-user-login")
 			.reply(200, {
 				login: "test-pull-request-author-login",
@@ -98,6 +99,14 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 
 		githubNock.get("/repos/test-repo-owner/test-repo-name/pulls/1/reviews")
 			.reply(200, reviewsPayload);
+
+		githubNock.get("/users/test-pull-request-reviewer-login")
+			.reply(200, {
+				login: "test-pull-request-reviewer-login",
+				avatar_url: "test-pull-request-reviewer-avatar",
+				html_url: "test-pull-request-reviewer-url",
+				email: "test-pull-request-reviewer-login@gmail.com"
+			});
 
 		githubNock.patch("/repos/test-repo-owner/test-repo-name/issues/1", {
 			body: `[TEST-124] body of the test pull request.\n\n[TEST-124]: ${jiraHost}/browse/TEST-124`
@@ -166,7 +175,8 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 								{
 									avatar: "test-pull-request-reviewer-avatar",
 									name: "test-pull-request-reviewer-login",
-									email: "test-pull-request-reviewer-login@noreply.user.github.com",
+									email: "test-pull-request-reviewer-login@gmail.com",
+									login: "test-pull-request-reviewer-login",
 									url: "https://github.com/reviewer",
 									approvalStatus: "APPROVED"
 								}
@@ -195,6 +205,7 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 		githubUserTokenNock(gitHubInstallationId);
 		githubUserTokenNock(gitHubInstallationId);
 		githubUserTokenNock(gitHubInstallationId);
+		githubUserTokenNock(gitHubInstallationId);
 		githubNock.get("/users/test-pull-request-user-login")
 			.reply(200, {
 				login: "test-pull-request-author-login",
@@ -204,6 +215,14 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 
 		githubNock.get("/repos/test-repo-owner/test-repo-name/pulls/1/reviews")
 			.reply(200, reviewsPayload);
+
+		githubNock.get("/users/test-pull-request-reviewer-login")
+			.reply(200, {
+				login: "test-pull-request-reviewer-login",
+				avatar_url: "test-pull-request-reviewer-avatar",
+				html_url: "test-pull-request-reviewer-url",
+				email: "test-pull-request-reviewer-login@gmail.com"
+			});
 
 		githubNock.patch("/repos/test-repo-owner/test-repo-name/issues/1", {
 			body: `[TEST-124] body of the test pull request.\n\n[TEST-124]: ${jiraHost}/browse/TEST-124`
@@ -310,6 +329,7 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 			githubUserTokenNock(gitHubInstallationId);
 			githubUserTokenNock(gitHubInstallationId);
 			githubUserTokenNock(gitHubInstallationId);
+			githubUserTokenNock(gitHubInstallationId);
 
 			githubNock.get("/users/test-pull-request-user-login")
 				.reply(200, {
@@ -320,6 +340,14 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 
 			githubNock.get("/repos/test-repo-owner/test-repo-name/pulls/1/reviews")
 				.reply(200, reviewsPayload);
+
+			githubNock.get("/users/test-pull-request-reviewer-login")
+				.reply(200, {
+					login: "test-pull-request-reviewer-login",
+					avatar_url: "test-pull-request-reviewer-avatar",
+					html_url: "test-pull-request-reviewer-url",
+					email: "test-pull-request-reviewer-login@gmail.com"
+				});
 
 			githubNock
 				.patch("/repos/test-repo-owner/test-repo-name/issues/1", {
@@ -397,8 +425,9 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 												{
 													avatar: "test-pull-request-reviewer-avatar",
 													name: "test-pull-request-reviewer-login",
-													email: "test-pull-request-reviewer-login@noreply.user.github.com",
+													email: "test-pull-request-reviewer-login@gmail.com",
 													url: "https://github.com/reviewer",
+													login: "test-pull-request-reviewer-login",
 													approvalStatus: "APPROVED"
 												}
 											],
@@ -430,6 +459,7 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 			githubUserTokenNock(gitHubInstallationId);
 			githubUserTokenNock(gitHubInstallationId);
 			githubUserTokenNock(gitHubInstallationId);
+			githubUserTokenNock(gitHubInstallationId);
 
 			githubNock.get("/users/test-pull-request-user-login")
 				.reply(200, {
@@ -440,6 +470,14 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 
 			githubNock.get("/repos/test-repo-owner/test-repo-name/pulls/1/reviews")
 				.reply(200, reviewsPayload);
+
+			githubNock.get("/users/test-pull-request-reviewer-login")
+				.reply(200, {
+					login: "test-pull-request-reviewer-login",
+					avatar_url: "test-pull-request-reviewer-avatar",
+					html_url: "test-pull-request-reviewer-url",
+					email: "test-pull-request-reviewer-login@gmail.com"
+				});
 
 			githubNock.patch("/repos/test-repo-owner/test-repo-name/issues/1", {
 				body: `[TEST-124] body of the test pull request.\n\n[TEST-124]: ${jiraHost}/browse/TEST-124`
@@ -481,7 +519,8 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 									{
 										avatar: "test-pull-request-reviewer-avatar",
 										name: "test-pull-request-reviewer-login",
-										email: "test-pull-request-reviewer-login@noreply.user.github.com",
+										email: "test-pull-request-reviewer-login@gmail.com",
+										login: "test-pull-request-reviewer-login",
 										url: "https://github.com/reviewer",
 										approvalStatus: "APPROVED"
 									}
@@ -512,6 +551,7 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 			githubUserTokenNock(gitHubInstallationId);
 			githubUserTokenNock(gitHubInstallationId);
 			githubUserTokenNock(gitHubInstallationId);
+			githubUserTokenNock(gitHubInstallationId);
 
 			githubNock.get("/users/test-pull-request-user-login")
 				.twice()
@@ -527,6 +567,14 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 
 			githubNock.get("/repos/test-repo-owner/test-repo-name/pulls/1/reviews")
 				.reply(200, reviewsPayload);
+
+			githubNock.get("/users/test-pull-request-reviewer-login")
+				.reply(200, {
+					login: "test-pull-request-reviewer-login",
+					avatar_url: "test-pull-request-reviewer-avatar",
+					html_url: "test-pull-request-reviewer-url",
+					email: "test-pull-request-reviewer-login@gmail.com"
+				});
 
 			jiraNock.get("/rest/api/latest/issue/TEST-124?fields=summary")
 				.reply(200, {
@@ -597,8 +645,9 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 												{
 													avatar: "test-pull-request-reviewer-avatar",
 													name: "test-pull-request-reviewer-login",
-													email: "test-pull-request-reviewer-login@noreply.user.github.com",
+													email: "test-pull-request-reviewer-login@gmail.com",
 													url: "https://github.com/reviewer",
+													login: "test-pull-request-reviewer-login",
 													approvalStatus: "APPROVED"
 												}
 											],

--- a/src/github/pull-request.test.ts
+++ b/src/github/pull-request.test.ts
@@ -105,7 +105,7 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 				login: "test-pull-request-reviewer-login",
 				avatar_url: "test-pull-request-reviewer-avatar",
 				html_url: "test-pull-request-reviewer-url",
-				email: "test-pull-request-reviewer-login@gmail.com"
+				email: "test-pull-request-reviewer-login@email.test"
 			});
 
 		githubNock.patch("/repos/test-repo-owner/test-repo-name/issues/1", {
@@ -175,7 +175,7 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 								{
 									avatar: "test-pull-request-reviewer-avatar",
 									name: "test-pull-request-reviewer-login",
-									email: "test-pull-request-reviewer-login@gmail.com",
+									email: "test-pull-request-reviewer-login@email.test",
 									login: "test-pull-request-reviewer-login",
 									url: "https://github.com/reviewer",
 									approvalStatus: "APPROVED"
@@ -221,7 +221,7 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 				login: "test-pull-request-reviewer-login",
 				avatar_url: "test-pull-request-reviewer-avatar",
 				html_url: "test-pull-request-reviewer-url",
-				email: "test-pull-request-reviewer-login@gmail.com"
+				email: "test-pull-request-reviewer-login@email.test"
 			});
 
 		githubNock.patch("/repos/test-repo-owner/test-repo-name/issues/1", {
@@ -346,7 +346,7 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 					login: "test-pull-request-reviewer-login",
 					avatar_url: "test-pull-request-reviewer-avatar",
 					html_url: "test-pull-request-reviewer-url",
-					email: "test-pull-request-reviewer-login@gmail.com"
+					email: "test-pull-request-reviewer-login@email.test"
 				});
 
 			githubNock
@@ -425,7 +425,7 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 												{
 													avatar: "test-pull-request-reviewer-avatar",
 													name: "test-pull-request-reviewer-login",
-													email: "test-pull-request-reviewer-login@gmail.com",
+													email: "test-pull-request-reviewer-login@email.test",
 													url: "https://github.com/reviewer",
 													login: "test-pull-request-reviewer-login",
 													approvalStatus: "APPROVED"
@@ -476,7 +476,7 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 					login: "test-pull-request-reviewer-login",
 					avatar_url: "test-pull-request-reviewer-avatar",
 					html_url: "test-pull-request-reviewer-url",
-					email: "test-pull-request-reviewer-login@gmail.com"
+					email: "test-pull-request-reviewer-login@email.test"
 				});
 
 			githubNock.patch("/repos/test-repo-owner/test-repo-name/issues/1", {
@@ -519,7 +519,7 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 									{
 										avatar: "test-pull-request-reviewer-avatar",
 										name: "test-pull-request-reviewer-login",
-										email: "test-pull-request-reviewer-login@gmail.com",
+										email: "test-pull-request-reviewer-login@email.test",
 										login: "test-pull-request-reviewer-login",
 										url: "https://github.com/reviewer",
 										approvalStatus: "APPROVED"
@@ -573,7 +573,7 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 					login: "test-pull-request-reviewer-login",
 					avatar_url: "test-pull-request-reviewer-avatar",
 					html_url: "test-pull-request-reviewer-url",
-					email: "test-pull-request-reviewer-login@gmail.com"
+					email: "test-pull-request-reviewer-login@email.test"
 				});
 
 			jiraNock.get("/rest/api/latest/issue/TEST-124?fields=summary")
@@ -645,7 +645,7 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 												{
 													avatar: "test-pull-request-reviewer-avatar",
 													name: "test-pull-request-reviewer-login",
-													email: "test-pull-request-reviewer-login@gmail.com",
+													email: "test-pull-request-reviewer-login@email.test",
 													url: "https://github.com/reviewer",
 													login: "test-pull-request-reviewer-login",
 													approvalStatus: "APPROVED"

--- a/src/github/pull-request.test.ts
+++ b/src/github/pull-request.test.ts
@@ -176,7 +176,6 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 									avatar: "test-pull-request-reviewer-avatar",
 									name: "test-pull-request-reviewer-login",
 									email: "test-pull-request-reviewer-login@email.test",
-									login: "test-pull-request-reviewer-login",
 									url: "https://github.com/reviewer",
 									approvalStatus: "APPROVED"
 								}
@@ -427,7 +426,6 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 													name: "test-pull-request-reviewer-login",
 													email: "test-pull-request-reviewer-login@email.test",
 													url: "https://github.com/reviewer",
-													login: "test-pull-request-reviewer-login",
 													approvalStatus: "APPROVED"
 												}
 											],
@@ -520,7 +518,6 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 										avatar: "test-pull-request-reviewer-avatar",
 										name: "test-pull-request-reviewer-login",
 										email: "test-pull-request-reviewer-login@email.test",
-										login: "test-pull-request-reviewer-login",
 										url: "https://github.com/reviewer",
 										approvalStatus: "APPROVED"
 									}
@@ -647,7 +644,6 @@ describe.each([true, false])("Pull Request Webhook", (useSharedPrFlag) => {
 													name: "test-pull-request-reviewer-login",
 													email: "test-pull-request-reviewer-login@email.test",
 													url: "https://github.com/reviewer",
-													login: "test-pull-request-reviewer-login",
 													approvalStatus: "APPROVED"
 												}
 											],

--- a/src/interfaces/jira.ts
+++ b/src/interfaces/jira.ts
@@ -121,10 +121,6 @@ export interface JiraAuthor {
 	url?: string;
 }
 
-export interface JiraReviewer extends JiraReview {
-	login: string;
-}
-
 export interface JiraReview extends JiraAuthor {
 	approvalStatus: string;
 }

--- a/src/interfaces/jira.ts
+++ b/src/interfaces/jira.ts
@@ -121,8 +121,11 @@ export interface JiraAuthor {
 	url?: string;
 }
 
-export interface JiraReview extends JiraAuthor {
+export interface JiraReviewer extends JiraReview {
 	login: string;
+}
+
+export interface JiraReview extends JiraAuthor {
 	approvalStatus: string;
 }
 

--- a/src/interfaces/jira.ts
+++ b/src/interfaces/jira.ts
@@ -115,18 +115,14 @@ export enum JiraCommitFileChangeTypeEnum {
 }
 
 export interface JiraAuthor {
-	avatar?: string;
 	email: string;
-	name: string;
+	name?: string;
+	avatar?: string;
 	url?: string;
 }
 
-export interface JiraReviewer {
+export interface JiraReview extends JiraAuthor {
 	login: string;
-	email?: string;
-}
-
-export interface JiraReview extends JiraReviewer {
 	approvalStatus: string;
 }
 

--- a/src/interfaces/jira.ts
+++ b/src/interfaces/jira.ts
@@ -120,7 +120,13 @@ export interface JiraAuthor {
 	name: string;
 	url?: string;
 }
-export interface JiraReview extends JiraAuthor {
+
+export interface JiraReviewer {
+	login: string;
+	email?: string;
+}
+
+export interface JiraReview extends JiraReviewer {
 	approvalStatus: string;
 }
 

--- a/src/sync/pull-requests.test.ts
+++ b/src/sync/pull-requests.test.ts
@@ -94,7 +94,6 @@ describe("sync/pull-request", () => {
 										{
 											"avatar": "test-pull-request-reviewer-avatar",
 											"name": "test-pull-request-reviewer-login",
-											"login": "test-pull-request-reviewer-login",
 											"email": "test-pull-request-reviewer-login@email.test",
 											"url": "https://github.com/reviewer",
 											"approvalStatus": "APPROVED"

--- a/src/sync/pull-requests.test.ts
+++ b/src/sync/pull-requests.test.ts
@@ -94,7 +94,8 @@ describe("sync/pull-request", () => {
 										{
 											"avatar": "test-pull-request-reviewer-avatar",
 											"name": "test-pull-request-reviewer-login",
-											"email": "test-pull-request-reviewer-login@noreply.user.github.com",
+											"login": "test-pull-request-reviewer-login",
+											"email": "test-pull-request-reviewer-login@gmail.com",
 											"url": "https://github.com/reviewer",
 											"approvalStatus": "APPROVED"
 										}
@@ -245,6 +246,7 @@ describe("sync/pull-request", () => {
 				githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 				githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 				githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
+				githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 				githubNock
 					.get("/repos/integrations/test-repo-name/pulls")
 					.query(true)
@@ -253,6 +255,13 @@ describe("sync/pull-request", () => {
 					.reply(200, pullRequest)
 					.get("/repos/integrations/test-repo-name/pulls/51/reviews")
 					.reply(200, reviewsPayload)
+					.get("/users/test-pull-request-reviewer-login")
+					.reply(200, {
+						login: "test-pull-request-reviewer-login",
+						avatar_url: "test-pull-request-reviewer-avatar",
+						html_url: "test-pull-request-reviewer-url",
+						email: "test-pull-request-reviewer-login@gmail.com"
+					})
 					.get("/users/test-pull-request-author-login")
 					.reply(200, {
 						login: "test-pull-request-author-login",

--- a/src/sync/pull-requests.test.ts
+++ b/src/sync/pull-requests.test.ts
@@ -95,7 +95,7 @@ describe("sync/pull-request", () => {
 											"avatar": "test-pull-request-reviewer-avatar",
 											"name": "test-pull-request-reviewer-login",
 											"login": "test-pull-request-reviewer-login",
-											"email": "test-pull-request-reviewer-login@gmail.com",
+											"email": "test-pull-request-reviewer-login@email.test",
 											"url": "https://github.com/reviewer",
 											"approvalStatus": "APPROVED"
 										}
@@ -260,7 +260,7 @@ describe("sync/pull-request", () => {
 						login: "test-pull-request-reviewer-login",
 						avatar_url: "test-pull-request-reviewer-avatar",
 						html_url: "test-pull-request-reviewer-url",
-						email: "test-pull-request-reviewer-login@gmail.com"
+						email: "test-pull-request-reviewer-login@email.test"
 					})
 					.get("/users/test-pull-request-author-login")
 					.reply(200, {
@@ -365,7 +365,7 @@ describe("sync/pull-request", () => {
 					login: "test-pull-request-reviewer-login",
 					avatar_url: "test-pull-request-reviewer-avatar",
 					html_url: "test-pull-request-reviewer-url",
-					email: "test-pull-request-reviewer-login@gmail.com"
+					email: "test-pull-request-reviewer-login@email.test"
 				})
 				.get("/users/test-pull-request-author-login")
 				.reply(200, {

--- a/src/sync/pull-requests.test.ts
+++ b/src/sync/pull-requests.test.ts
@@ -351,6 +351,7 @@ describe("sync/pull-request", () => {
 			gheUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 			gheUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 			gheUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
+			gheUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 			gheApiNock
 				.get("/repos/integrations/test-repo-name/pulls")
 				.query(true)
@@ -359,6 +360,13 @@ describe("sync/pull-request", () => {
 				.reply(200, pullRequest)
 				.get("/repos/integrations/test-repo-name/pulls/51/reviews")
 				.reply(200, reviewsPayload)
+				.get("/users/test-pull-request-reviewer-login")
+				.reply(200, {
+					login: "test-pull-request-reviewer-login",
+					avatar_url: "test-pull-request-reviewer-avatar",
+					html_url: "test-pull-request-reviewer-url",
+					email: "test-pull-request-reviewer-login@gmail.com"
+				})
 				.get("/users/test-pull-request-author-login")
 				.reply(200, {
 					login: "test-pull-request-author-login",

--- a/src/transforms/transform-pull-request.ts
+++ b/src/transforms/transform-pull-request.ts
@@ -1,4 +1,4 @@
-import { isEmpty, orderBy } from "lodash";
+import { isEmpty, omit, orderBy } from "lodash";
 import { getJiraId } from "../jira/util/id";
 import { Octokit  } from "@octokit/rest";
 import Logger from "bunyan";
@@ -19,7 +19,7 @@ const mapStatus = (status: string, merged_at?: string) => {
 };
 
 interface JiraReviewer extends JiraReview {
-	login?: string;
+	login: string;
 }
 
 // TODO: define arguments and return
@@ -56,15 +56,10 @@ const mapReviews = async (reviews: Octokit.PullsListReviewsResponse = [], gitHub
 
 	// Get GitHub user email, so it can be matched to an AAID
 	return Promise.all(reviewsReduced.map(async reviewer => {
-		let login;
-		if (reviewer.login) {
-			login = reviewer.login;
-			delete reviewer.login;
-		}
-		const gitHubUser = await getGithubUser(gitHubInstallationClient, login);
+		const gitHubUser = await getGithubUser(gitHubInstallationClient, reviewer.login);
 		return {
-			...reviewer,
-			email: gitHubUser?.email || `${login}@noreply.user.github.com`
+			...omit(reviewer, "login"),
+			email: gitHubUser?.email || `${reviewer.login}@noreply.user.github.com`
 		};
 	}));
 };

--- a/src/transforms/transform-pull-request.ts
+++ b/src/transforms/transform-pull-request.ts
@@ -7,7 +7,7 @@ import { getGithubUser } from "services/github/user";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
 import { generateCreatePullRequestUrl } from "./util/pull-request-link-generator";
 import { GitHubInstallationClient } from "../github/client/github-installation-client";
-import { JiraReview } from "../interfaces/jira";
+import { JiraReviewer } from "../interfaces/jira";
 import { transformRepositoryDevInfoBulk } from "~/src/transforms/transform-repository";
 
 const mapStatus = (status: string, merged_at?: string) => {
@@ -19,13 +19,13 @@ const mapStatus = (status: string, merged_at?: string) => {
 };
 
 // TODO: define arguments and return
-const mapReviews = async (reviews: Octokit.PullsListReviewsResponse = [], gitHubInstallationClient: GitHubInstallationClient): Promise<JiraReview[]> => {
+const mapReviews = async (reviews: Octokit.PullsListReviewsResponse = [], gitHubInstallationClient: GitHubInstallationClient): Promise<JiraReviewer[]> => {
 	const sortedReviews = orderBy(reviews, "submitted_at", "desc");
-	const usernames: Record<string, JiraReview> = {};
+	const usernames: Record<string, JiraReviewer> = {};
 	// The reduce function goes through all the reviews and creates an array of unique users
 	// (so users' avatars won't be duplicated on the dev panel in Jira)
 	// and it considers 'APPROVED' as the main approval status for that user.
-	const reviewsReduced: JiraReview[] = sortedReviews.reduce((acc: JiraReview[], review) => {
+	const reviewsReduced: JiraReviewer[] = sortedReviews.reduce((acc: JiraReviewer[], review) => {
 		// Adds user to the usernames object if user is not yet added, then it adds that unique user to the accumulator.
 		const author = review?.user;
 
@@ -54,7 +54,7 @@ const mapReviews = async (reviews: Octokit.PullsListReviewsResponse = [], gitHub
 		const gitHubUser = await getGithubUser(gitHubInstallationClient, reviewer.login);
 		return {
 			...reviewer,
-			email: gitHubUser && gitHubUser.email ?  gitHubUser.email : `${reviewer.login}@noreply.user.github.com`
+			email: gitHubUser?.email || `${reviewer.login}@noreply.user.github.com`
 		};
 	}));
 };

--- a/src/transforms/transform-pull-request.ts
+++ b/src/transforms/transform-pull-request.ts
@@ -7,7 +7,7 @@ import { getGithubUser } from "services/github/user";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
 import { generateCreatePullRequestUrl } from "./util/pull-request-link-generator";
 import { GitHubInstallationClient } from "../github/client/github-installation-client";
-import { JiraReviewer } from "../interfaces/jira";
+import { JiraReview } from "../interfaces/jira";
 import { transformRepositoryDevInfoBulk } from "~/src/transforms/transform-repository";
 
 const mapStatus = (status: string, merged_at?: string) => {
@@ -17,6 +17,10 @@ const mapStatus = (status: string, merged_at?: string) => {
 	if (status === "closed" && !merged_at) return "DECLINED";
 	return "UNKNOWN";
 };
+
+interface JiraReviewer extends JiraReview {
+	login: string;
+}
 
 // TODO: define arguments and return
 const mapReviews = async (reviews: Octokit.PullsListReviewsResponse = [], gitHubInstallationClient: GitHubInstallationClient): Promise<JiraReviewer[]> => {

--- a/test/jira/multiple-jira.test.ts
+++ b/test/jira/multiple-jira.test.ts
@@ -112,7 +112,6 @@ const jiraMatchingIssuesKeysBulkResponse = {
 						{
 							avatar: "test-pull-request-reviewer-avatar",
 							name: "test-pull-request-reviewer-login",
-							login: "test-pull-request-reviewer-login",
 							email: "test-pull-request-reviewer-login@email.test",
 							url: "https://github.com/reviewer",
 							approvalStatus: "APPROVED"
@@ -187,7 +186,6 @@ const jiraMultipleJiraBulkResponse = {
 						{
 							avatar: "test-pull-request-reviewer-avatar",
 							name: "test-pull-request-reviewer-login",
-							login: "test-pull-request-reviewer-login",
 							email: "test-pull-request-reviewer-login@email.test",
 							url: "https://github.com/reviewer",
 							approvalStatus: "APPROVED"

--- a/test/jira/multiple-jira.test.ts
+++ b/test/jira/multiple-jira.test.ts
@@ -113,7 +113,7 @@ const jiraMatchingIssuesKeysBulkResponse = {
 							avatar: "test-pull-request-reviewer-avatar",
 							name: "test-pull-request-reviewer-login",
 							login: "test-pull-request-reviewer-login",
-							email: "test-pull-request-reviewer-login@gmail.com",
+							email: "test-pull-request-reviewer-login@email.test",
 							url: "https://github.com/reviewer",
 							approvalStatus: "APPROVED"
 						}
@@ -188,7 +188,7 @@ const jiraMultipleJiraBulkResponse = {
 							avatar: "test-pull-request-reviewer-avatar",
 							name: "test-pull-request-reviewer-login",
 							login: "test-pull-request-reviewer-login",
-							email: "test-pull-request-reviewer-login@gmail.com",
+							email: "test-pull-request-reviewer-login@email.test",
 							url: "https://github.com/reviewer",
 							approvalStatus: "APPROVED"
 						}
@@ -267,7 +267,7 @@ describe("multiple Jira instances", () => {
 				login: "test-pull-request-reviewer-login",
 				avatar_url: "test-pull-request-reviewer-avatar",
 				html_url: "test-pull-request-reviewer-url",
-				email: "test-pull-request-reviewer-login@gmail.com"
+				email: "test-pull-request-reviewer-login@email.test"
 			});
 
 		githubNock.patch("/repos/test-repo-owner/test-repo-name/issues/1", {
@@ -327,7 +327,7 @@ describe("multiple Jira instances", () => {
 				login: "test-pull-request-reviewer-login",
 				avatar_url: "test-pull-request-reviewer-avatar",
 				html_url: "test-pull-request-reviewer-url",
-				email: "test-pull-request-reviewer-login@gmail.com"
+				email: "test-pull-request-reviewer-login@email.test"
 			});
 
 		githubNock.patch("/repos/test-repo-owner/test-repo-name/issues/1", {

--- a/test/jira/multiple-jira.test.ts
+++ b/test/jira/multiple-jira.test.ts
@@ -112,7 +112,8 @@ const jiraMatchingIssuesKeysBulkResponse = {
 						{
 							avatar: "test-pull-request-reviewer-avatar",
 							name: "test-pull-request-reviewer-login",
-							email: "test-pull-request-reviewer-login@noreply.user.github.com",
+							login: "test-pull-request-reviewer-login",
+							email: "test-pull-request-reviewer-login@gmail.com",
 							url: "https://github.com/reviewer",
 							approvalStatus: "APPROVED"
 						}
@@ -186,7 +187,8 @@ const jiraMultipleJiraBulkResponse = {
 						{
 							avatar: "test-pull-request-reviewer-avatar",
 							name: "test-pull-request-reviewer-login",
-							email: "test-pull-request-reviewer-login@noreply.user.github.com",
+							login: "test-pull-request-reviewer-login",
+							email: "test-pull-request-reviewer-login@gmail.com",
 							url: "https://github.com/reviewer",
 							approvalStatus: "APPROVED"
 						}
@@ -248,6 +250,8 @@ describe("multiple Jira instances", () => {
 		githubUserTokenNock(gitHubInstallationId);
 		githubUserTokenNock(gitHubInstallationId);
 		githubUserTokenNock(gitHubInstallationId);
+		githubUserTokenNock(gitHubInstallationId);
+		githubUserTokenNock(gitHubInstallationId);
 
 		githubNock.get("/users/test-pull-request-user-login")
 			.times(2)
@@ -256,6 +260,15 @@ describe("multiple Jira instances", () => {
 		githubNock.get("/repos/test-repo-owner/test-repo-name/pulls/1/reviews")
 			.times(2)
 			.reply(200, githubPullReviewsResponse);
+
+		githubNock.get("/users/test-pull-request-reviewer-login")
+			.times(2)
+			.reply(200, {
+				login: "test-pull-request-reviewer-login",
+				avatar_url: "test-pull-request-reviewer-avatar",
+				html_url: "test-pull-request-reviewer-url",
+				email: "test-pull-request-reviewer-login@gmail.com"
+			});
 
 		githubNock.patch("/repos/test-repo-owner/test-repo-name/issues/1", {
 			body: `[TEST-124] [TEST-223] body of the test pull request.\n\n[TEST-223]: ${jira2Host}/browse/TEST-223`
@@ -297,6 +310,8 @@ describe("multiple Jira instances", () => {
 		githubUserTokenNock(gitHubInstallationId);
 		githubUserTokenNock(gitHubInstallationId);
 		githubUserTokenNock(gitHubInstallationId);
+		githubUserTokenNock(gitHubInstallationId);
+		githubUserTokenNock(gitHubInstallationId);
 
 		githubNock.get("/users/test-pull-request-user-login")
 			.twice()
@@ -305,6 +320,15 @@ describe("multiple Jira instances", () => {
 		githubNock.get("/repos/test-repo-owner/test-repo-name/pulls/1/reviews")
 			.twice()
 			.reply(200, githubPullReviewsResponse);
+
+		githubNock.get("/users/test-pull-request-reviewer-login")
+			.times(2)
+			.reply(200, {
+				login: "test-pull-request-reviewer-login",
+				avatar_url: "test-pull-request-reviewer-avatar",
+				html_url: "test-pull-request-reviewer-url",
+				email: "test-pull-request-reviewer-login@gmail.com"
+			});
 
 		githubNock.patch("/repos/test-repo-owner/test-repo-name/issues/1", {
 			body: `[TEST-124] body of the test pull request.\n\n[TEST-124]: ${jiraHost}/browse/TEST-124`


### PR DESCRIPTION
**What's in this PR?**
Adding a `getGithubUser` call after we map the reviews because the reviewers' data we get on the webhook payload doesn’t contain the email for that user.

**Why**
So PR Reviewers can be matched to their Atlassian account IDs.


**Affected issues**  
[ARC-1945]

**How has this been tested?**  
Locally - I'll test in staging now.


[ARC-1945]: https://softwareteams.atlassian.net/browse/ARC-1945