### PR TITLE
[EZY KARMA] [GENERATED BY CHATGPT] NONE: retry database connection errors on backfill

### DIFF
--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -23,6 +23,7 @@ import { getRepositoryTask } from "~/src/sync/discovery";
 import { createInstallationClient } from "~/src/util/get-github-client-config";
 import { getCloudOrServerFromGitHubAppId } from "utils/get-cloud-or-server";
 import { Task, TaskPayload, TaskProcessors, TaskType } from "./sync.types";
+import { ConnectionTimedOutError } from "sequelize";
 
 const tasks: TaskProcessors = {
 	repository: getRepositoryTask,
@@ -358,6 +359,12 @@ export const handleBackfillError = async (
 
 	if (String(err).includes("connect ECONNREFUSED")) {
 		logger.warn("ECONNREFUSED error, retrying in 30 seconds");
+		scheduleNextTask(30_000);
+		return;
+	}
+
+	if (err instanceof ConnectionTimedOutError) {
+		logger.warn("ConnectionTimedOutError error, retrying in 30 seconds");
 		scheduleNextTask(30_000);
 		return;
 	}


### PR DESCRIPTION
**What's in this PR?**
Retrying yet another error that could stop backfilling

Kudos to ChatGPT for help!
<img width="507" alt="image" src="https://user-images.githubusercontent.com/20631664/216189190-196c50b6-a3bd-4a50-8daf-956249875315.png">


**Why**
Customer is complaining

**Added feature flags**

**Affected issues**  

**Whats Next?**

The end of the world
