### PR TITLE
ARC-1958 fix the bug that client key is double hashed on Subscription table

### DIFF
--- a/src/github/client/token-cache.test.ts
+++ b/src/github/client/token-cache.test.ts
@@ -45,14 +45,14 @@ describe("InstallationTokenCache & AppTokenHolder", () => {
 		await Subscription.install({
 			host: "http://github.com",
 			installationId: 1234,
-			clientKey: "client-key",
+			hashedClientKey: "client-key",
 			gitHubAppId: undefined
 		});
 
 		await Subscription.install({
 			host: "http://github.com",
 			installationId: 4711,
-			clientKey: "client-key",
+			hashedClientKey: "client-key",
 			gitHubAppId: undefined
 		});
 

--- a/src/models/models.test.ts
+++ b/src/models/models.test.ts
@@ -61,14 +61,14 @@ describe("Models", () => {
 			await Subscription.install({
 				host: installation.jiraHost,
 				installationId: 1234,
-				clientKey: installation.plainClientKey,
+				hashedClientKey: getHashedKey(installation.plainClientKey),
 				gitHubAppId: undefined
 			});
 
 			await Subscription.install({
 				host: installation.jiraHost,
 				installationId: 2345,
-				clientKey: installation.plainClientKey,
+				hashedClientKey: getHashedKey(installation.plainClientKey),
 				gitHubAppId: undefined
 			});
 		});

--- a/src/models/subscription.test.ts
+++ b/src/models/subscription.test.ts
@@ -1,6 +1,5 @@
 import { Subscription } from "models/subscription";
 import { RepoSyncState } from "models/reposyncstate";
-import { getHashedKey } from "models/sequelize";
 
 const GITHUB_INSTALLATION_ID = 123;
 
@@ -290,7 +289,7 @@ describe("Subscription", () => {
 					installationId: GITHUB_INSTALLATION_ID,
 					host: "http://normal-cloud.atlassian.net",
 					gitHubAppId: undefined,
-					clientKey: "cloud_client_key"
+					hashedClientKey: "cloud_client_key"
 				});
 			});
 			it("should install subscription", async () => {
@@ -299,8 +298,8 @@ describe("Subscription", () => {
 					gitHubInstallationId: GITHUB_INSTALLATION_ID,
 					jiraHost: "http://normal-cloud.atlassian.net",
 					gitHubAppId: null,
-					jiraClientKey: getHashedKey("cloud_client_key"),
-					plainClientKey: "cloud_client_key"
+					jiraClientKey: "cloud_client_key",
+					plainClientKey: null
 				}));
 			});
 			it("should override existing record if found", async () => {
@@ -309,7 +308,7 @@ describe("Subscription", () => {
 					installationId: GITHUB_INSTALLATION_ID,
 					host: "http://normal-cloud.atlassian.net",
 					gitHubAppId: undefined,
-					clientKey: "cloud_client_key"
+					hashedClientKey: "cloud_client_key"
 				});
 				expect(cloudSub.id).toBe(cloudSub2.id);
 				expect((await Subscription.findAll()).length).toBe(1);
@@ -323,7 +322,7 @@ describe("Subscription", () => {
 					installationId: GITHUB_INSTALLATION_ID,
 					host: "http://normal-cloud.atlassian.net",
 					gitHubAppId: undefined,
-					clientKey: "cloud_client_key"
+					hashedClientKey: "cloud_client_key"
 				});
 			});
 			it("should install a new sub even with same gitHubInstallationId", async ()=>{
@@ -331,7 +330,7 @@ describe("Subscription", () => {
 					installationId: GITHUB_INSTALLATION_ID,
 					host: "http://normal-cloud.atlassian.net",
 					gitHubAppId: GHES_GITHUB_SERVER_APP_PK_ID,
-					clientKey: "cloud_client_key"
+					hashedClientKey: "cloud_client_key"
 				});
 				expect(cloudSub.id).not.toBe(ghesSub.id);
 				expect((await Subscription.findAll()).length).toBe(2);
@@ -339,8 +338,8 @@ describe("Subscription", () => {
 					gitHubInstallationId: GITHUB_INSTALLATION_ID,
 					jiraHost: "http://normal-cloud.atlassian.net",
 					gitHubAppId: GHES_GITHUB_SERVER_APP_PK_ID,
-					jiraClientKey: getHashedKey("cloud_client_key"),
-					plainClientKey: "cloud_client_key"
+					jiraClientKey: "cloud_client_key",
+					plainClientKey: null
 				}));
 			});
 			it("should override existing ghes sub when found", async ()=>{
@@ -348,13 +347,13 @@ describe("Subscription", () => {
 					installationId: GITHUB_INSTALLATION_ID,
 					host: "http://normal-cloud.atlassian.net",
 					gitHubAppId: GHES_GITHUB_SERVER_APP_PK_ID,
-					clientKey: "cloud_client_key"
+					hashedClientKey: "cloud_client_key"
 				});
 				const ghesSub2 = await Subscription.install({
 					installationId: GITHUB_INSTALLATION_ID,
 					host: "http://normal-cloud.atlassian.net",
 					gitHubAppId: GHES_GITHUB_SERVER_APP_PK_ID,
-					clientKey: "cloud_client_key"
+					hashedClientKey: "cloud_client_key"
 				});
 				expect(ghesSub1.id).toBe(ghesSub2.id);
 				expect((await Subscription.findAll()).length).toBe(2);

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -1,6 +1,6 @@
 import { DataTypes, DATE, Model, Op, QueryTypes, WhereOptions } from "sequelize";
 import { uniq } from "lodash";
-import { sequelize, getHashedKey } from "models/sequelize";
+import { sequelize } from "models/sequelize";
 
 export enum SyncStatus {
 	PENDING = "PENDING",
@@ -176,11 +176,11 @@ export class Subscription extends Model {
 			where: {
 				gitHubInstallationId: payload.installationId,
 				jiraHost: payload.host,
-				jiraClientKey: getHashedKey(payload.clientKey),
+				jiraClientKey: payload.hashedClientKey,
 				gitHubAppId: payload.gitHubAppId || null
 			},
 			defaults: {
-				plainClientKey: payload.clientKey
+				plainClientKey: null //TODO: Need an admin api to restore plain key on this from installations table
 			}
 		});
 
@@ -252,5 +252,5 @@ export interface SubscriptionPayload {
 }
 
 export interface SubscriptionInstallPayload extends SubscriptionPayload {
-	clientKey: string;
+	hashedClientKey: string;
 }

--- a/src/routes/api/configuration/api-configuration-get.test.ts
+++ b/src/routes/api/configuration/api-configuration-get.test.ts
@@ -38,7 +38,7 @@ describe("GitHub Configured Get", () => {
 			installationId: INSTALLATION_ID,
 			host: jiraHost,
 			gitHubAppId: undefined,
-			clientKey: "key"
+			hashedClientKey: "key"
 		});
 	});
 

--- a/src/routes/api/configuration/api-configuration-post.test.ts
+++ b/src/routes/api/configuration/api-configuration-post.test.ts
@@ -42,14 +42,14 @@ describe("GitHub Configured Get", () => {
 			installationId: 1,
 			host: JIRAHOST_A,
 			gitHubAppId: undefined,
-			clientKey: "key"
+			hashedClientKey: "key"
 		});
 
 		await Subscription.install({
 			installationId: 2,
 			host: JIRAHOST_B,
 			gitHubAppId: undefined,
-			clientKey: "key"
+			hashedClientKey: "key"
 		});
 	});
 

--- a/src/routes/api/installation/api-installation-delete.test.ts
+++ b/src/routes/api/installation/api-installation-delete.test.ts
@@ -17,7 +17,7 @@ describe("ApiInstallationDelete", ()=>{
 				installationId: GHES_GITHUB_INSTALLATION_ID,
 				host: jiraHost,
 				gitHubAppId: GHES_GITHUB_APP_ID,
-				clientKey: "key"
+				hashedClientKey: "key"
 			});
 			mockJiraClient = {
 				devinfo: {

--- a/src/routes/api/installation/api-installation-get.test.ts
+++ b/src/routes/api/installation/api-installation-get.test.ts
@@ -15,7 +15,7 @@ describe("ApiInstallationGet", () => {
 				installationId: GHES_GITHUB_INSTALLATION_ID,
 				host: jiraHost,
 				gitHubAppId: GHES_GITHUB_APP_ID,
-				clientKey: "key"
+				hashedClientKey: "key"
 			});
 		});
 		it("should find correct github app with id", async () => {

--- a/src/routes/api/installation/api-installation-sync-post.test.ts
+++ b/src/routes/api/installation/api-installation-sync-post.test.ts
@@ -14,7 +14,7 @@ describe("ApiInstallationSyncPost", ()=>{
 				installationId: GHES_GITHUB_INSTALLATION_ID,
 				host: jiraHost,
 				gitHubAppId: GHES_GITHUB_APP_ID,
-				clientKey: "key"
+				hashedClientKey: "key"
 			});
 		});
 		it("should get subcription with gitHubAppid", async ()=>{

--- a/src/routes/api/installation/api-installation-syncstate-get.test.ts
+++ b/src/routes/api/installation/api-installation-syncstate-get.test.ts
@@ -15,7 +15,7 @@ describe("ApiInstallationDelete", ()=>{
 				installationId: GHES_GITHUB_INSTALLATION_ID,
 				host: jiraHost,
 				gitHubAppId: GHES_GITHUB_APP_ID,
-				clientKey: "key"
+				hashedClientKey: "key"
 			});
 			await RepoSyncState.createForSubscription(sub, {
 				repoId: 123,

--- a/src/routes/github/configuration/github-configuration-post.ts
+++ b/src/routes/github/configuration/github-configuration-post.ts
@@ -70,7 +70,7 @@ export const GithubConfigurationPost = async (req: Request, res: Response): Prom
 		}
 
 		const subscription = await Subscription.install({
-			clientKey: req.body.clientKey,
+			hashedClientKey: req.body.clientKey,
 			installationId: gitHubInstallationId,
 			host: jiraHost,
 			gitHubAppId

--- a/src/routes/github/configuration/github-configuration-router.test.ts
+++ b/src/routes/github/configuration/github-configuration-router.test.ts
@@ -2,7 +2,6 @@
 import supertest from "supertest";
 import { Installation } from "models/installation";
 import { Subscription } from "models/subscription";
-import { getHashedKey } from "models/sequelize";
 import { getFrontendApp } from "~/src/app";
 import { getLogger } from "config/logger";
 import express, { Application } from "express";
@@ -401,14 +400,14 @@ describe("Github Configuration", () => {
 				.put("/rest/atlassian-connect/latest/addons/com.github.integration.test-atlassian-instance/properties/is-configured", { "isConfigured": "true" })
 				.reply(200, "OK");
 
-			const jiraClientKey = "a-unique-client-key-" + new Date().getTime();
+			const hashedJiraClientKey = "hashed-a-unique-client-key-" + new Date().getTime();
 			await client.appProperties.create("true");
 
 			await supertest(frontendApp)
 				.post("/github/configuration")
 				.send({
 					installationId: 1,
-					clientKey: jiraClientKey
+					clientKey: hashedJiraClientKey
 				})
 				.type("form")
 				.set(
@@ -420,12 +419,12 @@ describe("Github Configuration", () => {
 				)
 				.expect(200);
 
-			const subInDB = await Subscription.getAllForClientKey(getHashedKey(jiraClientKey));
+			const subInDB = await Subscription.getAllForClientKey(hashedJiraClientKey);
 			expect(subInDB.length).toBe(1);
 			expect(subInDB[0]).toEqual(expect.objectContaining({
 				gitHubInstallationId: 1,
-				jiraClientKey: getHashedKey(jiraClientKey),
-				plainClientKey: jiraClientKey
+				jiraClientKey: hashedJiraClientKey,
+				plainClientKey: null
 			}));
 		});
 	});

--- a/src/routes/github/create-branch/github-create-branch-options-get.test.ts
+++ b/src/routes/github/create-branch/github-create-branch-options-get.test.ts
@@ -41,7 +41,7 @@ describe("GitHub Create Branch Options Get", () => {
 		await Subscription.install({
 			host: jiraHost,
 			installationId: 1234,
-			clientKey: "key-123",
+			hashedClientKey: "key-123",
 			gitHubAppId: undefined
 		});
 		await supertest(app)
@@ -73,7 +73,7 @@ describe("GitHub Create Branch Options Get", () => {
 		await Subscription.install({
 			host: jiraHost,
 			installationId: 1234,
-			clientKey: "key-123",
+			hashedClientKey: "key-123",
 			gitHubAppId: serverApp.id
 		});
 		await supertest(app)
@@ -117,13 +117,13 @@ describe("GitHub Create Branch Options Get", () => {
 		await Subscription.install({
 			host: jiraHost,
 			installationId: 123,
-			clientKey: "key-123",
+			hashedClientKey: "key-123",
 			gitHubAppId: serverApp.id
 		});
 		await Subscription.install({
 			host: jiraHost,
 			installationId: 234,
-			clientKey: "key-123",
+			hashedClientKey: "key-123",
 			gitHubAppId: serverApp2.id
 		});
 
@@ -155,13 +155,13 @@ describe("GitHub Create Branch Options Get", () => {
 		await Subscription.install({
 			host: jiraHost,
 			installationId: 1234,
-			clientKey: "key-123",
+			hashedClientKey: "key-123",
 			gitHubAppId: serverApp.id
 		});
 		await Subscription.install({
 			host: jiraHost,
 			installationId: 1234,
-			clientKey: "key-123",
+			hashedClientKey: "key-123",
 			gitHubAppId: undefined
 		});
 

--- a/src/routes/jira/sync/jira-sync-post.test.ts
+++ b/src/routes/jira/sync/jira-sync-post.test.ts
@@ -28,7 +28,7 @@ describe("sync", () => {
 		await Subscription.install({
 			installationId: installationIdForCloud,
 			host: jiraHost,
-			clientKey: installation.clientKey,
+			hashedClientKey: installation.clientKey,
 			gitHubAppId: undefined
 		});
 		gitHubServerApp = await GitHubServerApp.install({
@@ -45,7 +45,7 @@ describe("sync", () => {
 		await Subscription.install({
 			installationId: installationIdForServer,
 			host: jiraHost,
-			clientKey: installation.clientKey,
+			hashedClientKey: installation.clientKey,
 			gitHubAppId: gitHubServerApp.id
 		});
 		app = express();

--- a/src/sync/sync-utils.test.ts
+++ b/src/sync/sync-utils.test.ts
@@ -19,7 +19,7 @@ describe("findOrStartSync", () => {
 				subscription = await Subscription.install({
 					installationId: JIRA_INSTALLATION_ID,
 					host: jiraHost,
-					clientKey: JIRA_CLIENT_KEY,
+					hashedClientKey: JIRA_CLIENT_KEY,
 					gitHubAppId: undefined
 				});
 			});
@@ -68,7 +68,7 @@ describe("findOrStartSync", () => {
 					installationId: JIRA_INSTALLATION_ID,
 					host: jiraHost,
 					gitHubAppId: gitHubServerApp.id,
-					clientKey: JIRA_CLIENT_KEY
+					hashedClientKey: JIRA_CLIENT_KEY
 				});
 			});
 			it("should send ghes gitHubAppConfig to msg queue", async () => {


### PR DESCRIPTION
**What's in this PR?**
Bug fix on double hashed client key

**Why**
Coz it is a bug.
Last time we have a correct "Subscription" record is 2021

`select "createdAt" from "Subscriptions" where exists (select 1 from "Installations" where "jiraClientKey" = "clientKey") order by "createdAt" desc limit 2;`

![image](https://user-images.githubusercontent.com/105693507/216504206-1185d776-d93d-47fc-8a36-75c808474184.png)


**Added feature flags**
N/A

**Affected issues**  
_Jira Issues_
ARC-1958

**How has this been tested?**  
Unit test.

**Whats Next?**
