### PR TITLE
ARC-1730 Fix the reposyncstate bulk update duplicate issue

### DIFF
--- a/src/models/reposyncstate.ts
+++ b/src/models/reposyncstate.ts
@@ -156,6 +156,30 @@ export class RepoSyncState extends Model {
 			}
 		});
 	}
+
+	static async bulkCreateOrUpdateByRepos(
+		subscriptionId: number,
+		repositories: {
+			repoId: number,
+			repoName: string,
+			repoFullName: string,
+			repoOwner: string,
+			repoUrl: string,
+			repoUpdatedAt: Date
+		}[]
+	): Promise<RepoSyncState[]> {
+		return Promise.all(repositories.map(repo => {
+			return RepoSyncState.findOrCreate({
+				where: {
+					subscriptionId,
+					repoId: repo.repoId
+				},
+				defaults: {
+					...repo
+				}
+			}).then((r: [RepoSyncState, boolean]) => r[0]);
+		}));
+	}
 }
 
 RepoSyncState.init({

--- a/src/sync/discovery.ts
+++ b/src/sync/discovery.ts
@@ -60,15 +60,14 @@ export const getRepositoryTask = async (
 	}
 
 	await subscription.update({ totalNumberOfRepos: totalCount });
-	const createdRepoSyncStates = await RepoSyncState.bulkCreate(repositories.map(repo => ({
-		subscriptionId: subscription.id,
+	const createdRepoSyncStates = await RepoSyncState.bulkCreateOrUpdateByRepos(subscription.id, repositories.map(repo => ({
 		repoId: repo.id,
 		repoName: repo.name,
 		repoFullName: repo.full_name,
 		repoOwner: repo.owner.login,
 		repoUrl: repo.html_url,
 		repoUpdatedAt: new Date(repo.updated_at)
-	})), { updateOnDuplicate: ["subscriptionId", "repoId"] });
+	})));
 
 	logger.debug({
 		repositories,


### PR DESCRIPTION
**What's in this PR?**
Convert the buggy bulkUpdateOrCreate to a more simple loop and discovering repos in backfill

**Why**
Partial backfill has some bug that duplicate the RepoSyncStates in some cases.

**Added feature flags**
N/A

**Affected issues**  
ARC-1730

**How has this been tested?**  
Unit test

**Whats Next?**
N/A