### PR TITLE
ARC-1975 promote commitsFromDate into msg body

### DIFF
--- a/src/sync/commits.test.ts
+++ b/src/sync/commits.test.ts
@@ -8,8 +8,6 @@ import { BackfillMessagePayload } from "../sqs/sqs.types";
 import commitNodesFixture from "fixtures/api/graphql/commit-nodes.json";
 import mixedCommitNodes from "fixtures/api/graphql/commit-nodes-mixed.json";
 import commitsNoKeys from "fixtures/api/graphql/commit-nodes-no-keys.json";
-import { when } from "jest-when";
-import { numberFlag, NumberFlags } from "config/feature-flags";
 import { getCommitsQueryWithChangedFiles } from "~/src/github/client/github-queries";
 import { waitUntil } from "test/utils/wait-until";
 import { GitHubServerApp } from "models/github-server-app";
@@ -207,87 +205,6 @@ describe("sync/commits", () => {
 			removeInterceptor(interceptor);
 		});
 
-		describe("SYNC_MAIN_COMMIT_TIME_LIMIT FF is enabled", () => {
-			let dateCutoff: Date;
-			beforeEach(() => {
-				const time = Date.now();
-				const cutoff = 1000 * 60 * 60 * 24;
-				mockSystemTime(time);
-				dateCutoff = new Date(time - cutoff);
-
-				when(numberFlag).calledWith(
-					NumberFlags.SYNC_MAIN_COMMIT_TIME_LIMIT,
-					expect.anything(),
-					expect.anything()
-				).mockResolvedValue(cutoff);
-			});
-
-			it("should only get commits since date specified", async () => {
-				const data: BackfillMessagePayload = { installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost };
-
-				createGitHubNock(commitNodesFixture, { commitSince: dateCutoff.toISOString() });
-				const commits = [
-					{
-						"author": {
-							"name": "test-author-name",
-							"email": "test-author-email@example.com"
-						},
-						"authorTimestamp": "test-authored-date",
-						"displayId": "test-o",
-						"fileCount": 0,
-						"hash": "test-oid",
-						"id": "test-oid",
-						"issueKeys": [
-							"TES-17"
-						],
-						"message": "[TES-17] test-commit-message",
-						"url": "https://github.com/test-login/test-repo/commit/test-sha",
-						"updateSequenceId": 12345678
-					}
-				];
-				createJiraNock(commits);
-
-				await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
-				await verifyMessageSent(data);
-			});
-
-
-			describe("Commit history value is passed", () => {
-				it("should use commit history depth parameter before feature flag time", async () => {
-
-					const time = Date.now();
-					const commitTimeLimitCutoff = 1000 * 60 * 60 * 72;
-					mockSystemTime(time);
-					const commitsFromDate = new Date(time - commitTimeLimitCutoff).toISOString();
-					const data: BackfillMessagePayload = { installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, commitsFromDate };
-
-					createGitHubNock(commitNodesFixture, { commitSince: commitsFromDate });
-					const commits = [
-						{
-							"author": {
-								"name": "test-author-name",
-								"email": "test-author-email@example.com"
-							},
-							"authorTimestamp": "test-authored-date",
-							"displayId": "test-o",
-							"fileCount": 0,
-							"hash": "test-oid",
-							"id": "test-oid",
-							"issueKeys": [
-								"TES-17"
-							],
-							"message": "[TES-17] test-commit-message",
-							"url": "https://github.com/test-login/test-repo/commit/test-sha",
-							"updateSequenceId": 12345678
-						}
-					];
-					createJiraNock(commits);
-
-					await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
-					await verifyMessageSent(data);
-				});
-			});
-		});
 	});
 
 	describe("for server",  () => {

--- a/src/sync/commits.ts
+++ b/src/sync/commits.ts
@@ -4,9 +4,7 @@ import { GitHubInstallationClient } from "../github/client/github-installation-c
 import Logger from "bunyan";
 import { CommitQueryNode } from "../github/client/github-queries";
 import { JiraCommitBulkSubmitData } from "src/interfaces/jira";
-import { NumberFlags } from "config/feature-flags";
 import { BackfillMessagePayload } from "~/src/sqs/sqs.types";
-import { getCommitSinceDate } from "~/src/sync/sync-utils";
 import { TaskPayload } from "~/src/sync/sync.types";
 
 const fetchCommits = async (gitHubClient: GitHubInstallationClient, repository: Repository, commitSince?: Date, cursor?: string | number, perPage?: number) => {
@@ -23,13 +21,13 @@ const fetchCommits = async (gitHubClient: GitHubInstallationClient, repository: 
 export const getCommitTask = async (
 	logger: Logger,
 	gitHubClient: GitHubInstallationClient,
-	jiraHost: string,
+	_jiraHost: string,
 	repository: Repository,
 	cursor?: string | number,
 	perPage?: number,
 	messagePayload?: BackfillMessagePayload): Promise<TaskPayload<CommitQueryNode, JiraCommitBulkSubmitData>> => {
 
-	const commitSince = await getCommitSinceDate(jiraHost, NumberFlags.SYNC_MAIN_COMMIT_TIME_LIMIT, messagePayload?.commitsFromDate);
+	const commitSince = messagePayload?.commitsFromDate ? new Date(messagePayload.commitsFromDate) : undefined;
 	const { edges, commits } = await fetchCommits(gitHubClient, repository, commitSince, cursor, perPage);
 	const jiraPayload = transformCommit(
 		{ commits, repository },

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -12,7 +12,7 @@ import { getCommitTask } from "./commits";
 import { getBuildTask } from "./build";
 import { getDeploymentTask } from "./deployment";
 import { metricSyncStatus, metricTaskStatus } from "config/metric-names";
-import { isBlocked, NumberFlags } from "config/feature-flags";
+import { isBlocked } from "config/feature-flags";
 import { Deduplicator, DeduplicatorResult, RedisInProgressStorageWithTimeout } from "./deduplicator";
 import { getRedisInfo } from "config/redis-info";
 import { BackfillMessagePayload } from "../sqs/sqs.types";
@@ -24,7 +24,6 @@ import { createInstallationClient } from "~/src/util/get-github-client-config";
 import { getCloudOrServerFromGitHubAppId } from "utils/get-cloud-or-server";
 import { Task, TaskPayload, TaskProcessors, TaskType } from "./sync.types";
 import { ConnectionTimedOutError } from "sequelize";
-import { getCommitSinceDate } from "~/src/sync/sync-utils";
 import { calcNewBackfillSinceDate } from "~/src/sync/backfill-since-date-calc";
 
 const tasks: TaskProcessors = {
@@ -516,7 +515,7 @@ const updateRepo = async (subscription: Subscription, repoId: number, values: Re
 };
 
 const getBackfillSince = async (subscription: Subscription, data: BackfillMessagePayload): Promise<Date | null> => {
-	const commitSince = await getCommitSinceDate(data.jiraHost, NumberFlags.SYNC_MAIN_COMMIT_TIME_LIMIT, data.commitsFromDate);
+	const commitSince = data.commitsFromDate ? new Date(data.commitsFromDate) : undefined;
 	const backfillSinceDateToSave = calcNewBackfillSinceDate(subscription.backfillSince, commitSince, data.syncType, data.isInitialSync);
 	//set it to null on falsy value so that we can override db with sequlize
 	return backfillSinceDateToSave || null;

--- a/src/sync/sync-utils.test.ts
+++ b/src/sync/sync-utils.test.ts
@@ -6,10 +6,49 @@ import { getLogger } from "config/logger";
 import { v4 as uuid } from "uuid";
 import { envVars } from "config/env";
 import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL } from "~/src/github/client/github-client-constants";
+import { numberFlag, NumberFlags } from "config/feature-flags";
+import { when } from "jest-when";
 
 jest.mock("../sqs/queues");
+jest.mock("config/feature-flags");
+
+const DATE_NOW = new Date("2023-03-04T05:06:07.000Z");
+jest.useFakeTimers().setSystemTime(DATE_NOW);
 
 describe("findOrStartSync", () => {
+	describe("Syncing logic", () => {
+		const JIRA_INSTALLATION_ID = 1111;
+		const JIRA_CLIENT_KEY = "jira-client-key";
+		const CUTOFF_IN_MSECS = 1000;
+		describe("commit since date", () => {
+			let subscription: Subscription;
+			beforeEach(async () => {
+				subscription = await Subscription.install({
+					installationId: JIRA_INSTALLATION_ID,
+					host: jiraHost,
+					hashedClientKey: JIRA_CLIENT_KEY,
+					gitHubAppId: undefined
+				});
+			});
+			it("should send a specific commit since date in the msg payload if provided", async () => {
+				const providedCommitSinceDate = new Date();
+				await findOrStartSync(subscription, getLogger("test"), true, undefined, providedCommitSinceDate, undefined);
+				expect(sqsQueues.backfill.sendMessage).toBeCalledWith(
+					expect.objectContaining({ commitsFromDate: providedCommitSinceDate.toISOString() }),
+					expect.anything(), expect.anything());
+			});
+			it("should send a specific commit since date in the msg payload even if not provided", async () => {
+				when(jest.mocked(numberFlag))
+					.calledWith(NumberFlags.SYNC_MAIN_COMMIT_TIME_LIMIT, expect.anything(), jiraHost)
+					.mockResolvedValue(CUTOFF_IN_MSECS);
+				const targetCommitsFromDate = new Date(DATE_NOW.getTime() - CUTOFF_IN_MSECS);
+				await findOrStartSync(subscription, getLogger("test"), true, undefined, undefined, undefined);
+				expect(sqsQueues.backfill.sendMessage).toBeCalledWith(
+					expect.objectContaining({ commitsFromDate: targetCommitsFromDate.toISOString() }),
+					expect.anything(), expect.anything());
+			});
+		});
+	});
 	describe("GitHubAppConfig", () => {
 		const JIRA_INSTALLATION_ID = 1111;
 		const JIRA_CLIENT_KEY = "jira-client-key";

--- a/src/sync/sync-utils.ts
+++ b/src/sync/sync-utils.ts
@@ -42,6 +42,8 @@ export const findOrStartSync = async (
 
 	const gitHubAppConfig = await getGitHubAppConfig(subscription, logger);
 
+	const finalCommitsFromDate = await getCommitSinceDate(jiraHost, NumberFlags.SYNC_MAIN_COMMIT_TIME_LIMIT, commitsFromDate?.toISOString());
+
 	// Start sync
 	await sqsQueues.backfill.sendMessage({
 		installationId,
@@ -49,7 +51,7 @@ export const findOrStartSync = async (
 		isInitialSync,
 		syncType,
 		startTime: fullSyncStartTime,
-		commitsFromDate: commitsFromDate?.toISOString(),
+		commitsFromDate: finalCommitsFromDate?.toISOString(),
 		targetTasks,
 		gitHubAppConfig
 	}, 0, logger);


### PR DESCRIPTION
**What's in this PR?**
Promote the commitsSince date into msg body, so that they are calculated in WebServer instead of Worker.

**Why**
1. Explicit is always better than implicit.
2. We can apply more field, like commitsToDate in to msg body.

**Added feature flags**
N/A

**Affected issues**  
ARC-1975

**How has this been tested?**  
Unit Test

**Whats Next?**
Might want to remove the branch commits date ff.
