### PR TITLE
ARC-1976: add encryption endpoint

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -26,7 +26,8 @@ export enum BooleanFlags {
 export enum StringFlags {
 	BLOCKED_INSTALLATIONS = "blocked-installations",
 	LOG_LEVEL = "log-level",
-	OUTBOUND_PROXY_SKIPLIST = "outbound-proxy-skiplist"
+	OUTBOUND_PROXY_SKIPLIST = "outbound-proxy-skiplist",
+	HEADERS_TO_ENCRYPT = "headers-to-encrypt"
 }
 
 export enum NumberFlags {

--- a/src/routes/github/github-encrypt-header-post.test.ts
+++ b/src/routes/github/github-encrypt-header-post.test.ts
@@ -1,0 +1,68 @@
+import supertest from "supertest";
+import { getSignedCookieHeader } from "test/utils/cookies";
+import express from "express";
+import { getLogger } from "config/logger";
+import { getFrontendApp } from "~/src/app";
+import { when } from "jest-when";
+import { stringFlag, StringFlags } from "config/feature-flags";
+
+jest.mock("config/feature-flags");
+
+describe("Github Encrypt Header post endpoint", () => {
+	const frontendApp = express();
+	frontendApp.use((request, _, next) => {
+		request.log = getLogger("test");
+		next();
+	});
+	frontendApp.use(getFrontendApp());
+
+	it("should return 400 when header is not provided", async () => {
+		when(stringFlag)
+			.calledWith(StringFlags.HEADERS_TO_ENCRYPT, expect.anything(), jiraHost)
+			.mockResolvedValue(undefined);
+
+		// githubNock.get("/").reply(200);
+		await supertest(frontendApp)
+			.post("/github/encrypt/header")
+			.set(
+				"Cookie",
+				getSignedCookieHeader({
+					jiraHost
+				})
+			)
+			.set(
+				"tEst-heAder",
+				"blah"
+			)
+			.expect(res => {
+				expect(res.status).toBe(401);
+			});
+	});
+
+	it("should return encrypted header", async () => {
+		when(stringFlag)
+			.calledWith(StringFlags.HEADERS_TO_ENCRYPT, expect.anything(), jiraHost)
+			.mockResolvedValue(" test-HEADER  ");
+
+		// githubNock.get("/").reply(200);
+		await supertest(frontendApp)
+			.post("/github/encrypt/header")
+			.set(
+				"Cookie",
+				getSignedCookieHeader({
+					jiraHost
+				})
+			)
+			.set(
+				"tEst-heAder",
+				"blah"
+			)
+			.expect(res => {
+				expect(res.status).toBe(200);
+				expect(res.body).toMatchObject({
+					encryptedValue: "encrypted:blah",
+					plainValueSha256: "8b7df143d91c716ecfa5fc1730022f6b421b05cedee8fd52b1fc65a96030ad52"
+				});
+			});
+	});
+});

--- a/src/routes/github/github-encrypt-header-post.test.ts
+++ b/src/routes/github/github-encrypt-header-post.test.ts
@@ -21,7 +21,6 @@ describe("Github Encrypt Header post endpoint", () => {
 			.calledWith(StringFlags.HEADERS_TO_ENCRYPT, expect.anything(), jiraHost)
 			.mockResolvedValue(undefined);
 
-		// githubNock.get("/").reply(200);
 		await supertest(frontendApp)
 			.post("/github/encrypt/header")
 			.set(
@@ -44,7 +43,6 @@ describe("Github Encrypt Header post endpoint", () => {
 			.calledWith(StringFlags.HEADERS_TO_ENCRYPT, expect.anything(), jiraHost)
 			.mockResolvedValue(" test-HEADER  ");
 
-		// githubNock.get("/").reply(200);
 		await supertest(frontendApp)
 			.post("/github/encrypt/header")
 			.set(

--- a/src/routes/github/github-encrypt-header-post.ts
+++ b/src/routes/github/github-encrypt-header-post.ts
@@ -46,7 +46,7 @@ export const GithubEncryptHeaderPost = async (req: Request, res: Response): Prom
 		return;
 	}
 
-	const encryptedValue = await EncryptionClient.encrypt(EncryptionSecretKeyEnum.GITHUB_SERVER_PREAUTH_HEADER_VALUE, plainValue, {
+	const encryptedValue = await EncryptionClient.encrypt(EncryptionSecretKeyEnum.GITHUB_SERVER_APP, plainValue, {
 		jiraHost: res.locals.jiraHost
 	});
 

--- a/src/routes/github/github-encrypt-header-post.ts
+++ b/src/routes/github/github-encrypt-header-post.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { EncryptionClient, EncryptionSecretKeyEnum } from "utils/encryption-client";
 import crypto from "crypto";
+import { stringFlag, StringFlags } from "config/feature-flags";
 
 const getHashedKey = (clientKey: string): string => {
 	const keyHash = crypto.createHash("sha256");
@@ -9,24 +10,51 @@ const getHashedKey = (clientKey: string): string => {
 };
 
 export const GithubEncryptHeaderPost = async (req: Request, res: Response): Promise<void> => {
+	req.log.info("Encryption was requested");
 
-	if (typeof req.headers.tdauthtoken === "string") {
-		const plainValue: string = req.headers.tdauthtoken || "";
+	const headerToEncrypt = (await stringFlag(StringFlags.HEADERS_TO_ENCRYPT, "", res.locals.jiraHost) || "").toLowerCase().trim();
 
-		const encryptedValue = await EncryptionClient.encrypt(EncryptionSecretKeyEnum.GITHUB_SERVER_PREAUTH_HEADER_VALUE, plainValue, {
-			jiraHost: res.locals.jiraHost
-		});
-
-		res.json({
-			encryptedValue,
-			plainValueSha: getHashedKey(plainValue)
-		}).sendStatus(200);
-
-	} else {
-		res.json({
+	if (headerToEncrypt.length === 0) {
+		req.log.warn("Not allowed");
+		res.status(401).json({
 			error: {
-				message: "Header was not found!"
+				message: "Not allowed"
 			}
-		}).sendStatus(400);
+		});
+		return;
 	}
+
+	if (!req.headers[headerToEncrypt]) {
+		req.log.info("Header wasn't provided: " + headerToEncrypt);
+		res.status(400).json({
+			error: {
+				message: "Header not found: " + headerToEncrypt
+			}
+		});
+		return;
+	}
+
+	const plainValue = req.headers[headerToEncrypt] || "";
+
+	if (Array.isArray(plainValue)) {
+		req.log.info("Array was provided: " + headerToEncrypt);
+		res.status(400).json({
+			error: {
+				message: "Just one header was expected: " + headerToEncrypt
+			}
+		});
+		return;
+	}
+
+	const encryptedValue = await EncryptionClient.encrypt(EncryptionSecretKeyEnum.GITHUB_SERVER_PREAUTH_HEADER_VALUE, plainValue, {
+		jiraHost: res.locals.jiraHost
+	});
+
+	res.json({
+		encryptedValue: encryptedValue,
+		plainValueSha256: getHashedKey(plainValue)
+	});
+
+	req.log.info("Encrypted header was returned sent back!");
+
 };

--- a/src/routes/github/github-encrypt-header-post.ts
+++ b/src/routes/github/github-encrypt-header-post.ts
@@ -1,0 +1,32 @@
+import { Request, Response } from "express";
+import { EncryptionClient, EncryptionSecretKeyEnum } from "utils/encryption-client";
+import crypto from "crypto";
+
+const getHashedKey = (clientKey: string): string => {
+	const keyHash = crypto.createHash("sha256");
+	keyHash.update(clientKey);
+	return keyHash.digest("hex");
+};
+
+export const GithubEncryptHeaderPost = async (req: Request, res: Response): Promise<void> => {
+
+	if (typeof req.headers.tdauthtoken === "string") {
+		const plainValue: string = req.headers.tdauthtoken || "";
+
+		const encryptedValue = await EncryptionClient.encrypt(EncryptionSecretKeyEnum.GITHUB_SERVER_PREAUTH_HEADER_VALUE, plainValue, {
+			jiraHost: res.locals.jiraHost
+		});
+
+		res.json({
+			encryptedValue,
+			plainValueSha: getHashedKey(plainValue)
+		}).sendStatus(200);
+
+	} else {
+		res.json({
+			error: {
+				message: "Header was not found!"
+			}
+		}).sendStatus(400);
+	}
+};

--- a/src/routes/github/github-router.ts
+++ b/src/routes/github/github-router.ts
@@ -15,6 +15,7 @@ import { GithubRepositoryRouter } from "routes/github/repository/github-reposito
 import { GithubBranchRouter } from "routes/github/branch/github-branch-router";
 import { jiraSymmetricJwtMiddleware } from "~/src/middleware/jira-symmetric-jwt-middleware";
 import { Errors } from "config/errors";
+import { GithubEncryptHeaderPost } from "routes/github/github-encrypt-header-post";
 
 //  DO NOT USE THIS MIDDLEWARE ELSE WHERE EXCEPT FOR CREATE BRANCH FLOW AS THIS HAS SECURITY HOLE
 // TODO - Once JWT is passed from Jira for create branch this midddleware is obsolete.
@@ -51,6 +52,9 @@ subRouter.use(GithubOAuthRouter);
 
 subRouter.use(jiraSymmetricJwtMiddleware);
 subRouter.use(GithubServerAppMiddleware);
+
+subRouter.post("/encrypt/header", GithubEncryptHeaderPost);
+
 
 // CSRF Protection Middleware for all following routes
 subRouter.use(csrfMiddleware);

--- a/src/util/encryption-client.ts
+++ b/src/util/encryption-client.ts
@@ -4,8 +4,7 @@ import { retry } from "ts-retry-promise";
 
 export enum EncryptionSecretKeyEnum {
 	GITHUB_SERVER_APP = "github-server-app-secrets",
-	JIRA_INSTANCE_SECRETS = "jira-instance-secrets",
-	GITHUB_SERVER_PREAUTH_HEADER_VALUE = "github-server-preauth-header-value"
+	JIRA_INSTANCE_SECRETS = "jira-instance-secrets"
 }
 
 export type EncryptionContext = Record<string, string | number>;

--- a/src/util/encryption-client.ts
+++ b/src/util/encryption-client.ts
@@ -5,6 +5,7 @@ import { retry } from "ts-retry-promise";
 export enum EncryptionSecretKeyEnum {
 	GITHUB_SERVER_APP = "github-server-app-secrets",
 	JIRA_INSTANCE_SECRETS = "jira-instance-secrets",
+	GITHUB_SERVER_PREAUTH_HEADER_VALUE = "github-server-preauth-header-value"
 }
 
 export type EncryptionContext = Record<string, string | number>;


### PR DESCRIPTION
**What's in this PR?**
Adding a temp endpoint for our enterprise customer to encrypt a header. 

**Why**
This is needed for BTF work: until we have UI we will support them with feature flags

**Added feature flags**
https://app.launchdarkly.com/github-for-jira/production/features/headers-to-encrypt/targeting

**Affected issues**  
ARC-1976

**How has this been tested?**  
Locally
