### PR TITLE
NONE: add more logs to preemptive rate-limit

### DIFF
--- a/src/util/preemptive-rate-limit.ts
+++ b/src/util/preemptive-rate-limit.ts
@@ -47,6 +47,6 @@ const getRateResetTime = (rateLimitResponse: Octokit.RateLimitGetResponse, log: 
 	const resetEpochDateTime = Math.max(rateLimitResponse?.resources?.core?.reset, rateLimitResponse?.resources?.graphql?.reset);
 	// Get the difference in seconds between now and reset time
 	const timeToResetInSeconds = resetEpochDateTime - (Date.now()/1000);
-	log.info({ timeToResetInSeconds }, "Preemptive rate limit reset time");
+	log.info({ rateLimitResponse, timeToResetInSeconds }, "Preemptive rate limit reset time");
 	return timeToResetInSeconds;
 };


### PR DESCRIPTION
**What's in this PR?**
Adding more logs to preemptive rate limiting

**Why**
Looks like sometimes we calculate reset time to negative value, which exhausts the retries and makes the sync stuck 😬 

<img width="500" alt="image" src="https://user-images.githubusercontent.com/20631664/222031224-4fae5db2-fa30-45a9-9c1e-9b022e93f035.png">

<img width="500" alt="image" src="https://user-images.githubusercontent.com/20631664/222031310-bbea2a42-4d44-45f9-9c40-a39ca3568c93.png">


