### PR TITLE
NONE: improve error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ Also see our guides for [builds](./docs/builds.md) and [deployments](./docs/depl
 When a workflow (e.g. GitHub Action) or development event (e.g. pull request, commit, branch) runs, the app receives a webhook from GitHub. The app then extract the issue key from the respective branch/commit/PR and send this information to Jira.
 
 ## How the backfill works
-The app is designed to backfill historical data into Jira. Once you have installed and configured the app successfully, it will automatically trigger the backfilling process to update Jira with historical information such as pull requests, deployments, branches, builds, and commits.
+The app is designed to backfill historical data into Jira. Once you have installed and configured the app successfully,
+it will automatically trigger the backfilling process for the allowed repositories to update Jira with historical information such as pull requests, deployments, branches, builds, and commits.
 
 1. The backfilling process attempts to connect all branches that fulfill at least one of the following criteria:
     - The branch name contains the issue key.

--- a/src/config/logger.test.ts
+++ b/src/config/logger.test.ts
@@ -378,7 +378,6 @@ describe("logger behaviour", () => {
 
 			logger.error({
 				err: new GithubClientGraphQLError(
-					response.config,
 					response,
 					[
 						{

--- a/src/config/logger.test.ts
+++ b/src/config/logger.test.ts
@@ -3,6 +3,7 @@ import { RingBuffer, Stream } from "bunyan";
 import { createHashWithSharedSecret as hash } from "utils/encryption";
 import { GithubClientGraphQLError } from "~/src/github/client/github-client-errors";
 import { createAnonymousClient } from "utils/get-github-client-config";
+import { noop } from "lodash";
 
 describe("logger behaviour", () => {
 
@@ -440,8 +441,7 @@ describe("logger behaviour", () => {
 
 			const client = await createAnonymousClient(gheUrl, jiraHost, logger);
 
-			// eslint-disable-next-line @typescript-eslint/no-empty-function
-			await client.getMainPage(1000).catch(() => { });
+			await client.getMainPage(1000).catch(noop);
 
 			const record = JSON.parse(ringBuffer.records[ringBuffer.records.length - 1]);
 

--- a/src/github/branch.test.ts
+++ b/src/github/branch.test.ts
@@ -1,9 +1,9 @@
 import { createBranchWebhookHandler, deleteBranchWebhookHandler } from "./branch";
 import { WebhookContext } from "routes/github/webhook/webhook-context";
 import { getLogger } from "config/logger";
-import { GITHUB_CLOUD_BASEURL, GITHUB_CLOUD_API_BASEURL } from "utils/get-github-client-config";
 import { envVars } from "config/env";
 import { sqsQueues } from "../sqs/queues";
+import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL } from "~/src/github/client/github-client-constants";
 
 jest.mock("../sqs/queues");
 

--- a/src/github/client/github-anonymous-client.ts
+++ b/src/github/client/github-anonymous-client.ts
@@ -15,7 +15,7 @@ export interface CreatedGitHubAppResponse {
  * A GitHub client without any authentication
  */
 export class GitHubAnonymousClient extends GitHubClient {
-	constructor(githubConfig: GitHubConfig, logger?: Logger) {
+	constructor(githubConfig: GitHubConfig, logger: Logger) {
 		super(githubConfig, logger);
 	}
 

--- a/src/github/client/github-app-client.ts
+++ b/src/github/client/github-app-client.ts
@@ -3,7 +3,7 @@ import { Octokit } from "@octokit/rest";
 import { AxiosRequestConfig, AxiosRequestHeaders, AxiosResponse } from "axios";
 import { AppTokenHolder } from "./app-token-holder";
 import { AuthToken } from "~/src/github/client/auth-token";
-import { GITHUB_ACCEPT_HEADER } from "~/src/util/get-github-client-config";
+import { GITHUB_ACCEPT_HEADER } from "./github-client-constants";
 import { GitHubClient, GitHubConfig } from "./github-client";
 
 /**

--- a/src/github/client/github-client-constants.ts
+++ b/src/github/client/github-client-constants.ts
@@ -1,0 +1,4 @@
+export const GITHUB_CLOUD_HOSTNAME = "github.com";
+export const GITHUB_CLOUD_BASEURL = "https://github.com";
+export const GITHUB_CLOUD_API_BASEURL = "https://api.github.com";
+export const GITHUB_ACCEPT_HEADER = "application/vnd.github.v3+json";

--- a/src/github/client/github-client-errors.test.ts
+++ b/src/github/client/github-client-errors.test.ts
@@ -3,7 +3,7 @@ import { BlockedIpError } from "./github-client-errors";
 describe("GitHubClientError", () => {
 
 	it("propagates the stacktrace", async () => {
-		const error = new BlockedIpError({}, {
+		const error = new BlockedIpError({
 			name: "BlockedIpError",
 			message: "ignored",
 			stack: "existing stack trace line 1\nexisting stack trace line 2\nexisting stack trace line 3",

--- a/src/github/client/github-client-errors.ts
+++ b/src/github/client/github-client-errors.ts
@@ -5,20 +5,16 @@ export class GithubClientError extends Error {
 	cause: AxiosError;
 	isRetryable = true;
 
+	status?: number;
+	code?: string;
+
 	constructor(message: string, cause: AxiosError) {
 		super(message);
-		if (cause) {
-			this.cause = { ...cause };
-			this.stack = this.stack?.split("\n").slice(0, 2).join("\n") + "\n" + cause.stack;
-		}
-	}
 
-	getStatus() {
-		return this.cause.response?.status;
-	}
-
-	getCode() {
-		return this.cause.code;
+		this.cause = { ...cause };
+		this.stack = this.stack?.split("\n").slice(0, 2).join("\n") + "\n" + cause.stack;
+		this.status = this.cause.response?.status;
+		this.code = this.cause.code;
 	}
 }
 

--- a/src/github/client/github-client-errors.ts
+++ b/src/github/client/github-client-errors.ts
@@ -11,10 +11,11 @@ export class GithubClientError extends Error {
 	constructor(message: string, cause: AxiosError) {
 		super(message);
 
+		this.status = cause.response?.status;
+		this.code = cause.code;
+
 		this.cause = { ...cause };
 		this.stack = this.stack?.split("\n").slice(0, 2).join("\n") + "\n" + cause.stack;
-		this.status = this.cause.response?.status;
-		this.code = this.cause.code;
 	}
 }
 

--- a/src/github/client/github-client-interceptors.ts
+++ b/src/github/client/github-client-interceptors.ts
@@ -117,7 +117,7 @@ export const handleFailedRequest = (logger: Logger) =>
 			const rateLimitRemainingHeaderValue: string = response.headers?.["x-ratelimit-remaining"];
 			if (status === 403 && rateLimitRemainingHeaderValue == "0") {
 				logger.warn("Rate limiting error");
-				return Promise.reject(new RateLimitingError(response, err));
+				return Promise.reject(new RateLimitingError(err));
 			}
 
 			if (status === 403 && response.data?.message?.includes("has an IP allow list enabled")) {

--- a/src/github/client/github-client-interceptors.ts
+++ b/src/github/client/github-client-interceptors.ts
@@ -108,7 +108,7 @@ export const handleFailedRequest = (logger: Logger) =>
 
 		if (response?.status === 408 || err.code === "ETIMEDOUT") {
 			logger.warn("Request timed out");
-			return Promise.reject(new GithubClientTimeoutError(config, err));
+			return Promise.reject(new GithubClientTimeoutError(err));
 		}
 
 		if (response) {
@@ -117,19 +117,19 @@ export const handleFailedRequest = (logger: Logger) =>
 			const rateLimitRemainingHeaderValue: string = response.headers?.["x-ratelimit-remaining"];
 			if (status === 403 && rateLimitRemainingHeaderValue == "0") {
 				logger.warn("Rate limiting error");
-				return Promise.reject(new RateLimitingError(config, response, err));
+				return Promise.reject(new RateLimitingError(response, err));
 			}
 
 			if (status === 403 && response.data?.message?.includes("has an IP allow list enabled")) {
 				logger.warn({ remote: response.data.message }, "Blocked by GitHub allowlist");
-				return Promise.reject(new BlockedIpError(config, err, status));
+				return Promise.reject(new BlockedIpError(err));
 			}
 
 			if (status === 403 && response.data?.message?.includes("Resource not accessible by integration")) {
 				logger.warn({
 					remote: response.data.message
 				}, "unauthorized");
-				return Promise.reject(new InvalidPermissionsError(config, err, status));
+				return Promise.reject(new InvalidPermissionsError(err));
 			}
 			const isWarning = status && (status >= 300 && status < 500 && status !== 400);
 
@@ -139,7 +139,7 @@ export const handleFailedRequest = (logger: Logger) =>
 				logger.error(errorMessage);
 			}
 
-			return Promise.reject(new GithubClientError(config, errorMessage, status, err));
+			return Promise.reject(new GithubClientError(errorMessage, err));
 		}
 
 		return Promise.reject(err);

--- a/src/github/client/github-client-server.test.ts
+++ b/src/github/client/github-client-server.test.ts
@@ -4,7 +4,7 @@ import { GitHubInstallationClient } from "./github-installation-client";
 import { statsd }  from "config/statsd";
 import { InstallationId } from "./installation-id";
 import nock from "nock";
-import { GITHUB_ACCEPT_HEADER } from "utils/get-github-client-config";
+import { GITHUB_ACCEPT_HEADER } from "~/src/github/client/github-client-constants";
 
 jest.mock("config/feature-flags");
 

--- a/src/github/client/github-client.nock.test.ts
+++ b/src/github/client/github-client.nock.test.ts
@@ -2,10 +2,11 @@
 import "config/env";
 
 import { GitHubClient, GitHubConfig } from "~/src/github/client/github-client";
+import { getLogger } from "config/logger";
 
 class TestGitHubClient extends GitHubClient {
 	constructor(config: GitHubConfig) {
-		super(config);
+		super(config, getLogger("test"));
 	}
 	public doTestHttpCall() {
 		return this.axios.get("/", {});

--- a/src/github/client/github-client.test.ts
+++ b/src/github/client/github-client.test.ts
@@ -3,12 +3,13 @@ import "config/env";
 
 import * as axios from "axios";
 import { GitHubClient, GitHubConfig } from "~/src/github/client/github-client";
+import { getLogger } from "config/logger";
 
 jest.mock("axios");
 
 class TestGitHubClient extends GitHubClient {
 	constructor(config: GitHubConfig) {
-		super(config);
+		super(config, getLogger("test"));
 	}
 	public doTestGraphqlCall() {
 		return this.graphql("foo", {});

--- a/src/github/client/github-client.ts
+++ b/src/github/client/github-client.ts
@@ -97,13 +97,13 @@ export class GitHubClient {
 
 		const graphqlErrors = response.data?.errors;
 		if (graphqlErrors?.length) {
-			this.logger.warn({ res: response }, "GraphQL errors");
-			const graphQlError = new GithubClientGraphQLError(config, response, graphqlErrors);
-			if (graphqlErrors.find(err => err.type == "RATE_LIMITED")) {
-				this.logger.info({ err: graphqlErrors }, "Mapping a GraphQl error to a rate-limiting error");
-				return Promise.reject(new RateLimitingError(response, buildAxiosStubErrorForGraphQlErrors(config, response)));
+			const err = new GithubClientGraphQLError(response, graphqlErrors);
+			this.logger.warn({ err }, "GraphQL errors");
+			if (graphqlErrors.find(graphQLError => graphQLError.type == "RATE_LIMITED")) {
+				this.logger.info({ err }, "Mapping GraphQL errors to a rate-limiting error");
+				return Promise.reject(new RateLimitingError(buildAxiosStubErrorForGraphQlErrors(response)));
 			}
-			return Promise.reject(graphQlError);
+			return Promise.reject(err);
 		}
 
 		return response;

--- a/src/github/client/github-client.ts
+++ b/src/github/client/github-client.ts
@@ -1,5 +1,4 @@
 import Logger from "bunyan";
-import { getLogger } from "~/src/config/logger";
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 import { HttpProxyAgent } from "http-proxy-agent";
 import { HttpsProxyAgent } from "https-proxy-agent";
@@ -47,7 +46,7 @@ export class GitHubClient {
 
 	constructor(
 		gitHubConfig: GitHubConfig,
-		logger: Logger = getLogger("gitHub-client")
+		logger: Logger
 	) {
 		this.logger = logger;
 		this.baseUrl = gitHubConfig.baseUrl;

--- a/src/github/client/github-client.ts
+++ b/src/github/client/github-client.ts
@@ -50,6 +50,14 @@ export class GitHubClient {
 		this.restApiUrl = gitHubConfig.apiUrl;
 		this.graphqlUrl = gitHubConfig.graphqlUrl;
 
+		this.axios = axios.create({
+			baseURL: this.restApiUrl,
+			transitional: {
+				clarifyTimeoutError: true
+			},
+			... (gitHubConfig.proxyBaseUrl ? this.buildProxyConfig(gitHubConfig.proxyBaseUrl) : {})
+		});
+
 		this.axios.interceptors.request.use(setRequestStartTime);
 		this.axios.interceptors.request.use(setRequestTimeout);
 		this.axios.interceptors.request.use(urlParamsMiddleware);
@@ -61,14 +69,6 @@ export class GitHubClient {
 			instrumentRequest(metricHttpRequest.github, this.restApiUrl),
 			instrumentFailedRequest(metricHttpRequest.github, this.restApiUrl)
 		);
-
-		this.axios = axios.create({
-			baseURL: this.restApiUrl,
-			transitional: {
-				clarifyTimeoutError: true
-			},
-			... (gitHubConfig.proxyBaseUrl ? this.buildProxyConfig(gitHubConfig.proxyBaseUrl) : {})
-		});
 
 		if (gitHubConfig.apiKeyConfig) {
 			logger.info("Use API key");

--- a/src/github/client/github-installation-client.ts
+++ b/src/github/client/github-installation-client.ts
@@ -45,7 +45,7 @@ export class GitHubInstallationClient extends GitHubClient {
 		githubInstallationId: InstallationId,
 		gitHubConfig: GitHubConfig,
 		jiraHost: string,
-		logger?: Logger,
+		logger: Logger,
 		gshaId?: number
 	) {
 		super(gitHubConfig, logger);

--- a/src/github/client/github-installation-client.ts
+++ b/src/github/client/github-installation-client.ts
@@ -4,9 +4,6 @@ import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { AppTokenHolder } from "./app-token-holder";
 import { InstallationTokenCache } from "./installation-token-cache";
 import { AuthToken } from "./auth-token";
-import { handleFailedRequest, instrumentFailedRequest, instrumentRequest, setRequestStartTime, setRequestTimeout } from "./github-client-interceptors";
-import { metricHttpRequest } from "config/metric-names";
-import { urlParamsMiddleware } from "utils/axios/url-params-middleware";
 import { InstallationId } from "./installation-id";
 import {
 	getBranchesQueryWithChangedFiles,
@@ -54,17 +51,6 @@ export class GitHubInstallationClient extends GitHubClient {
 		super(gitHubConfig, logger);
 		this.jiraHost = jiraHost;
 
-		this.axios.interceptors.request.use(setRequestStartTime);
-		this.axios.interceptors.request.use(setRequestTimeout);
-		this.axios.interceptors.request.use(urlParamsMiddleware);
-		this.axios.interceptors.response.use(
-			undefined,
-			handleFailedRequest(this.logger)
-		);
-		this.axios.interceptors.response.use(
-			instrumentRequest(metricHttpRequest.github, this.restApiUrl),
-			instrumentFailedRequest(metricHttpRequest.github, this.restApiUrl)
-		);
 		this.installationTokenCache = InstallationTokenCache.getInstance();
 		this.githubInstallationId = githubInstallationId;
 		this.gitHubServerAppId = gshaId;

--- a/src/github/client/github-installation-client.ts
+++ b/src/github/client/github-installation-client.ts
@@ -26,7 +26,7 @@ import {
 	ReposGetContentsResponse
 } from "./github-client.types";
 import { isChangedFilesError } from "./github-client-errors";
-import { GITHUB_ACCEPT_HEADER } from "utils/get-github-client-config";
+import { GITHUB_ACCEPT_HEADER } from "./github-client-constants";
 import { GitHubClient, GitHubConfig } from "./github-client";
 
 /**

--- a/src/github/client/github-installation-client.ts
+++ b/src/github/client/github-installation-client.ts
@@ -241,7 +241,7 @@ export class GitHubInstallationClient extends GitHubClient {
 		const config = await this.installationAuthenticationHeaders();
 		const response = await this.graphql<getBranchesResponse>(getBranchesQueryWithChangedFiles, config, variables)
 			.catch((err) => {
-				if (!isChangedFilesError(err)) {
+				if (!isChangedFilesError(this.logger, err)) {
 					return Promise.reject(err);
 				}
 
@@ -277,7 +277,7 @@ export class GitHubInstallationClient extends GitHubClient {
 		const config = await this.installationAuthenticationHeaders();
 		const response = await this.graphql<getCommitsResponse>(getCommitsQueryWithChangedFiles, config, variables)
 			.catch((err) => {
-				if (!isChangedFilesError(err)) {
+				if (!isChangedFilesError(this.logger, err)) {
 					return Promise.reject(err);
 				}
 				this.logger.warn("retrying commit graphql query without changedFiles");

--- a/src/github/client/github-user-client.ts
+++ b/src/github/client/github-user-client.ts
@@ -1,9 +1,6 @@
 import Logger from "bunyan";
 import { Octokit } from "@octokit/rest";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
-import { handleFailedRequest, instrumentFailedRequest, instrumentRequest, setRequestStartTime, setRequestTimeout } from "./github-client-interceptors";
-import { metricHttpRequest } from "config/metric-names";
-import { urlParamsMiddleware } from "utils/axios/url-params-middleware";
 import { GITHUB_ACCEPT_HEADER } from "utils/get-github-client-config";
 import { CreateReferenceBody } from "~/src/github/client/github-client.types";
 import { GitHubClient, GitHubConfig } from "./github-client";
@@ -34,19 +31,6 @@ export class GitHubUserClient extends GitHubClient {
 				}
 			};
 		});
-		this.axios.interceptors.request.use(setRequestStartTime);
-		this.axios.interceptors.request.use(setRequestTimeout);
-		this.axios.interceptors.request.use(urlParamsMiddleware);
-
-		this.axios.interceptors.response.use(
-			undefined,
-			handleFailedRequest(this.logger)
-		);
-
-		this.axios.interceptors.response.use(
-			instrumentRequest(metricHttpRequest.github, this.restApiUrl),
-			instrumentFailedRequest(metricHttpRequest.github, this.restApiUrl)
-		);
 	}
 
 	private async get<T>(url, config?: AxiosRequestConfig): Promise<AxiosResponse<T>> {

--- a/src/github/client/github-user-client.ts
+++ b/src/github/client/github-user-client.ts
@@ -17,7 +17,7 @@ import { GITHUB_ACCEPT_HEADER } from "./github-client-constants";
 export class GitHubUserClient extends GitHubClient {
 	private readonly userToken: string;
 
-	constructor(userToken: string, githubConfig: GitHubConfig, logger?: Logger) {
+	constructor(userToken: string, githubConfig: GitHubConfig, logger: Logger) {
 		super(githubConfig, logger);
 		this.userToken = userToken;
 

--- a/src/github/client/github-user-client.ts
+++ b/src/github/client/github-user-client.ts
@@ -1,7 +1,6 @@
 import Logger from "bunyan";
 import { Octokit } from "@octokit/rest";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
-import { GITHUB_ACCEPT_HEADER } from "utils/get-github-client-config";
 import { CreateReferenceBody } from "~/src/github/client/github-client.types";
 import { GitHubClient, GitHubConfig } from "./github-client";
 import {
@@ -10,6 +9,7 @@ import {
 	UserOrganizationsQuery,
 	UserOrganizationsResponse
 } from "~/src/github/client/github-queries";
+import { GITHUB_ACCEPT_HEADER } from "./github-client-constants";
 
 /**
  * A GitHub client that supports authentication as a GitHub User.

--- a/src/github/client/installation-id.ts
+++ b/src/github/client/installation-id.ts
@@ -1,5 +1,5 @@
 import { envVars }  from "config/env";
-import { GITHUB_CLOUD_API_BASEURL } from "utils/get-github-client-config";
+import { GITHUB_CLOUD_API_BASEURL } from "./github-client-constants";
 /**
  * An installation ID uniquely identifies an installation of a GitHub app across the (single) cloud instance
  * and (potentially many) GHE instances.

--- a/src/github/deployment.test.ts
+++ b/src/github/deployment.test.ts
@@ -1,9 +1,9 @@
 import { deploymentWebhookHandler } from "./deployment";
 import { WebhookContext } from "routes/github/webhook/webhook-context";
 import { getLogger } from "config/logger";
-import { GITHUB_CLOUD_BASEURL, GITHUB_CLOUD_API_BASEURL } from "utils/get-github-client-config";
 import { envVars } from "config/env";
 import { sqsQueues } from "../sqs/queues";
+import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL } from "~/src/github/client/github-client-constants";
 
 jest.mock("../sqs/queues");
 

--- a/src/github/push.test.ts
+++ b/src/github/push.test.ts
@@ -3,9 +3,9 @@ import { WebhookContext } from "routes/github/webhook/webhook-context";
 import { getLogger } from "config/logger";
 import { GitHubCommit, GitHubPushData, GitHubRepository } from "../interfaces/github";
 import { enqueuePush } from "../transforms/push";
-import { GITHUB_CLOUD_BASEURL, GITHUB_CLOUD_API_BASEURL } from "utils/get-github-client-config";
 import { envVars } from "config/env";
 import { Subscription } from "models/subscription";
+import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL } from "~/src/github/client/github-client-constants";
 
 jest.mock("../transforms/push");
 

--- a/src/middleware/github-server-app-middleware.ts
+++ b/src/middleware/github-server-app-middleware.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import { GitHubServerApp } from "models/github-server-app";
 import { Installation } from "models/installation";
 import { envVars } from "config/env";
-import { GITHUB_CLOUD_BASEURL } from "utils/get-github-client-config";
+import { GITHUB_CLOUD_BASEURL } from "~/src/github/client/github-client-constants";
 
 export const GithubServerAppMiddleware = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
 	const { jiraHost } = res.locals;

--- a/src/routes/github/webhook/webhook-receiver-post.test.ts
+++ b/src/routes/github/webhook/webhook-receiver-post.test.ts
@@ -10,8 +10,8 @@ import { deleteRepositoryWebhookHandler } from "~/src/github/repository";
 import { workflowWebhookHandler } from "~/src/github/workflow";
 import { deploymentWebhookHandler } from "~/src/github/deployment";
 import { codeScanningAlertWebhookHandler } from "~/src/github/code-scanning-alert";
-import { GITHUB_CLOUD_BASEURL, GITHUB_CLOUD_API_BASEURL } from "~/src/util/get-github-client-config";
 import { envVars } from "config/env";
+import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL } from "~/src/github/client/github-client-constants";
 
 jest.mock("~/src/middleware/github-webhook-middleware");
 

--- a/src/routes/github/webhook/webhook-receiver-post.ts
+++ b/src/routes/github/webhook/webhook-receiver-post.ts
@@ -15,8 +15,8 @@ import { deleteRepositoryWebhookHandler } from "~/src/github/repository";
 import { workflowWebhookHandler } from "~/src/github/workflow";
 import { deploymentWebhookHandler } from "~/src/github/deployment";
 import { codeScanningAlertWebhookHandler } from "~/src/github/code-scanning-alert";
-import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL } from "utils/get-github-client-config";
 import { getLogger } from "config/logger";
+import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL } from "~/src/github/client/github-client-constants";
 
 export const WebhookReceiverPost = async (request: Request, response: Response): Promise<void> => {
 	const eventName = request.headers["x-github-event"] as string;

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.test.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.test.ts
@@ -3,6 +3,7 @@ import { GitHubServerApp } from "models/github-server-app";
 import { JiraConnectEnterprisePost } from "routes/jira/connect/enterprise/jira-connect-enterprise-post";
 import { Installation } from "models/installation";
 import { v4 as newUUID } from "uuid";
+import { getLogger } from "config/logger";
 
 jest.mock("config/feature-flags");
 
@@ -11,12 +12,7 @@ const testSharedSecret = "test-secret";
 describe("POST /jira/connect/enterprise", () => {
 	let installation;
 	const mockRequest = (gheServerURL: string): any => ({
-		log: {
-			info: jest.fn(),
-			warn: jest.fn(),
-			error: jest.fn(),
-			debug: jest.fn()
-		},
+		log: getLogger("test"),
 		body: { gheServerURL },
 		query: {},
 		csrfToken: jest.fn().mockReturnValue({})

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.ts
@@ -6,6 +6,8 @@ import { metricError } from "config/metric-names";
 import { sendAnalytics } from "utils/analytics-client";
 import { AnalyticsEventTypes, AnalyticsTrackEventsEnum, AnalyticsTrackSource } from "interfaces/common";
 import { createAnonymousClient } from "utils/get-github-client-config";
+import { GithubClientError } from "~/src/github/client/github-client-errors";
+import { AxiosError } from "axios";
 
 const GITHUB_CLOUD_HOSTS = ["github.com", "www.github.com"];
 
@@ -68,17 +70,17 @@ export const JiraConnectEnterprisePost = async (
 		return;
 	}
 
+	const gitHubServerApps = await GitHubServerApp.getAllForGitHubBaseUrlAndInstallationId(gheServerURL, installationId);
+
+	if (gitHubServerApps?.length) {
+		req.log.debug(`GitHub apps found for url: ${gheServerURL}. Redirecting to Jira list apps page.`);
+		res.status(200).send({ success: true, appExists: true });
+		return;
+	}
+
+	req.log.debug(`No existing GitHub apps found for url: ${gheServerURL}. Making request to provided url.`);
+
 	try {
-		const gitHubServerApps = await GitHubServerApp.getAllForGitHubBaseUrlAndInstallationId(gheServerURL, installationId);
-
-		if (gitHubServerApps?.length) {
-			req.log.debug(`GitHub apps found for url: ${gheServerURL}. Redirecting to Jira list apps page.`);
-			res.status(200).send({ success: true, appExists: true });
-			return;
-		}
-
-		req.log.debug(`No existing GitHub apps found for url: ${gheServerURL}. Making request to provided url.`);
-
 		const client = await createAnonymousClient(gheServerURL, jiraHost, req.log);
 		await client.getMainPage(TIMEOUT_PERIOD_MS);
 		res.status(200).send({ success: true, appExists: false });
@@ -89,27 +91,42 @@ export const JiraConnectEnterprisePost = async (
 			jiraHost: jiraHost
 		});
 	} catch (err) {
-		req.log.warn({ err, gheServerURL }, `Couldn't access GHE host`);
-		const codeOrStatus = "" + (err.code || err.response.status);
+		const axiosError: AxiosError = (err instanceof GithubClientError) ? err.cause : err;
 
-		req.log.info({ err, gheServerURL }, `Couldn't access GHE host, result of whether skip the check is ${!err.code && err.response?.status}`);
-		if (!err.code && err.response?.status) {
-			//err.code means there's error on the tcp/https connection,
-			//err.status means traffic reach network, but server reject it.
-			//as long as there's no code and a status, means server returns something
-			//so the domain name is reachable, it is just it required some api tokens to be accessible,
-			//and we can bypass this check to allow the manual app creation.
+		//err.code means there's error on the tcp/https connection,
+		//err.status means traffic reach network, but server reject it.
+		//as long as there's no code and a status, means server returns something
+		//so the domain name is reachable, it is just it required some api tokens to be accessible,
+		//and we can bypass this check to allow the manual app creation.
+		const hasServerResponded = !axiosError.code && axiosError.response?.status;
+
+		req.log.info({ err, gheServerURL }, `Couldn't access GHE host, result of whether skip the check is ${hasServerResponded}`);
+		if (hasServerResponded) {
+			req.log.info({ err }, "Server is reachable, but responded with a status different from 200/202");
 			res.status(200).send({ success: true, appExists: false });
 			return;
 		}
 
+		const codeOrStatus = "" + (axiosError.code || axiosError.response?.status);
+		req.log.warn({ err, gheServerURL }, `Couldn't access GHE host`);
+
+		const reasons = [err.message];
+		reasons.push(axiosError.message || "");
+
+		reasons.push(
+			isInteger(codeOrStatus)
+				? `Received ${codeOrStatus} response.`
+				: codeOrStatus
+		);
+
 		res.status(200).send({
 			success: false, errors: [{
 				code: ErrorResponseCode.CANNOT_CONNECT,
-				reason:
-					isInteger(codeOrStatus)
-						? `received ${codeOrStatus} response`
-						: codeOrStatus
+				reason: reasons
+					.filter(item => !!item)
+					.map(reason =>
+						reason.trim().replace(/\.*$/, ""))
+					.join(". ")
 			}]
 		});
 		sendErrorMetricAndAnalytics(jiraHost, ErrorResponseCode.CANNOT_CONNECT, codeOrStatus);

--- a/src/sqs/error-handlers.test.ts
+++ b/src/sqs/error-handlers.test.ts
@@ -102,7 +102,15 @@ describe("error-handlers", () => {
 		it("Retryable with proper delay on Rate Limiting", async () => {
 			const headers: AxiosResponseHeaders = { "x-ratelimit-reset": `${Math.floor(new Date("2020-01-01").getTime() / 1000) + 100}` };
 			const mockedResponse = { status: 403, headers: headers } as AxiosResponse;
-			const result = await jiraAndGitHubErrorsHandler(new RateLimitingError(mockedResponse, { } as AxiosError), createContext(1, false));
+
+			const result = await jiraAndGitHubErrorsHandler(
+				new RateLimitingError({
+					response: mockedResponse
+				} as AxiosError),
+
+				createContext(1, false)
+			);
+
 			expect(result.retryable).toBe(true);
 			//Make sure delay is equal to recommended delay + 10 seconds
 			expect(result.retryDelaySec).toBe(110);

--- a/src/sqs/error-handlers.test.ts
+++ b/src/sqs/error-handlers.test.ts
@@ -5,7 +5,7 @@ import { getLogger } from "config/logger";
 import { JiraClientError } from "../jira/client/axios";
 import { Octokit } from "@octokit/rest";
 import { RateLimitingError } from "../github/client/github-client-errors";
-import { AxiosResponse, AxiosResponseHeaders } from "axios";
+import { AxiosError, AxiosResponse, AxiosResponseHeaders } from "axios";
 import { ErrorHandlingResult, SQSMessageContext } from "~/src/sqs/sqs.types";
 
 describe("error-handlers", () => {
@@ -102,7 +102,7 @@ describe("error-handlers", () => {
 		it("Retryable with proper delay on Rate Limiting", async () => {
 			const headers: AxiosResponseHeaders = { "x-ratelimit-reset": `${Math.floor(new Date("2020-01-01").getTime() / 1000) + 100}` };
 			const mockedResponse = { status: 403, headers: headers } as AxiosResponse;
-			const result = await jiraAndGitHubErrorsHandler(new RateLimitingError({}, mockedResponse), createContext(1, false));
+			const result = await jiraAndGitHubErrorsHandler(new RateLimitingError(mockedResponse, { } as AxiosError), createContext(1, false));
 			expect(result.retryable).toBe(true);
 			//Make sure delay is equal to recommended delay + 10 seconds
 			expect(result.retryDelaySec).toBe(110);

--- a/src/sync/installation.test.ts
+++ b/src/sync/installation.test.ts
@@ -11,6 +11,7 @@ import { Repository, Subscription } from "models/subscription";
 import { mockNotFoundErrorOctokitGraphql, mockNotFoundErrorOctokitRequest, mockOtherError, mockOtherOctokitGraphqlErrors, mockOtherOctokitRequestErrors } from "test/mocks/error-responses";
 import { v4 as UUID } from "uuid";
 import { ConnectionTimedOutError } from "sequelize";
+import { AxiosError } from "axios";
 
 jest.mock("../sqs/queues");
 const mockedExecuteWithDeduplication = jest.fn();
@@ -159,7 +160,7 @@ describe("sync/installation", () => {
 				config: {}
 			};
 
-			await handleBackfillError(new RateLimitingError({}, axiosResponse), JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
+			await handleBackfillError(new RateLimitingError(axiosResponse, { } as AxiosError), JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
 			expect(scheduleNextTask).toBeCalledWith(14322);
 			expect(updateStatusSpy).toHaveBeenCalledTimes(0);
 			expect(failRepoSpy).toHaveBeenCalledTimes(0);
@@ -178,7 +179,7 @@ describe("sync/installation", () => {
 				config: {}
 			};
 
-			await handleBackfillError(new RateLimitingError({}, axiosResponse), JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
+			await handleBackfillError(new RateLimitingError(axiosResponse, {} as AxiosError), JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
 			expect(scheduleNextTask).toBeCalledWith(0);
 			expect(updateStatusSpy).toHaveBeenCalledTimes(0);
 			expect(failRepoSpy).toHaveBeenCalledTimes(0);

--- a/src/sync/installation.test.ts
+++ b/src/sync/installation.test.ts
@@ -160,7 +160,13 @@ describe("sync/installation", () => {
 				config: {}
 			};
 
-			await handleBackfillError(new RateLimitingError(axiosResponse, { } as AxiosError), JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
+			await handleBackfillError(
+				new RateLimitingError(
+					{ response: axiosResponse } as unknown as AxiosError
+				),
+				JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask
+			);
+
 			expect(scheduleNextTask).toBeCalledWith(14322);
 			expect(updateStatusSpy).toHaveBeenCalledTimes(0);
 			expect(failRepoSpy).toHaveBeenCalledTimes(0);
@@ -179,7 +185,9 @@ describe("sync/installation", () => {
 				config: {}
 			};
 
-			await handleBackfillError(new RateLimitingError(axiosResponse, {} as AxiosError), JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
+			await handleBackfillError(new RateLimitingError({
+				response: axiosResponse
+			} as unknown as AxiosError), JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
 			expect(scheduleNextTask).toBeCalledWith(0);
 			expect(updateStatusSpy).toHaveBeenCalledTimes(0);
 			expect(failRepoSpy).toHaveBeenCalledTimes(0);

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -218,7 +218,12 @@ const doProcessInstallation = async (data: BackfillMessagePayload, sentry: Hub, 
 
 	const { task, cursor, repository } = nextTask;
 
-	const logger = rootLogger.child({ task: nextTask, gitHubProduct });
+	const logger = rootLogger.child({
+		task: nextTask,
+		gitHubProduct,
+		startTime: data.startTime,
+		commitsFromDate: data.commitsFromDate
+	});
 
 	logger.info("Starting task");
 

--- a/src/sync/sync-utils.test.ts
+++ b/src/sync/sync-utils.test.ts
@@ -5,7 +5,7 @@ import { GitHubServerApp } from "models/github-server-app";
 import { getLogger } from "config/logger";
 import { v4 as uuid } from "uuid";
 import { envVars } from "config/env";
-import { GITHUB_CLOUD_BASEURL, GITHUB_CLOUD_API_BASEURL } from "utils/get-github-client-config";
+import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL } from "~/src/github/client/github-client-constants";
 
 jest.mock("../sqs/queues");
 

--- a/src/sync/sync-utils.ts
+++ b/src/sync/sync-utils.ts
@@ -6,8 +6,8 @@ import { numberFlag, NumberFlags } from "config/feature-flags";
 import { TaskType } from "~/src/sync/sync.types";
 import { GitHubAppConfig } from "~/src/sqs/sqs.types";
 import { envVars } from "config/env";
-import { GITHUB_CLOUD_BASEURL, GITHUB_CLOUD_API_BASEURL } from "utils/get-github-client-config";
 import { GitHubServerApp } from "models/github-server-app";
+import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL } from "~/src/github/client/github-client-constants";
 
 type SyncType = "full" | "partial";
 

--- a/src/transforms/transform-repository-id.test.ts
+++ b/src/transforms/transform-repository-id.test.ts
@@ -1,5 +1,5 @@
 import { transformRepositoryId } from "~/src/transforms/transform-repository-id";
-import { GITHUB_CLOUD_BASEURL } from "utils/get-github-client-config";
+import { GITHUB_CLOUD_BASEURL } from "~/src/github/client/github-client-constants";
 
 describe("transform-repository-id", () => {
 

--- a/src/transforms/transform-repository-id.ts
+++ b/src/transforms/transform-repository-id.ts
@@ -1,4 +1,4 @@
-import { GITHUB_CLOUD_BASEURL } from "utils/get-github-client-config";
+import { GITHUB_CLOUD_BASEURL } from "~/src/github/client/github-client-constants";
 
 declare const transformedRepositoryId: unique symbol;
 

--- a/src/util/get-cloud-or-server.ts
+++ b/src/util/get-cloud-or-server.ts
@@ -1,4 +1,4 @@
-import { GITHUB_CLOUD_API_BASEURL } from "utils/get-github-client-config";
+import { GITHUB_CLOUD_API_BASEURL } from "~/src/github/client/github-client-constants";
 
 export const getCloudOrServerFromGitHubAppId = (gitHubAppId: number | undefined) => gitHubAppId ? "server" : "cloud";
 export const getCloudOrServerFromHost = (host: string) => GITHUB_CLOUD_API_BASEURL.includes(host) ? "cloud" : "server";

--- a/src/util/get-github-client-config.ts
+++ b/src/util/get-github-client-config.ts
@@ -10,11 +10,7 @@ import { keyLocator } from "~/src/github/client/key-locator";
 import { GitHubClientApiKeyConfig, GitHubConfig } from "~/src/github/client/github-client";
 import { GitHubAnonymousClient } from "~/src/github/client/github-anonymous-client";
 import { EncryptionClient } from "utils/encryption-client";
-
-export const GITHUB_CLOUD_HOSTNAME = "github.com";
-export const GITHUB_CLOUD_BASEURL = "https://github.com";
-export const GITHUB_CLOUD_API_BASEURL = "https://api.github.com";
-export const GITHUB_ACCEPT_HEADER = "application/vnd.github.v3+json";
+import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL, GITHUB_CLOUD_HOSTNAME } from "~/src/github/client/github-client-constants";
 
 interface GitHubClientConfig extends GitHubConfig {
 	serverId?: number;

--- a/src/util/get-github-client-config.ts
+++ b/src/util/get-github-client-config.ts
@@ -164,10 +164,10 @@ export const createUserClient = async (githubToken: string, jiraHost: string, lo
 };
 
 export const createAnonymousClient = async (gitHubBaseUrl: string, jiraHost: string, logger: Logger): Promise<GitHubAnonymousClient> => {
-	return new GitHubAnonymousClient(await buildGitHubServerConfig(gitHubBaseUrl, jiraHost, logger));
+	return new GitHubAnonymousClient(await buildGitHubServerConfig(gitHubBaseUrl, jiraHost, logger), logger);
 };
 
 export const createAnonymousClientByGitHubAppId = async (gitHubAppId: number | undefined, jiraHost: string, logger: Logger): Promise<GitHubAnonymousClient> => {
 	const config = await getGitHubClientConfigFromAppId(gitHubAppId, logger, jiraHost);
-	return new GitHubAnonymousClient(config);
+	return new GitHubAnonymousClient(config, logger);
 };

--- a/src/util/github-utils.test.ts
+++ b/src/util/github-utils.test.ts
@@ -7,7 +7,7 @@ describe("GitHub Utils", () => {
 	describe("isUserAdminOfOrganization", () => {
 		let githubUserClient: GitHubUserClient;
 		beforeEach(() => {
-			githubUserClient = new GitHubUserClient("token", gitHubCloudConfig);
+			githubUserClient = new GitHubUserClient("token", gitHubCloudConfig, getLogger("test"));
 		});
 
 		it("should return true if user is admin of a given organization", async () => {


### PR DESCRIPTION
**What's in this PR?**
 - remove extra fields from Error exceptions because they are accessible from cause
 - make cause mandatory for all GitHub errors - there MUST be an Axios cause! The only exception is GraphQL error (when server responds with 200), adding a stub "cause" 
 - moving error interceptors from individual clients to the base client
 - improve logging: serialiser, adding tests etc

