### PR TITLE
Arc 1995 keep msg in queue for exceed ratelimit

### DIFF
--- a/src/sqs/sqs.ts
+++ b/src/sqs/sqs.ts
@@ -82,7 +82,7 @@ export class SqsQueue<MessagePayload extends BaseMessagePayload> {
 
 		const sendMessageResult = await this.sqs.sendMessage(params)
 			.promise();
-		logger.info({ delaySeconds: delaySec, messageId: sendMessageResult.MessageId }, `Successfully added message to sqs queue messageId: ${sendMessageResult.MessageId}`);
+		logger.info({ delaySeconds: delaySec, newMessageId: sendMessageResult.MessageId }, `Successfully added message to sqs queue messageId: ${sendMessageResult.MessageId}`);
 		statsd.increment(sqsQueueMetrics.sent, this.metricsTags);
 		return sendMessageResult;
 	}

--- a/src/sqs/sqs.ts
+++ b/src/sqs/sqs.ts
@@ -82,7 +82,7 @@ export class SqsQueue<MessagePayload extends BaseMessagePayload> {
 
 		const sendMessageResult = await this.sqs.sendMessage(params)
 			.promise();
-		logger.info(`Successfully added message to sqs queue messageId: ${sendMessageResult.MessageId}`);
+		logger.info({ DelaySeconds: delaySec, MessageId: sendMessageResult.MessageId }, `Successfully added message to sqs queue messageId: ${sendMessageResult.MessageId}`);
 		statsd.increment(sqsQueueMetrics.sent, this.metricsTags);
 		return sendMessageResult;
 	}

--- a/src/sqs/sqs.types.ts
+++ b/src/sqs/sqs.types.ts
@@ -124,12 +124,12 @@ export type BaseMessagePayload = {
 	jiraHost: string,
 	installationId: number,
 	gitHubAppConfig?: GitHubAppConfig, //undefined for cloud
+	webhookId?: string,
 }
 
 export type BranchMessagePayload = BaseMessagePayload & {
 	webhookReceived: number,
 	webhookId: string,
-
 	// The original webhook payload from GitHub. We don't need to worry about the SQS size limit because metrics show
 	// that payload size for deployment_status webhooks maxes out at 9KB.
 	webhookPayload: WebhookPayloadCreate,
@@ -146,7 +146,6 @@ export type BackfillMessagePayload = BaseMessagePayload & {
 export type DeploymentMessagePayload = BaseMessagePayload & {
 	webhookReceived: number,
 	webhookId: string,
-
 	// The original webhook payload from GitHub. We don't need to worry about the SQS size limit because metrics show
 	// that payload size for deployment_status webhooks maxes out at 13KB.
 	webhookPayload: WebhookPayloadDeploymentStatus,

--- a/src/sqs/sqs.types.ts
+++ b/src/sqs/sqs.types.ts
@@ -120,10 +120,13 @@ export interface SQSContext {
 	log: Logger;
 }
 
-export type BranchMessagePayload = {
+export type BaseMessagePayload = {
 	jiraHost: string,
 	installationId: number,
 	gitHubAppConfig?: GitHubAppConfig, //undefined for cloud
+}
+
+export type BranchMessagePayload = BaseMessagePayload & {
 	webhookReceived: number,
 	webhookId: string,
 
@@ -132,21 +135,15 @@ export type BranchMessagePayload = {
 	webhookPayload: WebhookPayloadCreate,
 }
 
-export type BackfillMessagePayload = {
-	jiraHost: string,
-	installationId: number,
+export type BackfillMessagePayload = BaseMessagePayload & {
 	isInitialSync?: boolean,
 	syncType?: SyncType,
-	gitHubAppConfig?: GitHubAppConfig, //undefined for cloud
 	startTime?: string,
 	commitsFromDate?: string,
 	targetTasks?: TaskType[]
 }
 
-export type DeploymentMessagePayload = {
-	jiraHost: string,
-	installationId: number,
-	gitHubAppConfig?: GitHubAppConfig, //undefined for cloud
+export type DeploymentMessagePayload = BaseMessagePayload & {
 	webhookReceived: number,
 	webhookId: string,
 
@@ -155,10 +152,7 @@ export type DeploymentMessagePayload = {
 	webhookPayload: WebhookPayloadDeploymentStatus,
 }
 
-export type PushQueueMessagePayload = {
-	jiraHost: string,
-	installationId: number,
-	gitHubAppConfig?: GitHubAppConfig, //undefined for cloud
+export type PushQueueMessagePayload = BaseMessagePayload & {
 	repository: PayloadRepository,
 	shas: { id: string, issueKeys: string[] }[],
 	webhookId: string,

--- a/src/sync/branch.test.ts
+++ b/src/sync/branch.test.ts
@@ -135,7 +135,6 @@ describe("sync/branches", () => {
 				.repoSyncStatePendingForBranches()
 				.create();
 
-			mocked(sqsQueues.backfill.sendMessage).mockResolvedValue(Promise.resolve());
 			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 
 		});

--- a/src/sync/build.test.ts
+++ b/src/sync/build.test.ts
@@ -42,7 +42,6 @@ describe("sync/builds", () => {
 			.repoSyncStatePendingForBuilds()
 			.create();
 
-		jest.mocked(sqsQueues.backfill.sendMessage).mockResolvedValue();
 	});
 
 	it("should sync builds to Jira when build message contains issue key", async () => {

--- a/src/sync/commits.test.ts
+++ b/src/sync/commits.test.ts
@@ -72,7 +72,6 @@ describe("sync/commits", () => {
 				.repoSyncStatePendingForCommits()
 				.create();
 
-			jest.mocked(sqsQueues.backfill.sendMessage).mockResolvedValue(Promise.resolve());
 			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 		});
 

--- a/src/sync/deployment.test.ts
+++ b/src/sync/deployment.test.ts
@@ -60,7 +60,6 @@ describe("sync/deployments", () => {
 				.repoSyncStatePendingForDeployments()
 				.create();
 
-			jest.mocked(sqsQueues.backfill.sendMessage).mockResolvedValue();
 			githubUserTokenNock(installationId);
 		});
 
@@ -439,7 +438,6 @@ describe("sync/deployments", () => {
 
 			gitHubServerApp = builderOutput.gitHubServerApp!;
 
-			jest.mocked(sqsQueues.backfill.sendMessage).mockResolvedValue();
 			gheUserTokenNock(installationId);
 		});
 

--- a/src/sync/sync-utils.ts
+++ b/src/sync/sync-utils.ts
@@ -25,7 +25,7 @@ export const findOrStartSync = async (
 		syncWarning: null
 	});
 
-	logger.info({ subscription, syncType }, "Starting sync");
+	logger.info({ subscriptionId: subscription.id, syncType }, "Starting sync");
 
 	await resetTargetedTasks(subscription, syncType, targetTasks);
 

--- a/src/util/preemptive-rate-limit.test.ts
+++ b/src/util/preemptive-rate-limit.test.ts
@@ -1,14 +1,15 @@
-import { preemptiveRateLimitCheck } from "utils/preemptive-rate-limit";
+import { preemptiveRateLimitCheck, DEFAULT_PREEMPTY_RATELIMIT_DELAY_IN_SECONDS  } from "utils/preemptive-rate-limit";
 import { when } from "jest-when";
 import { numberFlag, NumberFlags } from "config/feature-flags";
+import type { SQSMessageContext, BaseMessagePayload } from "~/src/sqs/sqs.types";
 
 jest.mock("config/feature-flags");
 
 const TEST_INSTALLATION_ID = 1234;
-const REALLY_SMALL_RESET_TIME = 1000;
+const ONE_MINUTES_IN_SECONDS = 1 * 60;
 const THIRTY_MINUTES_IN_SECONDS = 30 * 60;
 
-const mockGitHubRateLimit = (limit , remaining, resetTime?) => {
+const mockGitHubRateLimit = (limit , remaining, resetTime) => {
 	githubUserTokenNock(TEST_INSTALLATION_ID);
 	githubNock.get(`/rate_limit`)
 		.reply(200, {
@@ -16,127 +17,91 @@ const mockGitHubRateLimit = (limit , remaining, resetTime?) => {
 				"core": {
 					"limit": limit,
 					"remaining": remaining,
-					"reset": resetTime || 1372700873
+					"reset": resetTime
 				},
 				"graphql": {
 					"limit": 5000,
 					"remaining": 5000,
-					"reset": resetTime || 1372700389
+					"reset": resetTime
 				}
 			}
 		});
 };
 
+const mockRatelimitThreshold = (threshold: number) => {
+	when(numberFlag).calledWith(
+		NumberFlags.PREEMPTIVE_RATE_LIMIT_THRESHOLD,
+		expect.anything(),
+		expect.anything()
+	).mockResolvedValue(threshold);
+};
+
+const getMessage = (): SQSMessageContext<BaseMessagePayload> => {
+	return {
+		payload: {
+			jiraHost: "JIRAHOST_MOCK",
+			installationId: TEST_INSTALLATION_ID,
+			gitHubAppConfig: {
+				gitHubAppId: 1
+			}
+		},
+		message: {},
+		log: {
+			info: jest.fn(),
+			warn: jest.fn()
+		}
+	} as any;
+};
+
 describe("Preemptive rate limit check - Cloud", () => {
 
-	it(`Should return true since the remaining percent is greater than the threshold`, async () => {
+	let sqsQueue;
+	let message;
+	let fakeDate;
+	let nowInSeconds;
 
-		when(numberFlag).calledWith(
-			NumberFlags.PREEMPTIVE_RATE_LIMIT_THRESHOLD,
-			expect.anything(),
-			expect.anything()
-		).mockResolvedValue(50);
-
-		mockGitHubRateLimit(100, 30);
-		const message = {
-			payload: {
-				jiraHost: "JIRAHOST_MOCK",
-				installationId: TEST_INSTALLATION_ID,
-				gitHubAppConfig: {
-					gitHubAppId: 1
-				}
-			},
-			message: {},
-			log: {
-				info: jest.fn(),
-				warn: jest.fn()
-			}
-		};
-		const sqsQueue = {
+	beforeEach(() => {
+		sqsQueue = {
 			queueName: "backfill",
 			changeVisibilityTimeout: jest.fn()
 		};
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		expect(await preemptiveRateLimitCheck(message, sqsQueue)).toBe(true);
+		message = getMessage();
+		fakeDate = 1678021200000; //2023-03-06T00:00:00
+		jest.spyOn(global.Date, "now").mockImplementation(() => { return fakeDate; });
+		nowInSeconds = fakeDate / 1000;
+	});
+
+	it(`Should return true since the remaining percent is greater than the threshold`, async () => {
+		mockRatelimitThreshold(50);
+		mockGitHubRateLimit(100, 30, nowInSeconds + THIRTY_MINUTES_IN_SECONDS);
+		expect(await preemptiveRateLimitCheck(message, sqsQueue)).toEqual({
+			isExceedThreshold: true,
+			resetTimeInSeconds: THIRTY_MINUTES_IN_SECONDS
+		});
 	});
 
 	it(`Should use default time delay if rest time is negative`, async () => {
-
-		when(numberFlag).calledWith(
-			NumberFlags.PREEMPTIVE_RATE_LIMIT_THRESHOLD,
-			expect.anything(),
-			expect.anything()
-		).mockResolvedValue(50);
-
-		mockGitHubRateLimit(100, 30, REALLY_SMALL_RESET_TIME);
-
-		const changeVisibilityTimeoutMock = jest.fn();
-		const message = {
-			payload: {
-				jiraHost: "JIRAHOST_MOCK",
-				installationId: TEST_INSTALLATION_ID,
-				gitHubAppConfig: {
-					gitHubAppId: 1
-				}
-			},
-			message: {},
-			log: {
-				info: jest.fn(),
-				warn: jest.fn()
-			}
-		};
-		const sqsQueue = {
-			queueName: "backfill",
-			changeVisibilityTimeout: changeVisibilityTimeoutMock
-		};
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		expect(await preemptiveRateLimitCheck(message, sqsQueue)).toBe(true);
-
-		expect(changeVisibilityTimeoutMock).toHaveBeenLastCalledWith(expect.anything(), THIRTY_MINUTES_IN_SECONDS, expect.anything());
+		mockRatelimitThreshold(50);
+		mockGitHubRateLimit(100, 30, nowInSeconds + ONE_MINUTES_IN_SECONDS);
+		expect(await preemptiveRateLimitCheck(message, sqsQueue)).toEqual({
+			isExceedThreshold: true,
+			resetTimeInSeconds: DEFAULT_PREEMPTY_RATELIMIT_DELAY_IN_SECONDS
+		});
 	});
 
 	it(`Should return false since threshold is not met`, async () => {
-
-		when(numberFlag).calledWith(
-			NumberFlags.PREEMPTIVE_RATE_LIMIT_THRESHOLD,
-			expect.anything(),
-			expect.anything()
-		).mockResolvedValue(90);
-
-		mockGitHubRateLimit(100, 99);
-		const sqsQueue = {
-			queueName: "backfill",
-			changeVisibilityTimeout: jest.fn()
-		};
-		const message = {
-			payload: {
-				jiraHost: "JIRAHOST_MOCK",
-				installationId: TEST_INSTALLATION_ID,
-				gitHubAppConfig: {
-					gitHubAppId: 1
-				}
-			},
-			message: {},
-			log: {
-				info: jest.fn(),
-				warn: jest.fn()
-			}
-		};
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		expect(await preemptiveRateLimitCheck(message, sqsQueue)).toBe(false);
+		mockRatelimitThreshold(90);
+		mockGitHubRateLimit(100, 99, nowInSeconds + THIRTY_MINUTES_IN_SECONDS);
+		expect(await preemptiveRateLimitCheck(message, sqsQueue)).toEqual({
+			isExceedThreshold: false
+		});
 	});
 
 	it(`Should not attempt to preempt when invalid quene name`, async () => {
-		const sqsQueue = {
-			queueName: "cats",
-			changeVisibilityTimeout: jest.fn()
-		};
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		expect(await preemptiveRateLimitCheck({}, sqsQueue)).toBe(false);
+		sqsQueue.queueName = "cats";
+		expect(await preemptiveRateLimitCheck(message, sqsQueue)).toEqual({
+			isExceedThreshold: false
+		});
 	});
 
 });

--- a/src/util/preemptive-rate-limit.test.ts
+++ b/src/util/preemptive-rate-limit.test.ts
@@ -9,7 +9,7 @@ const TEST_INSTALLATION_ID = 1234;
 const ONE_MINUTES_IN_SECONDS = 1 * 60;
 const THIRTY_MINUTES_IN_SECONDS = 30 * 60;
 
-const mockGitHubRateLimit = (limit , remaining, resetTime) => {
+const mockGitHubRateLimit = (limit: number, remaining: number, resetTime: number) => {
 	githubUserTokenNock(TEST_INSTALLATION_ID);
 	githubNock.get(`/rate_limit`)
 		.reply(200, {
@@ -55,10 +55,10 @@ const getMessage = (): SQSMessageContext<BaseMessagePayload> => {
 
 describe("Preemptive rate limit check - Cloud", () => {
 
-	let sqsQueue;
-	let message;
-	let fakeDate;
-	let nowInSeconds;
+	let sqsQueue: any;
+	let message: SQSMessageContext<BaseMessagePayload>;
+	let fakeDate: number;
+	let nowInSeconds: number;
 
 	beforeEach(() => {
 		sqsQueue = {

--- a/src/util/preemptive-rate-limit.ts
+++ b/src/util/preemptive-rate-limit.ts
@@ -15,7 +15,7 @@ type PreemptyRateLimitCheckResult = {
 };
 
 // Fetch the rate limit from GitHub API and check if the usages has exceeded the preemptive threshold
-export const preemptiveRateLimitCheck = async (context: SQSMessageContext<BaseMessagePayload>, sqsQueue: SqsQueue<BaseMessagePayload>) : Promise<PreemptyRateLimitCheckResult> => {
+export const preemptiveRateLimitCheck = async <T extends BaseMessagePayload>(context: SQSMessageContext<T>, sqsQueue: SqsQueue<T>) : Promise<PreemptyRateLimitCheckResult> => {
 
 	if (!TARGETTED_QUEUES.includes(sqsQueue.queueName))
 	{

--- a/src/util/preemptive-rate-limit.ts
+++ b/src/util/preemptive-rate-limit.ts
@@ -56,8 +56,8 @@ const getRateRateLimitStatus = async (context: SQSMessageContext<BaseMessagePayl
 const getRateResetTimeInSeconds = (rateLimitResponse: Octokit.RateLimitGetResponse): number => {
 	// Get the furthest away rate reset to ensure we don't exhaust the other one too quickly
 	const resetEpochDateTimeInSeconds = Math.max(rateLimitResponse?.resources?.core?.reset, rateLimitResponse?.resources?.graphql?.reset);
-	// Get the difference in seconds between now and reset time
 	const timeToResetInSeconds = resetEpochDateTimeInSeconds - (Date.now()/1000);
+	//sometimes, possibly a bug in github?, the timeToResetInSeconds is almost 0. To avoid reschdule to task too soon, adding a minimum of 10 minutes.
 	const finalTimeToRestInSeconds = Math.max(DEFAULT_PREEMPTY_RATELIMIT_DELAY_IN_SECONDS, timeToResetInSeconds);
 	return finalTimeToRestInSeconds;
 };

--- a/src/util/preemptive-rate-limit.ts
+++ b/src/util/preemptive-rate-limit.ts
@@ -3,17 +3,23 @@ import { Octokit } from "@octokit/rest";
 import { numberFlag, NumberFlags } from "config/feature-flags";
 import { SQSMessageContext } from "~/src/sqs/sqs.types";
 import { SqsQueue } from "~/src/sqs/sqs";
-import Logger from "bunyan";
+import type { BaseMessagePayload } from "~/src/sqs/sqs.types";
 
 // List of queues we want to apply the preemptive rate limiting on
 const TARGETTED_QUEUES = ["backfill"];
-const DEFAULT_PREEMPTY_RATELIMIT_DELAY_IN_SECONDS = 30 * 60; //30 minutes
+export const DEFAULT_PREEMPTY_RATELIMIT_DELAY_IN_SECONDS = 10 * 60; //10 minutes
+
+type PreemptyRateLimitCheckResult = {
+	isExceedThreshold: boolean;
+	resetTimeInSeconds?: number;
+};
 
 // Fetch the rate limit from GitHub API and check if the usages has exceeded the preemptive threshold
-export const preemptiveRateLimitCheck = async (context: SQSMessageContext<any>, sqsQueue: SqsQueue<any>) : Promise<boolean> => {
+export const preemptiveRateLimitCheck = async (context: SQSMessageContext<BaseMessagePayload>, sqsQueue: SqsQueue<BaseMessagePayload>) : Promise<PreemptyRateLimitCheckResult> => {
+
 	if (!TARGETTED_QUEUES.includes(sqsQueue.queueName))
 	{
-		return false;
+		return { isExceedThreshold: false };
 	}
 
 	const { jiraHost } = context.payload;
@@ -25,37 +31,33 @@ export const preemptiveRateLimitCheck = async (context: SQSMessageContext<any>, 
 		const usedPercentCore = ((core.limit - core.remaining) / core.limit) * 100;
 		const usedPercentGraphql = ((graphql.limit - graphql.remaining) / graphql.limit) * 100;
 		if (usedPercentCore >= threshold || usedPercentGraphql >= threshold) {
-			// Delay the message until rate limit has reset
-			await sqsQueue.changeVisibilityTimeout(context.message, getRateResetTime(rateLimitResponse, context.log), context.log);
-			return true;
+			const resetTimeInSeconds = getRateResetTimeInSeconds(rateLimitResponse);
+			context.log.info({ threshold, usedPercentCore, usedPercentGraphql, rateLimitResponse, resetTimeInSeconds }, `Rate limit check result: exceeded threshold`);
+			return {
+				isExceedThreshold: true,
+				resetTimeInSeconds
+			};
 		}
 	} catch (err) {
 		context.log.error({ err, gitHubServerAppId: context.payload.gitHubAppConfig?.gitHubAppId }, "Failed to fetch Rate Limit");
 	}
 
-	return false;
+	return { isExceedThreshold: false };
+
 };
 
-const getRateRateLimitStatus = async (context: SQSMessageContext<any>) => {
+const getRateRateLimitStatus = async (context: SQSMessageContext<BaseMessagePayload>) => {
 	const { installationId, jiraHost } = context.payload;
 	const gitHubAppId = context.payload.gitHubAppConfig?.gitHubAppId;
 	const gitHubInstallationClient = await createInstallationClient(installationId, jiraHost, context.log, gitHubAppId);
 	return await gitHubInstallationClient.getRateLimit();
 };
 
-const getRateResetTime = (rateLimitResponse: Octokit.RateLimitGetResponse, log: Logger): number => {
+const getRateResetTimeInSeconds = (rateLimitResponse: Octokit.RateLimitGetResponse): number => {
 	// Get the furthest away rate reset to ensure we don't exhaust the other one too quickly
-	const resetEpochDateTime = Math.max(rateLimitResponse?.resources?.core?.reset, rateLimitResponse?.resources?.graphql?.reset);
+	const resetEpochDateTimeInSeconds = Math.max(rateLimitResponse?.resources?.core?.reset, rateLimitResponse?.resources?.graphql?.reset);
 	// Get the difference in seconds between now and reset time
-	const timeToResetInSeconds = resetEpochDateTime - (Date.now()/1000);
-	const finalTimeToRestInSeconds = timeToResetInSeconds <= 0 ? DEFAULT_PREEMPTY_RATELIMIT_DELAY_IN_SECONDS : timeToResetInSeconds;
-
-	log.info({
-		timeToResetInSeconds,
-		finalTimeToRestInSeconds,
-		coreReset: rateLimitResponse?.resources?.core?.reset,
-		graphqlRest: rateLimitResponse?.resources?.graphql?.reset
-	}, "Preemptive rate limit reset time");
-
+	const timeToResetInSeconds = resetEpochDateTimeInSeconds - (Date.now()/1000);
+	const finalTimeToRestInSeconds = Math.max(DEFAULT_PREEMPTY_RATELIMIT_DELAY_IN_SECONDS, timeToResetInSeconds);
 	return finalTimeToRestInSeconds;
 };


### PR DESCRIPTION
**What's in this PR?**
Fix the bug of preemtively rate limiting.

**Why**
1. It sometimes reschdule the msg immediately. Fixed via added minimum delay. This seems to be something strange from the github side. It return the reset time that's almost exactly same as current time.
2. It use changeMsgVisiblity, which will incurr exceed retry count and lost the msg, customer sync will get stuck. Fixed via sending a new message. 

**Added feature flags**
N/A

**Affected issues**  
ARC-1995

**How has this been tested?**  
Unit test.

On stage:

When setting threshold to 1, rate limit kicked in, new msg was scheduled
![image](https://user-images.githubusercontent.com/105693507/223290419-33dbdb3c-a6e1-4d71-b3d1-9ad816aa94c7.png)

Reset the threshold back to normal, and after 15min (the maximum new msg delay), backfill success again.
![image](https://user-images.githubusercontent.com/105693507/223292816-b5af28cd-6b5c-4c2c-87ec-6adb7a4f4f7d.png)

![image](https://user-images.githubusercontent.com/105693507/223292847-5e6847eb-56bc-404d-9cab-5173438bb85a.png)


**Whats Next?**
N/A
