### PR TITLE
ARC-942 Renew Github token with a refresh token

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -66,13 +66,9 @@ const getLaunchDarklyValue = async <T = boolean | string | number>(flag: Boolean
 };
 
 // Include jiraHost for any FF that needs to be rolled out in stages
-export const booleanFlag = async (flag: BooleanFlags, key?: string): Promise<boolean> => {
-	if (flag === BooleanFlags.USE_OUTBOUND_PROXY_FOR_OUATH_ROUTER || flag === BooleanFlags.NEW_JWT_VALIDATION) {
-		return true;
-	}
+export const booleanFlag = async (flag: BooleanFlags, key?: string): Promise<boolean> =>
 	// Always use the default value as false to prevent issues
-	return	await getLaunchDarklyValue(flag, false, key);
-};
+	await getLaunchDarklyValue(flag, false, key);
 
 export const stringFlag = async <T = string>(flag: StringFlags, defaultValue: T, key?: string): Promise<T> =>
 	await getLaunchDarklyValue<T>(flag, defaultValue, key);

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -26,7 +26,8 @@ export enum BooleanFlags {
 	ISSUEKEY_REGEX_CHAR_LIMIT = "issuekey-regex-char-limit",
 	USE_SHARED_PR_TRANSFORM = "use-shared-pr-transform",
 	NEW_JWT_VALIDATION = "new-jwt-validation",
-	RELAX_GHE_URLS_CHECK = "relax-ghe-url-check"
+	RELAX_GHE_URLS_CHECK = "relax-ghe-url-check",
+	RENEW_GITHUB_TOKEN = "renew-github-token"
 }
 
 export enum StringFlags {
@@ -65,9 +66,13 @@ const getLaunchDarklyValue = async <T = boolean | string | number>(flag: Boolean
 };
 
 // Include jiraHost for any FF that needs to be rolled out in stages
-export const booleanFlag = async (flag: BooleanFlags, key?: string): Promise<boolean> =>
+export const booleanFlag = async (flag: BooleanFlags, key?: string): Promise<boolean> => {
+	if (flag === BooleanFlags.USE_OUTBOUND_PROXY_FOR_OUATH_ROUTER || flag === BooleanFlags.NEW_JWT_VALIDATION) {
+		return true;
+	}
 	// Always use the default value as false to prevent issues
-	await getLaunchDarklyValue(flag, false, key);
+	return	await getLaunchDarklyValue(flag, false, key);
+};
 
 export const stringFlag = async <T = string>(flag: StringFlags, defaultValue: T, key?: string): Promise<T> =>
 	await getLaunchDarklyValue<T>(flag, defaultValue, key);

--- a/src/github/client/github-anonymous-client.ts
+++ b/src/github/client/github-anonymous-client.ts
@@ -34,7 +34,7 @@ export class GitHubAnonymousClient extends GitHubClient {
 		code: string,
 		state: string
 	}) {
-		const response = await this.axios.get(`/login/oauth/access_token`,
+		const { data: { access_token: accessToken, refresh_token: refreshToken } } = await this.axios.get(`/login/oauth/access_token`,
 			{
 				baseURL: this.baseUrl,
 				params: {
@@ -50,7 +50,10 @@ export class GitHubAnonymousClient extends GitHubClient {
 				responseType: "json"
 			}
 		);
-		return response.data.access_token;
+		return {
+			accessToken,
+			refreshToken
+		};
 	}
 
 	public async checkGitHubToken(gitHubToken: string) {
@@ -59,6 +62,32 @@ export class GitHubAnonymousClient extends GitHubClient {
 				Authorization: `Bearer ${gitHubToken}`
 			}
 		});
+	}
+
+	public async renewGitHubToken(opts: {
+		refreshToken: string,
+		clientId: string,
+		clientSecret: string
+	}) {
+		const { data: { access_token: accessToken, refresh_token: refreshToken } } = await this.axios.post(`/login/oauth/access_token`,
+			{
+				refresh_token: opts.refreshToken,
+				grant_type: "refresh_token",
+				client_id: opts.clientId,
+				client_secret: opts.clientSecret
+			},{
+				baseURL: this.baseUrl,
+				headers: {
+					accept: "application/json",
+					"content-type": "application/json"
+				},
+				responseType: "json"
+			}
+		);
+		return {
+			accessToken,
+			refreshToken
+		};
 	}
 
 }

--- a/src/interfaces/common.ts
+++ b/src/interfaces/common.ts
@@ -63,6 +63,7 @@ declare global {
 			session: {
 				jiraHost?: string;
 				githubToken?: string;
+				githubRefreshToken?: string;
 				gitHubUuid?: string;
 				temp?:  {
 					[key: string]: string;

--- a/src/routes/github/create-branch/github-remove-session.ts
+++ b/src/routes/github/create-branch/github-remove-session.ts
@@ -10,6 +10,7 @@ export const GithubRemoveSession = (req: Request, res: Response) => {
 	}
 
 	req.session.githubToken = undefined;
+	req.session.githubRefreshToken = undefined;
 	res.send({ baseUrl: gitHubAppConfig.hostname });
 
 };

--- a/src/routes/github/github-oauth-router.test.ts
+++ b/src/routes/github/github-oauth-router.test.ts
@@ -19,6 +19,10 @@ describe("github-oauth-router", () => {
 			BooleanFlags.USE_OUTBOUND_PROXY_FOR_OUATH_ROUTER,
 			expect.anything()
 		).mockResolvedValue(true);
+		when(booleanFlag).calledWith(
+			BooleanFlags.RENEW_GITHUB_TOKEN,
+			expect.anything()
+		).mockResolvedValue(true);
 	});
 
 	describe("GithubOAuthCallbackGet", () => {
@@ -122,6 +126,7 @@ describe("github-oauth-router", () => {
 				const res = {
 					locals: {
 						gitHubAppConfig: {},
+						jiraHost,
 						githubToken: ""
 					}
 				};

--- a/src/routes/github/github-oauth-router.ts
+++ b/src/routes/github/github-oauth-router.ts
@@ -269,12 +269,8 @@ const renewGitHubToken = async (githubRefreshToken: string, gitHubAppConfig: Git
 		const clientSecret = await getCloudOrGHESAppClientSecret(gitHubAppConfig, jiraHost);
 		if (clientSecret) {
 			const gitHubAnonymousClient = await createAnonymousClientByGitHubAppId(gitHubAppConfig?.gitHubAppId, jiraHost, logger);
-			const { accessToken, refreshToken } = await gitHubAnonymousClient.renewGitHubToken({
-				refreshToken: githubRefreshToken,
-				clientId: gitHubAppConfig.clientId,
-				clientSecret
-			});
-			return { accessToken, refreshToken };
+			const res = await gitHubAnonymousClient.renewGitHubToken(githubRefreshToken, gitHubAppConfig.clientId, clientSecret);
+			return { accessToken: res.accessToken, refreshToken: res.refreshToken };
 		}
 	} catch (err) {
 		logger.warn({ err }, "Failed to renew Github token...");

--- a/src/routes/github/github-oauth-router.ts
+++ b/src/routes/github/github-oauth-router.ts
@@ -186,7 +186,7 @@ export const GithubAuthMiddleware = async (req: Request, res: Response, next: Ne
 		return next();
 	} catch (e) {
 		req.log.debug(`Github token is not valid.`);
-		if (req.session?.githubRefreshToken) {
+		if (await booleanFlag(BooleanFlags.RENEW_GITHUB_TOKEN, res.locals.jiraHost) && req.session?.githubRefreshToken) {
 			req.log.debug(`Trying to renew Github token...`);
 			const token = await renewGitHubToken(req.session.githubRefreshToken, res.locals.gitHubAppConfig, res.locals.jiraHost, logger);
 			if (token) {

--- a/src/util/get-github-client-config.ts
+++ b/src/util/get-github-client-config.ts
@@ -147,7 +147,7 @@ export const createAnonymousClient = async (gitHubBaseUrl: string, jiraHost: str
 	return new GitHubAnonymousClient(await buildGitHubServerConfig(gitHubBaseUrl, jiraHost, logger));
 };
 
-export const createAnonymousClientByGitHubAppId = async (gitHubAppId: number, jiraHost: string, logger: Logger): Promise<GitHubAnonymousClient> => {
+export const createAnonymousClientByGitHubAppId = async (gitHubAppId: number | undefined, jiraHost: string, logger: Logger): Promise<GitHubAnonymousClient> => {
 	const config = await getGitHubClientConfigFromAppId(gitHubAppId, logger, jiraHost);
 	return new GitHubAnonymousClient(config);
 };


### PR DESCRIPTION
**What's in this PR?**
The current behaviour was when GitHub access token becomes invalid, user is redirected to OAuth flow to generate new access token. We were not leveraging the refresh token which is also generated along with access token.  Now the refresh token is stored in session along with access token. When access token becomes invalid, refresh token is being used to generate a new access token if possible (refresh token also have expiry). If not, redirected to OAuth flow.

**Why**
This will improve the user experience not to reload the page for generating GitHub access token

**Added feature flags**
RENEW_GITHUB_TOKEN

**Affected issues**  
[ARC-942]

**How has this been tested?**  
Unit Test
Local



[ARC-942]: https://softwareteams.atlassian.net/browse/ARC-942