### PR TITLE
Add template for feature request, and direct requests to support portal

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support and Bug Requests
+    url: https://support.atlassian.com/jira-software-cloud/
+    about: Need some help? Please submit a support request or bug report via Jira Software Support portal

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest an idea or solution for the Github for Jira app
+title: ''
+labels: feature request
+assignees: ''
+
+---
+
+**Tell us about the use cases or problems this request will address**
+A clear and concise description of what the use case is. 
+
+**What's your role in the team?**
+I.e: I am a software engineer / product manager / QA / ...
+
+**What's size of your team and the company? (This will help us triage requests)**
+I.e: I am in a team of 8, in a company with around 400 employees
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ integration is an open-source project, built and maintained by [Atlassian](https
 
 ## Support
 
-For general support inquiries, [please contact the Atlassian Support team](https://support.atlassian.com/contact/#/?inquiry_category=technical_issues&is_cloud=true&product_key=jira-software).  For technical issues, [please create a new issue](https://github.com/atlassian/github-for-jira/issues/new).
+For general support inquiries and bug reports, [please contact the Atlassian Support team](https://support.atlassian.com/contact/#/?inquiry_category=technical_issues&is_cloud=true&product_key=jira-software).  For feature requests, [please create a new issue](https://github.com/atlassian/github-for-jira/issues/new).
 
 ## Table of Contents
   - [Install app](#install-app)


### PR DESCRIPTION
**What's in this PR?**
Templates and links to:    
* Direct support and bug requests to support portal
* Put more structure to help people give more details when they leave feature requests

**Why**
* At the moment we are under-resourced to act like a support team and attend to all the support and bug requests in GH issues, and we want our users to be better served when they need help.
* More details on feature requests help the product team to better manage and triage features.

**Added feature flags**

**Affected issues**  
_Jira Issues_

**How has this been tested?**  
Only tested with my personal repo. Someone should review the copy writing here.

**Whats Next?**
