### PR TITLE
NONE: add coef for page size for builds

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -34,7 +34,8 @@ export enum NumberFlags {
 	GITHUB_CLIENT_TIMEOUT = "github-client-timeout",
 	SYNC_MAIN_COMMIT_TIME_LIMIT = "sync-main-commit-time-limit",
 	SYNC_BRANCH_COMMIT_TIME_LIMIT = "sync-branch-commit-time-limit",
-	PREEMPTIVE_RATE_LIMIT_THRESHOLD = "preemptive-rate-limit-threshold"
+	PREEMPTIVE_RATE_LIMIT_THRESHOLD = "preemptive-rate-limit-threshold",
+	INCREASE_BUILDS_PAGE_SIZE_COEF = "increase-builds-page-size-coef"
 }
 
 const createLaunchdarklyUser = (key?: string): LDUser => {

--- a/src/sync/build.test.ts
+++ b/src/sync/build.test.ts
@@ -11,8 +11,13 @@ import multiBuildFixture from "fixtures/api/build-multi.json";
 import noKeysBuildFixture from "fixtures/api/build-no-keys.json";
 import compareReferencesFixture from "fixtures/api/compare-references.json";
 import { DatabaseStateCreator } from "test/utils/database-state-creator";
+import { when } from "jest-when";
+import { numberFlag, NumberFlags } from "config/feature-flags";
+import { RepoSyncState } from "models/reposyncstate";
+
 
 jest.mock("../sqs/queues");
+jest.mock("config/feature-flags");
 
 describe("sync/builds", () => {
 	const sentry: Hub = { setUser: jest.fn() } as any;
@@ -33,14 +38,17 @@ describe("sync/builds", () => {
 			.reply(200);
 	};
 
+	let repoSyncState: RepoSyncState;
+
 	beforeEach(async () => {
 
 		mockSystemTime(12345678);
 
-		await new DatabaseStateCreator()
+		repoSyncState = (await new DatabaseStateCreator()
 			.withActiveRepoSyncState()
 			.repoSyncStatePendingForBuilds()
-			.create();
+			.withBuildsCustomCursor("10")
+			.create()).repoSyncState!;
 
 		jest.mocked(sqsQueues.backfill.sendMessage).mockResolvedValue();
 	});
@@ -52,7 +60,7 @@ describe("sync/builds", () => {
 		githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 
 		githubNock
-			.get(`/repos/integrations/test-repo-name/actions/runs?per_page=20&page=1`)
+			.get(`/repos/integrations/test-repo-name/actions/runs?per_page=20&page=10`)
 			.reply(200, buildFixture);
 
 		githubNock.get(`/repos/integrations/integration-test-jira/compare/BASE_REF...HEAD_REF`)
@@ -90,6 +98,36 @@ describe("sync/builds", () => {
 		expect(sqsQueues.backfill.sendMessage).toBeCalledWith(data, 0, expect.anything());
 	});
 
+	it("should use updated per_page and cursor when FF is ON", async () => {
+
+		when(numberFlag).calledWith(
+			NumberFlags.INCREASE_BUILDS_PAGE_SIZE_COEF,
+			expect.anything(),
+			expect.anything()
+		).mockResolvedValue(5);
+
+		const data: BackfillMessagePayload = { installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost };
+
+		githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
+		githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
+
+		const nock = githubNock
+			.get(`/repos/integrations/test-repo-name/actions/runs?per_page=100&page=2`)
+			.reply(200, buildFixture);
+
+		githubNock.get(`/repos/integrations/integration-test-jira/compare/BASE_REF...HEAD_REF`)
+			.reply(200, compareReferencesFixture);
+
+		jiraNock
+			.post("/rest/builds/0.1/bulk")
+			.reply(200);
+
+		await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+		expect(sqsQueues.backfill.sendMessage).toBeCalledWith(data, 0, expect.anything());
+		expect(nock.isDone()).toBeTruthy();
+		expect((await RepoSyncState.findByPk(repoSyncState!.id)).buildCursor).toEqual("15");
+	});
+
 	it("should sync multiple builds to Jira when they contain issue keys", async () => {
 		const data: BackfillMessagePayload = { installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost };
 
@@ -97,7 +135,7 @@ describe("sync/builds", () => {
 		githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 
 		githubNock
-			.get(`/repos/integrations/test-repo-name/actions/runs?per_page=20&page=1`)
+			.get(`/repos/integrations/test-repo-name/actions/runs?per_page=20&page=10`)
 			.reply(200, multiBuildFixture);
 
 		githubNock.get(`/repos/integrations/integration-test-jira/compare/BASE_REF...HEAD_REF`)
@@ -167,7 +205,7 @@ describe("sync/builds", () => {
 		githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 
 		githubNock
-			.get(`/repos/integrations/test-repo-name/actions/runs?per_page=20&page=1`)
+			.get(`/repos/integrations/test-repo-name/actions/runs?per_page=20&page=10`)
 			.reply(200, noKeysBuildFixture);
 
 		githubNock.get(`/repos/integrations/integration-test-jira/compare/BASE_REF...HEAD_REF`)
@@ -188,7 +226,7 @@ describe("sync/builds", () => {
 
 		githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 		githubNock
-			.get(`/repos/integrations/test-repo-name/actions/runs?per_page=20&page=1`)
+			.get(`/repos/integrations/test-repo-name/actions/runs?per_page=20&page=10`)
 			.reply(200, {});
 
 		const interceptor = jiraNock.post(/.*/);

--- a/src/sync/sync.types.ts
+++ b/src/sync/sync.types.ts
@@ -14,9 +14,9 @@ export interface TaskProcessors {
 		gitHubInstallationClient: GitHubInstallationClient,
 		jiraHost: string,
 		repository: Repository,
-		cursor?: string | number,
-		perPage?: number,
-		messagePayload?: BackfillMessagePayload
+		cursor: string | number | undefined,
+		perPage: number,
+		messagePayload: BackfillMessagePayload
 	) => Promise<TaskPayload>;
 }
 

--- a/test/utils/database-state-creator.ts
+++ b/test/utils/database-state-creator.ts
@@ -22,6 +22,8 @@ export class DatabaseStateCreator {
 	private pendingForBuilds: boolean;
 	private pendingForDeployments: boolean;
 
+	private buildsCustomCursor: string | undefined;
+
 	public static GITHUB_INSTALLATION_ID = 111222;
 
 	public forServer() {
@@ -51,6 +53,11 @@ export class DatabaseStateCreator {
 
 	public repoSyncStatePendingForBuilds() {
 		this.pendingForBuilds = true;
+		return this;
+	}
+
+	public withBuildsCustomCursor(cursor: string) {
+		this.buildsCustomCursor = cursor;
 		return this;
 	}
 
@@ -106,6 +113,7 @@ export class DatabaseStateCreator {
 			pullStatus: this.pendingForPrs ? "pending" : "complete",
 			buildStatus: this.pendingForBuilds ? "pending" : "complete",
 			deploymentStatus: this.pendingForDeployments ? "pending" : "complete",
+			... (this.buildsCustomCursor ? { buildCursor: this.buildsCustomCursor } : { }),
 			updatedAt: new Date(),
 			createdAt: new Date()
 		}) : undefined;


### PR DESCRIPTION
**What's in this PR?**
Increaseing page size for builds: a sync is going on forever for one particular customer

**Why**
I'd like to see how the changed page size affects the speed of the sync. 

**Added feature flags**
- increase-builds-page-size-coef

