### PR TITLE
NONE: improve logging for cryptor; retry when cryptor is not there

### DIFF
--- a/src/jira/client/jira-client.ts
+++ b/src/jira/client/jira-client.ts
@@ -47,7 +47,7 @@ export const getJiraClient = async (
 	}
 	const instance = getAxiosInstance(
 		installation.jiraHost,
-		await installation.decrypt("encryptedSharedSecret"),
+		await installation.decrypt("encryptedSharedSecret", logger),
 		logger
 	);
 

--- a/src/jira/verify-installation.ts
+++ b/src/jira/verify-installation.ts
@@ -7,7 +7,7 @@ export const verifyJiraInstallation = (installation: Installation, log: Logger) 
 	return async (): Promise<boolean> => {
 		const instance = getAxiosInstance(
 			installation.jiraHost,
-			await installation.decrypt("encryptedSharedSecret"),
+			await installation.decrypt("encryptedSharedSecret", log),
 			log
 		);
 		try {

--- a/src/middleware/jira-jwt-middleware.ts
+++ b/src/middleware/jira-jwt-middleware.ts
@@ -37,7 +37,7 @@ export const verifyJiraJwtMiddleware = (tokenType: TokenType) => async (
 	});
 
 	verifySymmetricJwtTokenMiddleware(
-		await installation.decrypt("encryptedSharedSecret"),
+		await installation.decrypt("encryptedSharedSecret", req.log),
 		tokenType,
 		req,
 		res,

--- a/src/middleware/jira-symmetric-jwt-middleware.ts
+++ b/src/middleware/jira-symmetric-jwt-middleware.ts
@@ -34,7 +34,7 @@ export const jiraSymmetricJwtMiddleware = async (req: Request, res: Response, ne
 			return res.status(401).send("Unauthorised");
 		}
 
-		const secret = await installation.decrypt("encryptedSharedSecret");
+		const secret = await installation.decrypt("encryptedSharedSecret", req.log);
 
 		const tokenType = checkPathValidity(req.originalUrl) && req.method == "GET" ? TokenType.normal : TokenType.context;
 		try {

--- a/src/models/encrypted-model.test.ts
+++ b/src/models/encrypted-model.test.ts
@@ -1,6 +1,7 @@
 import { DataTypes, Sequelize } from "sequelize";
 import { EncryptionClient, EncryptionSecretKeyEnum } from "utils/encryption-client";
 import { EncryptedModel } from "./encrypted-model";
+import { getLogger } from "config/logger";
 
 class Dummy extends EncryptedModel {
 	id: number;
@@ -43,12 +44,12 @@ Dummy.init({
 }, {
 	hooks: {
 		beforeSave: async (app, opts) => {
-			await app.encryptChangedSecretFields(opts.fields);
+			await app.encryptChangedSecretFields(opts.fields, getLogger("test"));
 		},
 
 		beforeBulkCreate: async (apps, opts) => {
 			for (const app of apps) {
-				await app.encryptChangedSecretFields(opts.fields);
+				await app.encryptChangedSecretFields(opts.fields, getLogger("test"));
 			}
 		}
 	},

--- a/src/models/encrypted-model.ts
+++ b/src/models/encrypted-model.ts
@@ -1,12 +1,10 @@
 import { Model } from "sequelize";
 import { EncryptionClient, EncryptionSecretKeyEnum } from "utils/encryption-client";
-import { getLogger } from "config/logger";
+import Logger from "bunyan";
 
 type StringValues<Obj> = {
 	[Prop in keyof Obj]: Obj[Prop] extends string ? Prop : never
 };
-
-const logger = getLogger("encryption-model");
 
 export abstract class EncryptedModel extends Model {
 
@@ -16,7 +14,7 @@ export abstract class EncryptedModel extends Model {
 
 	abstract getSecretFields(): readonly (keyof StringValues<this>)[];
 
-	async decrypt(field: (keyof StringValues<this>)): Promise<string> {
+	async decrypt(field: (keyof StringValues<this>), logger: Logger): Promise<string> {
 		const value = this[field];
 		if (typeof value !== "string") {
 			//error TS2731: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.
@@ -24,13 +22,13 @@ export abstract class EncryptedModel extends Model {
 		}
 		try {
 			return await EncryptionClient.decrypt(value, await this.getEncryptContext(field));
-		} catch (e) {
-			logger.error(`Fail to decrypt field ${String(field)}`, { error: e });
-			throw e;
+		} catch (err) {
+			logger.error({ err }, `Fail to decrypt field ${String(field)}`);
+			throw err;
 		}
 	}
 
-	protected async encrypt(field: (keyof StringValues<this>)): Promise<string> {
+	protected async encrypt(field: (keyof StringValues<this>), logger: Logger): Promise<string> {
 		const value = this[field];
 		if (typeof value !== "string") {
 			//error TS2731: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.
@@ -38,19 +36,19 @@ export abstract class EncryptedModel extends Model {
 		}
 		try {
 			return await EncryptionClient.encrypt(this.getEncryptionSecretKey(), value, await this.getEncryptContext(field));
-		} catch (e) {
-			logger.error(`Fail to encrypt field ${String(field)}`, { error: e });
-			throw e;
+		} catch (err) {
+			logger.error({ err }, `Fail to encrypt field ${String(field)}`);
+			throw err;
 		}
 	}
 
-	async encryptChangedSecretFields(fieldsChanged: string[] = []): Promise<void> {
+	async encryptChangedSecretFields(fieldsChanged: string[] = [], logger: Logger): Promise<void> {
 		const fieldsChangedTyped = fieldsChanged as (keyof StringValues<this>)[];
 		await Promise.all(
 			this.getSecretFields()
 				.filter(f => fieldsChangedTyped.includes(f))
 				.map(async (f) => {
-					this[f] = await this.encrypt(f) as any;
+					this[f] = await this.encrypt(f, logger) as any;
 				})
 		);
 	}

--- a/src/models/installation.ts
+++ b/src/models/installation.ts
@@ -3,6 +3,7 @@ import { Subscription } from "./subscription";
 import { getHashedKey, sequelize } from "models/sequelize";
 import { EncryptedModel } from "models/encrypted-model";
 import { EncryptionSecretKeyEnum } from "utils/encryption-client";
+import { getLogger } from "config/logger";
 
 export class Installation extends EncryptedModel {
 	id: number;
@@ -110,6 +111,9 @@ export class Installation extends EncryptedModel {
 	}
 }
 
+const LOGGER_HOOK_BEFORE_SAVE = getLogger("installation-hook-beforeSave");
+const LOGGER_HOOK_BEFORE_BULK_CREATE = getLogger("installation-hook-beforeBulkCreate");
+
 Installation.init({
 	id: {
 		type: DataTypes.INTEGER,
@@ -137,12 +141,12 @@ Installation.init({
 	hooks: {
 		beforeSave: async (instance: Installation, opts) => {
 			if (!opts.fields) return;
-			await instance.encryptChangedSecretFields(opts.fields);
+			await instance.encryptChangedSecretFields(opts.fields, LOGGER_HOOK_BEFORE_SAVE);
 		},
 		beforeBulkCreate: async (instances: Installation[], opts) => {
 			for (const instance of instances) {
 				if (!opts.fields) return;
-				await instance.encryptChangedSecretFields(opts.fields);
+				await instance.encryptChangedSecretFields(opts.fields, LOGGER_HOOK_BEFORE_BULK_CREATE);
 			}
 		}
 	},

--- a/src/models/jira-client.ts
+++ b/src/models/jira-client.ts
@@ -11,7 +11,7 @@ export class JiraClient {
 		const jiraClient = new JiraClient();
 		jiraClient.axios = getAxiosInstance(
 			installation.jiraHost,
-			await installation.decrypt("encryptedSharedSecret"),
+			await installation.decrypt("encryptedSharedSecret", log),
 			log
 		);
 		return jiraClient;

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-put.test.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-put.test.ts
@@ -32,7 +32,7 @@ describe("PUT /jira/connect/enterprise/app/:uuid", () => {
 		jwt = encodeSymmetric({
 			qsh: "context-qsh",
 			iss: "jira-client-key"
-		}, await installation.decrypt("encryptedSharedSecret"));
+		}, await installation.decrypt("encryptedSharedSecret", getLogger("test")));
 	});
 
 	it("should return 202 when correct uuid and installation id are passed", async () => {

--- a/src/routes/jira/sync/jira-sync-post.test.ts
+++ b/src/routes/jira/sync/jira-sync-post.test.ts
@@ -60,7 +60,7 @@ describe("sync", () => {
 		jwt = encodeSymmetric({
 			qsh: "context-qsh",
 			iss: "jira-client-key"
-		}, await installation.decrypt("encryptedSharedSecret"));
+		}, await installation.decrypt("encryptedSharedSecret", getLogger("test")));
 	});
 
 	it("should return 200 on correct post for /jira/sync for Cloud app", async () => {

--- a/src/sync/installation.test.ts
+++ b/src/sync/installation.test.ts
@@ -195,7 +195,7 @@ describe("sync/installation", () => {
 
 		});
 
-		it("Error with headers indicating rate limit will be retryed with the appropriate delay", async () => {
+		it("Error with headers indicating rate limit will be retried with the appropriate delay", async () => {
 			const probablyRateLimitError = {
 				...new Error(),
 				documentation_url: "https://docs.github.com/rest/reference/pulls#list-pull-requests",
@@ -291,6 +291,15 @@ describe("sync/installation", () => {
 
 			await handleBackfillError(connectionTimeoutErr, JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
 			expect(scheduleNextTask).toHaveBeenCalledWith(5_000);
+			expect(updateStatusSpy).toHaveBeenCalledTimes(0);
+			expect(failRepoSpy).toHaveBeenCalledTimes(0);
+		});
+
+		it("30s delay if cannot connect", async () => {
+			const connectionRefusedError = "connect ECONNREFUSED 10.255.0.9:26272";
+
+			await handleBackfillError(connectionRefusedError, JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
+			expect(scheduleNextTask).toHaveBeenCalledWith(30_000);
 			expect(updateStatusSpy).toHaveBeenCalledTimes(0);
 			expect(failRepoSpy).toHaveBeenCalledTimes(0);
 		});


### PR DESCRIPTION
**What's in this PR?**
1. use existing loggers for logging to stitch logs together
2. retry cryptor errors during backfill

**Why**
Long backfills might face some intermittent cryptor errors and we don't want this to break the backfilling

**Added feature flags**
🤠 

**Affected issues**  
CES-10000

**How has this been tested?**  
🤠 

**Whats Next?**
🤠 
