### PR TITLE
ARC-1867 - Create e2e tests for create branch flow 

### DIFF
--- a/test/e2e/constants.ts
+++ b/test/e2e/constants.ts
@@ -4,7 +4,7 @@ export const STATE_PATH = "./test/e2e/test-results/states";
 export const SCREENSHOT_PATH = "./test/e2e/test-results/screenshots";
 
 export const TEST_PROJECT_NAME = "E2E - Test - " + Date.now();
-export const TEST_PROJECT_KEY = "E" + Math.floor(Math.random()*9000) + 1000;
+export const TEST_PROJECT_KEY = "E" + Math.floor(Math.random()*900) + 100;
 
 export const testData: TestData = {
 	stateDirectoryPath: STATE_PATH,

--- a/test/e2e/create-branch.e2e.ts
+++ b/test/e2e/create-branch.e2e.ts
@@ -1,5 +1,5 @@
 import { expect, Page, test } from "@playwright/test";
-import { jiraAddProject, jiraAppInstall, jiraCreateIssue, jiraLogin } from "test/e2e/utils/jira";
+import { jiraAddProject, jiraAppInstall, jiraCreateIssue, jiraLogin, jiraRemoveProject } from "test/e2e/utils/jira";
 import { testData } from "test/e2e/constants";
 
 test.describe("Create branch", () => {
@@ -18,15 +18,20 @@ test.describe("Create branch", () => {
 	test.describe("cloud", () => {
 		test.beforeEach(async() => {
 			await jiraAppInstall(page);
-		});
-		test("When there are no GitHub connections", async () => {
 			await jiraAddProject(page);
 			await jiraCreateIssue(page);
+		});
+
+		test("When there are no GitHub connections", async () => {
 			await page.goto(data.urls.testProjectIssue);
 			await (page.locator("a[data-testid='development-summary-common.ui.summary-item.link-formatted-button']")).click();
 			const poppedUpPage = await page.waitForEvent("popup");
 			await poppedUpPage.waitForLoadState();
 			expect(poppedUpPage.getByText("Almost there!")).toBeTruthy();
+		});
+
+		test.afterEach(async() => {
+			await jiraRemoveProject(page);
 		});
 	});
 });

--- a/test/e2e/create-branch.e2e.ts
+++ b/test/e2e/create-branch.e2e.ts
@@ -1,5 +1,5 @@
 import { expect, Page, test } from "@playwright/test";
-import { jiraAddProject, jiraAppInstall, jiraCreateIssue, jiraLogin, jiraRemoveProject } from "test/e2e/utils/jira";
+import { jiraAddProject, jiraCreateIssue, jiraLogin, jiraRemoveProject } from "test/e2e/utils/jira";
 import { testData } from "test/e2e/constants";
 
 test.describe("Create branch", () => {
@@ -17,13 +17,11 @@ test.describe("Create branch", () => {
 
 	test.describe("cloud", () => {
 		test.beforeEach(async() => {
-			await jiraAppInstall(page);
+			await jiraAddProject(page);
+			await jiraCreateIssue(page);
 		});
 
 		test("When there are no GitHub connections", async () => {
-			await jiraAddProject(page);
-			await jiraCreateIssue(page);
-
 			await page.goto(data.urls.testProjectIssue);
 			await (page.locator("a[data-testid='development-summary-common.ui.summary-item.link-formatted-button']")).click();
 			const poppedUpPage = await page.waitForEvent("popup");

--- a/test/e2e/create-branch.e2e.ts
+++ b/test/e2e/create-branch.e2e.ts
@@ -19,10 +19,10 @@ test.describe("Create branch", () => {
 		test.beforeEach(async() => {
 			await jiraAppInstall(page);
 			await jiraAddProject(page);
-			await jiraCreateIssue(page);
 		});
 
 		test("When there are no GitHub connections", async () => {
+			await jiraCreateIssue(page);
 			await page.goto(data.urls.testProjectIssue);
 			await (page.locator("a[data-testid='development-summary-common.ui.summary-item.link-formatted-button']")).click();
 			const poppedUpPage = await page.waitForEvent("popup");

--- a/test/e2e/create-branch.e2e.ts
+++ b/test/e2e/create-branch.e2e.ts
@@ -18,11 +18,12 @@ test.describe("Create branch", () => {
 	test.describe("cloud", () => {
 		test.beforeEach(async() => {
 			await jiraAppInstall(page);
-			await jiraAddProject(page);
 		});
 
 		test("When there are no GitHub connections", async () => {
+			await jiraAddProject(page);
 			await jiraCreateIssue(page);
+
 			await page.goto(data.urls.testProjectIssue);
 			await (page.locator("a[data-testid='development-summary-common.ui.summary-item.link-formatted-button']")).click();
 			const poppedUpPage = await page.waitForEvent("popup");

--- a/test/e2e/setup.ts
+++ b/test/e2e/setup.ts
@@ -1,5 +1,5 @@
 import { chromium } from "@playwright/test";
-import { jiraLogin } from "test/e2e/utils/jira";
+import { jiraAppInstall, jiraLogin } from "test/e2e/utils/jira";
 // import { githubAppUpdateURLs, githubLogin } from "test/e2e/utils/github";
 import { clearState, stateExists } from "test/e2e/e2e-utils";
 import { testData } from "test/e2e/constants";
@@ -13,7 +13,9 @@ export default async function setup() {
 
 	// login and save state before tests
 	await Promise.all([
-		ngrokBypass(await browser.newPage()).then(async (page) => jiraLogin(page, "admin", true))
+		ngrokBypass(await browser.newPage())
+			.then(async (page) => jiraLogin(page, "admin", true))
+			.then(async (page) => jiraAppInstall(page))
 		// githubLogin(await browser.newPage(), "admin", true).then(githubAppUpdateURLs)
 	]);
 

--- a/test/e2e/utils/jira.ts
+++ b/test/e2e/utils/jira.ts
@@ -37,6 +37,7 @@ export const jiraLogin = async (page: Page, roleName: keyof JiraTestDataRoles, s
 
 export const jiraAppInstall = async (page: Page): Promise<Page> => {
 	await page.goto(data.urls.manageApps);
+	await page.waitForLoadState();
 
 	// If app is already installed, uninstall it first
 	if (await removeApp(page)) {

--- a/test/e2e/utils/jira.ts
+++ b/test/e2e/utils/jira.ts
@@ -37,7 +37,6 @@ export const jiraLogin = async (page: Page, roleName: keyof JiraTestDataRoles, s
 
 export const jiraAppInstall = async (page: Page): Promise<Page> => {
 	await page.goto(data.urls.manageApps);
-	await page.waitForLoadState();
 
 	// If app is already installed, uninstall it first
 	if (await removeApp(page)) {


### PR DESCRIPTION
**What's in this PR?**
- Util methods added for creating new project and new issue.
- Util method added for removing the new project.
- Added test case for checking the route to Create Branch, when no GitHub orgs are connected.  

**Why**
- PIR action item.

**How has this been tested?**  
- Locally using `yarn test:e2e`

**Whats Next?**
- Add more test cases when there are GitHub orgs for both cloud and enterprise.