### PR TITLE
[ONE-LINER] NONE: pass over the correct logger

### DIFF
--- a/src/routes/github/repository/github-repository-get.ts
+++ b/src/routes/github/repository/github-repository-get.ts
@@ -33,7 +33,7 @@ export const GitHubRepositoryGet = async (req: Request, res: Response): Promise<
 	}
 
 	try {
-		const repositories = await searchInstallationAndUserRepos(repoName, jiraHost, gitHubAppConfig.gitHubAppId || null, githubToken, req.log);
+		const repositories = await searchInstallationAndUserRepos(repoName, jiraHost, gitHubAppConfig.gitHubAppId || null, githubToken, log);
 		res.send({
 			repositories
 		});


### PR DESCRIPTION
**What's in this PR?**
Use the correct logger

**Why**
Cause currently it is impossible to see logs for a single jiraHost

