### PR TITLE
Just let go if rate limit check failed

### DIFF
--- a/src/util/preemptive-rate-limit.ts
+++ b/src/util/preemptive-rate-limit.ts
@@ -27,12 +27,15 @@ export const preemptiveRateLimitCheck = async (context: SQSMessageContext<any>, 
 			// Delay the message until rate limit has reset
 			await sqsQueue.changeVisibilityTimeout(context.message, getRateResetTime(rateLimitResponse, context.log), context.log);
 			return true;
+		} else {
+			return false;
 		}
 	} catch (err) {
 		context.log.error({ err, gitHubServerAppId: context.payload.gitHubAppConfig?.gitHubAppId }, "Failed to fetch Rate Limit");
+		//something wrong checking the rate-limit, so to be safe, just let it continue
+		return true;
 	}
 
-	return false;
 };
 
 const getRateRateLimitStatus = async (context: SQSMessageContext<any>) => {


### PR DESCRIPTION
**What's in this PR?**
Allow sqs to continue process msg when rate limit check fail.

**Why**
So not to block processing.

**Added feature flags**
N/A

**Affected issues**  
N/A

**How has this been tested?**  
Unit test.

**Whats Next?**
N/A
