### PR TITLE
None do not blow repo seach on single error

### DIFF
--- a/src/routes/github/repository/github-repository-get.test.ts
+++ b/src/routes/github/repository/github-repository-get.test.ts
@@ -18,6 +18,25 @@ describe("GitHub Repository Search", () => {
 		});
 		app.use(getFrontendApp());
 	});
+
+	const nockSearchRepos200 = (queryString: string, result) => {
+		githubNock
+			.get(`/search/repositories`)
+			.query({
+				q: queryString,
+				order: "updated" })
+			.reply(200, result);
+	};
+
+	const nockSearchRepos422 = (queryString: string) => {
+		githubNock
+			.get(`/search/repositories`)
+			.query({
+				q: queryString,
+				order: "updated" })
+			.reply(422, { message: "fatal error" });
+	};
+
 	describe("Testing the Repository Search route", () => {
 
 		it("should redirect to Github login if unauthorized", async () => {
@@ -59,25 +78,13 @@ describe("GitHub Repository Search", () => {
 				.get("/user")
 				.reply(200, { login: "test-account" });
 
-			const queryStringInstallation = `${randomString} org:${orgName} in:name`;
-			githubNock
-				.get(`/search/repositories`)
-				.query({
-					q: queryStringInstallation,
-					order: "updated" })
-				.reply(200, {
-					items: [{ full_name: "first", id: 2 }, { full_name: "second", id: 1 }]
-				});
+			nockSearchRepos200(`${randomString} org:${orgName} in:name`, {
+				items: [{ full_name: "first", id: 2 }, { full_name: "second", id: 1 }]
+			});
 
-			const queryStringUser = `${randomString} org:${orgName} org:test-account in:name`;
-			githubNock
-				.get(`/search/repositories`)
-				.query({
-					q: queryStringUser,
-					order: "updated" })
-				.reply(200, {
-					items: [{ full_name: "first", id: 1 }, { full_name: "second", id: 2 }]
-				});
+			nockSearchRepos200(`${randomString} org:${orgName} org:test-account in:name`, {
+				items: [{ full_name: "first", id: 1 }, { full_name: "second", id: 2 }]
+			});
 
 			await supertest(app)
 				.get("/github/repository").set(
@@ -118,25 +125,79 @@ describe("GitHub Repository Search", () => {
 				.get("/user")
 				.reply(200, { login: "test-account" });
 
-			const queryStringInstallation = `${randomString} org:${orgName} in:name`;
-			githubNock
-				.get(`/search/repositories`)
-				.query({
-					q: queryStringInstallation,
-					order: "updated" })
-				.reply(200, {
-					items: [{ full_name: "first", id: 1 }, { full_name: "second", id: 22 }, { full_name: "second" }]
-				});
+			nockSearchRepos200(`${randomString} org:${orgName} in:name`, {
+				items: [{ full_name: "first", id: 1 }, { full_name: "second", id: 22 }, { full_name: "second" }]
+			});
 
-			const queryStringUser = `${randomString} org:${orgName} org:test-account in:name`;
-			githubNock
-				.get(`/search/repositories`)
-				.query({
-					q: queryStringUser,
-					order: "updated" })
-				.reply(200, {
-					items: [{ full_name: "first", id: 1 }, { full_name: "second", id: 9000 }]
+			nockSearchRepos200(`${randomString} org:${orgName} org:test-account in:name`, {
+				items: [{ full_name: "first", id: 1 }, { full_name: "second", id: 9000 }]
+			});
+
+			await supertest(app)
+				.get("/github/repository").set(
+					"Cookie",
+					getSignedCookieHeader({
+						jiraHost,
+						githubToken: "random-token"
+					}))
+				.expect(res => {
+					expect(res.status).toBe(200);
+					expect(res.body?.repositories).toHaveLength(1);
+					expect(res.body?.repositories[0].id).toEqual(1);
 				});
+		});
+
+		it("a single error shouldn't nuke everything", async () => {
+			const gitHubInstallationId = 15;
+			const orgName = "orgName";
+
+			await Subscription.create({
+				gitHubInstallationId,
+				jiraHost
+			});
+
+			await Subscription.create({
+				gitHubInstallationId: gitHubInstallationId + 1,
+				jiraHost
+			});
+
+			githubNock
+				.get("/")
+				.matchHeader("Authorization", /^(Bearer|token) .+$/i)
+				.reply(200);
+
+			githubNock
+				.get(`/app/installations/${gitHubInstallationId}`)
+				.reply(200, { account: { login: orgName } });
+
+			githubNock
+				.get(`/app/installations/${gitHubInstallationId + 1}`)
+				.reply(200, { account: { login: orgName + "1" } });
+
+			githubNock
+				.post(`/app/installations/${gitHubInstallationId}/access_tokens`)
+				.reply(200);
+
+			githubNock
+				.post(`/app/installations/${gitHubInstallationId + 1}/access_tokens`)
+				.reply(200);
+
+			githubNock
+				.get("/user")
+				.times(2)
+				.reply(200, { login: "test-account" });
+
+			nockSearchRepos200(`${randomString} org:${orgName} in:name`, {
+				items: [{ full_name: "first", id: 1 }, { full_name: "second", id: 22 }, { full_name: "second" }]
+			});
+
+			nockSearchRepos422(`${randomString} org:${orgName + "1"} in:name`);
+
+			nockSearchRepos200(`${randomString} org:${orgName} org:test-account in:name`, {
+				items: [{ full_name: "first", id: 1 }, { full_name: "second", id: 9000 }]
+			});
+
+			nockSearchRepos422(`${randomString} org:${orgName + "1"} org:test-account in:name`);
 
 			await supertest(app)
 				.get("/github/repository").set(

--- a/src/routes/github/repository/github-repository-get.ts
+++ b/src/routes/github/repository/github-repository-get.ts
@@ -79,6 +79,10 @@ const getReposBySubscriptions = async (repoName: string, subscriptions: Subscrip
 						const userInstallationSearch = responseInstallationSearch.data?.items || [];
 						logger.info(`Found ${userInstallationSearch.length} repos from installation search`);
 						return userInstallationSearch;
+					})
+					.catch(err => {
+						logger.warn({ err },"Cannot search for repos using installation client, falling back to empty array");
+						return [];
 					}),
 
 				gitHubUserClient.searchRepositories(searchQueryUserString, "updated")
@@ -86,6 +90,10 @@ const getReposBySubscriptions = async (repoName: string, subscriptions: Subscrip
 						const userClientSearch = responseUserSearch.data?.items || [];
 						logger.info(`Found ${userClientSearch.length} repos from user client search`);
 						return responseUserSearch.data?.items || [];
+					})
+					.catch(err => {
+						logger.warn({ err }, "Cannot search for repos using user client, falling back to empty array");
+						return [];
 					})
 			]);
 

--- a/src/routes/github/repository/github-repository-get.ts
+++ b/src/routes/github/repository/github-repository-get.ts
@@ -80,6 +80,9 @@ const getReposBySubscriptions = async (repoName: string, subscriptions: Subscrip
 						logger.info(`Found ${userInstallationSearch.length} repos from installation search`);
 						return userInstallationSearch;
 					})
+					// When no enough perms, API might throw errors. We don't want that to stop the routine because there might
+					// be other orgs connected where the customer has enough perms
+					// https://docs.github.com/en/rest/search?apiVersion=2022-11-28#access-errors-or-missing-search-results
 					.catch(err => {
 						logger.warn({ err },"Cannot search for repos using installation client, falling back to empty array");
 						return [];


### PR DESCRIPTION
**What's in this PR?**
Be more tolerant towards GitHub API errors in create-branch call

**Why**
https://github.com/atlassian/github-for-jira/issues/1845
According to https://docs.github.com/en/rest/search?apiVersion=2022-11-28#access-errors-or-missing-search-results , if a user don't have perms to access an org, the API might throw a error. And if the customer has multiple orgs connected to it, that shouldn't be a reason to kill the whole request only because of a single org

