### PR TITLE
Arc 1975 show backfill since label

### DIFF
--- a/src/config/interfaces.ts
+++ b/src/config/interfaces.ts
@@ -38,6 +38,7 @@ export interface AppInstallation extends Octokit.AppsGetInstallationResponse {
 	syncWarning?: string;
 	totalNumberOfRepos?: number;
 	numberOfSyncedRepos?: number;
+	backfillSince?: Date;
 	jiraHost: string;
 }
 

--- a/src/routes/jira/jira-get.ts
+++ b/src/routes/jira/jira-get.ts
@@ -38,14 +38,15 @@ interface GitHubCloudObj {
 	failedConnections: FailedConnection[]
 }
 
-const mapSyncStatus = (syncStatus: SyncStatus = SyncStatus.PENDING): string => {
+export type ConnectionSyncStatus = "IN PROGRESS" | "FINISHED" | "PENDING" | "FAILED" | undefined;
+const mapSyncStatus = (syncStatus: SyncStatus = SyncStatus.PENDING): ConnectionSyncStatus => {
 	switch (syncStatus) {
 		case "ACTIVE":
 			return "IN PROGRESS";
 		case "COMPLETE":
 			return "FINISHED";
 		default:
-			return syncStatus;
+			return syncStatus as ConnectionSyncStatus;
 	}
 };
 
@@ -123,7 +124,7 @@ const renderJiraCloudAndEnterpriseServer = async (res: Response, req: Request): 
 
 	const { jiraHost, nonce } = res.locals;
 
-	const shouldPromoteBackfillButtonToTableRow = await booleanFlag(BooleanFlags.USE_BACKFILL_ALGORITHM_INCREMENTAL, jiraHost);
+	const isIncrementalBackfillEnabled = await booleanFlag(BooleanFlags.USE_BACKFILL_ALGORITHM_INCREMENTAL, jiraHost);
 
 	const subscriptions = await Subscription.getAllForHost(jiraHost);
 	const gheServers: GitHubServerApp[] = await GitHubServerApp.findForInstallationId(res.locals.installation.id) || [];
@@ -162,7 +163,7 @@ const renderJiraCloudAndEnterpriseServer = async (res: Response, req: Request): 
 
 	res.render("jira-configuration-new.hbs", {
 		host: jiraHost,
-		shouldPromoteBackfillButtonToTableRow,
+		isIncrementalBackfillEnabled,
 		gheServers: groupedGheServers,
 		ghCloud: { successfulCloudConnections, failedCloudConnections },
 		hasCloudAndEnterpriseServers: !!((successfulCloudConnections.length || failedCloudConnections.length) && gheServers.length),

--- a/src/routes/jira/jira-get.ts
+++ b/src/routes/jira/jira-get.ts
@@ -75,6 +75,7 @@ const getInstallation = async (subscription: Subscription, gitHubAppId: number |
 			syncWarning: subscription.syncWarning,
 			totalNumberOfRepos: subscription.totalNumberOfRepos,
 			numberOfSyncedRepos: await RepoSyncState.countSyncedReposFromSubscription(subscription),
+			backfillSince: subscription.backfillSince,
 			jiraHost
 		};
 
@@ -161,7 +162,7 @@ const renderJiraCloudAndEnterpriseServer = async (res: Response, req: Request): 
 
 	res.render("jira-configuration-new.hbs", {
 		host: jiraHost,
-		shouldPromoteBackfillButtonToTableRow,
+		shouldPromoteBackfillButtonToTableRow: true,
 		gheServers: groupedGheServers,
 		ghCloud: { successfulCloudConnections, failedCloudConnections },
 		hasCloudAndEnterpriseServers: !!((successfulCloudConnections.length || failedCloudConnections.length) && gheServers.length),

--- a/src/routes/jira/jira-get.ts
+++ b/src/routes/jira/jira-get.ts
@@ -162,7 +162,7 @@ const renderJiraCloudAndEnterpriseServer = async (res: Response, req: Request): 
 
 	res.render("jira-configuration-new.hbs", {
 		host: jiraHost,
-		shouldPromoteBackfillButtonToTableRow: true,
+		shouldPromoteBackfillButtonToTableRow,
 		gheServers: groupedGheServers,
 		ghCloud: { successfulCloudConnections, failedCloudConnections },
 		hasCloudAndEnterpriseServers: !!((successfulCloudConnections.length || failedCloudConnections.length) && gheServers.length),

--- a/src/util/handlebars/handlebar-helpers.test.ts
+++ b/src/util/handlebars/handlebar-helpers.test.ts
@@ -3,7 +3,8 @@
 import {
 	replaceSpaceWithHyphenHelper,
 	toLowercaseHelper,
-	concatStringHelper
+	concatStringHelper,
+	isAllSyncSuccess
 } from "./handlebar-helpers";
 
 describe("Handlebar Helpers", () => {
@@ -54,6 +55,24 @@ describe("Handlebar Helpers", () => {
 			expect(concatStringHelper("I", "am", "Legend")).toEqual("I am Legend");
 			expect(concatStringHelper("Gotta", "catch", "'em", "all!")).toEqual("Gotta catch 'em all!");
 			expect(concatStringHelper("More", " ", "space")).toEqual("More   space");
+		});
+	});
+
+	describe("isAllSyncSuccess", () => {
+		it("should return false on undefined parameter", () => {
+			expect(isAllSyncSuccess(undefined)).toBe(false);
+		});
+		it("should return false if subscription has warning", () => {
+			expect(isAllSyncSuccess({ syncWarning: "something went wrong" })).toBe(false);
+		});
+		it("should return false if subscription status is not complete", () => {
+			expect(isAllSyncSuccess({ syncStatus: undefined })).toBe(false);
+			expect(isAllSyncSuccess({ syncStatus: "PENDING" })).toBe(false);
+			expect(isAllSyncSuccess({ syncStatus: "IN PROGRESS" })).toBe(false);
+			expect(isAllSyncSuccess({ syncStatus: "FAILED" })).toBe(false);
+		});
+		it("should return true if subscription is COMPLETE and no warning", () => {
+			expect(isAllSyncSuccess({ syncStatus: "FINISHED" })).toBe(true);
 		});
 	});
 });

--- a/src/util/handlebars/handlebar-helpers.ts
+++ b/src/util/handlebars/handlebar-helpers.ts
@@ -1,10 +1,16 @@
 import hbs from "hbs";
 import { isPlainObject } from "lodash";
+import { ConnectionSyncStatus } from "~/src/routes/jira/jira-get";
 
 export const concatStringHelper = (...strings: string[]) => strings.filter((arg: unknown) => typeof arg !== "object").join(" ");
 export const toLowercaseHelper = (str?: string) => !isPlainObject(str) && str?.toString?.().toLowerCase() || "";
 export const replaceSpaceWithHyphenHelper = (str?: string) => !isPlainObject(str) && str?.toString?.().replace(/ /g, "-") || "";
 export const toISOStringHelper = (date?: Date) => date ? date.toISOString() : undefined;
+
+type Connection = { syncStatus?: ConnectionSyncStatus, syncWarning?: string };
+export const isAllSyncSuccess = (conn?: Connection) => {
+	return conn && conn.syncStatus === "FINISHED" && !conn.syncWarning ? true : false;
+};
 
 export const registerHandlebarsHelpers = () => {
 	hbs.registerHelper("toLowerCase", toLowercaseHelper);
@@ -32,6 +38,7 @@ export const registerHandlebarsHelpers = () => {
 		: `/github/subscriptions/${installationId}`
 	);
 
+	hbs.registerHelper("isAllSyncSuccess", isAllSyncSuccess);
 	hbs.registerHelper(
 		"inProgressOrPendingSync",
 		(syncStatus) => syncStatus === "IN PROGRESS" || syncStatus === "PENDING"

--- a/src/util/handlebars/handlebar-helpers.ts
+++ b/src/util/handlebars/handlebar-helpers.ts
@@ -4,12 +4,14 @@ import { isPlainObject } from "lodash";
 export const concatStringHelper = (...strings: string[]) => strings.filter((arg: unknown) => typeof arg !== "object").join(" ");
 export const toLowercaseHelper = (str?: string) => !isPlainObject(str) && str?.toString?.().toLowerCase() || "";
 export const replaceSpaceWithHyphenHelper = (str?: string) => !isPlainObject(str) && str?.toString?.().replace(/ /g, "-") || "";
+export const toISOStringHelper = (date?: Date) => date ? date.toISOString() : undefined;
 
 export const registerHandlebarsHelpers = () => {
 	hbs.registerHelper("toLowerCase", toLowercaseHelper);
 
 	hbs.registerHelper("replaceSpaceWithHyphen", replaceSpaceWithHyphenHelper);
 	hbs.registerHelper("concat", concatStringHelper);
+	hbs.registerHelper("toISOString", toISOStringHelper);
 
 	hbs.registerHelper(
 		"ifAllReposSynced",

--- a/static/css/jira-configuration-new.css
+++ b/static/css/jira-configuration-new.css
@@ -155,7 +155,6 @@
     margin-left: 0.2em;
     margin: 0.2em auto auto 0.5em;
     font-size: 1.2rem;
-    position: absolute;
     transform: scaleX(-1) rotate(30deg);
     background: inherit;
     border: none;

--- a/static/css/jira-configuration-new.css
+++ b/static/css/jira-configuration-new.css
@@ -141,6 +141,7 @@
     border-bottom: none;
     border-top: none;
     padding: 0.8em 0;
+    vertical-align: middle;
 }
 
 .jiraConfiguration__retryContainer, .jiraConfiguration__retryContainer {
@@ -174,6 +175,7 @@
 
 .jiraConfiguration__infoContainer {
     display: flex;
+    align-items: center;
 }
 .jiraConfiguration__infoSpinner {
     margin-left: 8px;
@@ -378,6 +380,11 @@
     padding: 0.2em 0.3em;
 }
 
+.jiraConfiguration__info__backfillDate {
+  color: #42526e;
+  padding: 0.2em 0.3em;
+}
+
 .jiraConfiguration__table__pending,
 .syncStatusPending {
     background-color: #dfe1e6;
@@ -513,7 +520,7 @@
 .jiraConfiguration__cloudConnections {
     box-shadow: 0 1px 1px rgba(9, 30, 66, 0.25), 0 0 1px rgba(9, 30, 66, 0.31);
     border-radius: 12px;
-    padding: 1.5em 1.5em;
+    padding: 1.5em 3em;
 }
 
 .jiraConfiguration__enterpriseServer {

--- a/static/js/jira-configuration.js
+++ b/static/js/jira-configuration.js
@@ -278,4 +278,9 @@ $(".jiraConfiguration__editGitHubApp").click(function(event) {
 	);
 });
 
-
+$(".jiraConfiguration__info__backfillDate-label").each(backfillSinceLabelEle => {
+	const backfillSinceISOStr = backfillSinceLabelEle.dataset.backfillSince;
+	if(backfillSinceISOStr) {
+		backfillSinceLabelEle.text(AJS.I18n
+	}
+});

--- a/static/js/jira-configuration.js
+++ b/static/js/jira-configuration.js
@@ -278,9 +278,12 @@ $(".jiraConfiguration__editGitHubApp").click(function(event) {
 	);
 });
 
-$(".jiraConfiguration__info__backfillDate-label").each(backfillSinceLabelEle => {
-	const backfillSinceISOStr = backfillSinceLabelEle.dataset.backfillSince;
-	if(backfillSinceISOStr) {
-		backfillSinceLabelEle.text(AJS.I18n
+$(".jiraConfiguration__info__backfillDate-label").each((_, backfillSinceLabelEle) => {
+	try {
+		const isoStr = backfillSinceLabelEle.dataset.backfillSince;
+		const backfillDate = new Date(isoStr);
+		$(backfillSinceLabelEle).text(backfillDate.toLocaleDateString());
+	} catch (e) {
+		console.error(`Error trying to show the backfill since date for backfillSinceLabelEle`, e);
 	}
 });

--- a/views/jira-configuration-new.hbs
+++ b/views/jira-configuration-new.hbs
@@ -181,7 +181,7 @@
                 {{> jira-configuration-table
                     id=id
                     host=host
-                    shouldPromoteBackfillButtonToTableRow=shouldPromoteBackfillButtonToTableRow
+                    isIncrementalBackfillEnabled=isIncrementalBackfillEnabled
                     elementIdPrefix="ghCloud-"
                     html_url=html_url
                     csrfToken=csrfToken
@@ -255,7 +255,7 @@
                             {{> jira-configuration-table
                                 id=id
                                 host=../../host
-                                shouldPromoteBackfillButtonToTableRow=../../shouldPromoteBackfillButtonToTableRow
+                                isIncrementalBackfillEnabled=../../isIncrementalBackfillEnabled
                                 hideAvatar=true
                                 elementIdPrefix="gheServer-"
                                 html_url=html_url
@@ -305,7 +305,7 @@
       referrerpolicy="no-referrer"
       nonce="{{nonce}}"
     ></script>
-    {{#if shouldPromoteBackfillButtonToTableRow }}
+    {{#if isIncrementalBackfillEnabled }}
     <style>
     .jiraConfiguration__table__head__title:not(:last-child) {
         width: 23%;

--- a/views/partials/jira-configuration-table.hbs
+++ b/views/partials/jira-configuration-table.hbs
@@ -13,7 +13,7 @@
           </span>
         </th>
         {{! Restart Button }}
-        {{#if shouldPromoteBackfillButtonToTableRow}}
+        {{#if isIncrementalBackfillEnabled}}
         <th class="jiraConfiguration__table__head__title"></th>
         {{/if}}
         {{! Restart Button -- end}}
@@ -78,14 +78,16 @@
                 >
                   {{connection.syncStatus}}
                 </span>
-              {{#if ../shouldPromoteBackfillButtonToTableRow}}
-              <span class="jiraConfiguration__info__backfillDate">
-                  {{#if connection.backfillSince}}
-                    Backfilled till: <span class="jiraConfiguration__info__backfillDate-label" data-backfill-since="{{ toISOString connection.backfillSince }}">{{ connection.backfillSince }}</span>
-                  {{else}}
-                    All commits backfilled
-                  {{/if}}
-              </span>
+              {{#if ../isIncrementalBackfillEnabled}}
+                {{#if (isAllSyncSuccess connection)}}
+                  <span class="jiraConfiguration__info__backfillDate">
+                      {{#if connection.backfillSince}}
+                        Backfilled till: <span class="jiraConfiguration__info__backfillDate-label" data-backfill-since="{{ toISOString connection.backfillSince }}">{{ connection.backfillSince }}</span>
+                      {{else}}
+                        All commits backfilled
+                      {{/if}}
+                  </span>
+                {{/if}}
               {{/if}}
               {{!-- Display any sync warnings --}}
               {{#if (isMissingPermissions connection.syncWarning)}}
@@ -129,7 +131,7 @@
           </td>
 
           {{! Restart Button }}
-          {{#if ../shouldPromoteBackfillButtonToTableRow}}
+          {{#if ../isIncrementalBackfillEnabled}}
           <td class="jiraConfiguration__table__cell jiraConfiguration__table__cell__action__inline">
             <button
                 class="sync-connection-link restart-backfill-button-inline aui-button aui-button-secondary"
@@ -168,7 +170,7 @@
                 >
                   Configure
                 </a>
-                {{#unless ../shouldPromoteBackfillButtonToTableRow}}
+                {{#unless ../isIncrementalBackfillEnabled}}
                 <div class="jiraConfiguration__table__cell__settings__dropdownItem">
                   <button
                       class="sync-connection-link restart-backfill-button"

--- a/views/partials/jira-configuration-table.hbs
+++ b/views/partials/jira-configuration-table.hbs
@@ -78,6 +78,15 @@
                 >
                   {{connection.syncStatus}}
                 </span>
+              {{#if ../shouldPromoteBackfillButtonToTableRow}}
+              <span class="jiraConfiguration__info__backfillDate">
+                  {{#if connection.backfillSince}}
+                    Backfilled till: <span class="jiraConfiguration__info__backfillDate-label" data-backfill-since="{{ toISOString connection.backfillSince }}">{{ connection.backfillSince }}</span>
+                  {{else}}
+                    All commits backfilled
+                  {{/if}}
+              </span>
+              {{/if}}
               {{!-- Display any sync warnings --}}
               {{#if (isMissingPermissions connection.syncWarning)}}
                 <div class="jiraConfiguration__syncWarning">

--- a/views/partials/jira-configuration-table.hbs
+++ b/views/partials/jira-configuration-table.hbs
@@ -82,7 +82,7 @@
                 {{#if (isAllSyncSuccess connection)}}
                   <span class="jiraConfiguration__info__backfillDate">
                       {{#if connection.backfillSince}}
-                        Backfilled till: <span class="jiraConfiguration__info__backfillDate-label" data-backfill-since="{{ toISOString connection.backfillSince }}">{{ connection.backfillSince }}</span>
+                        Backfilled from: <span class="jiraConfiguration__info__backfillDate-label" data-backfill-since="{{ toISOString connection.backfillSince }}">{{ connection.backfillSince }}</span>
                       {{else}}
                         All commits backfilled
                       {{/if}}


### PR DESCRIPTION
**What's in this PR?**
Add a ui label to tell when is the last success backfill date.

FF On, backfilled all
![image](https://user-images.githubusercontent.com/105693507/223569508-88317a43-b22e-4516-bf4d-0405c60ad44f.png)

FF On, backfilled till sometime:
![image](https://user-images.githubusercontent.com/105693507/223569571-661bcfdb-3633-4cf3-8a3e-3e3dc835ed61.png)

FF On, backfilled not success
![image](https://user-images.githubusercontent.com/105693507/223575860-f3aa9b5e-b1f3-461b-a43f-716fc4c7648f.png)


**Why**
So the user is aware of when to continue to.

**Added feature flags**
Reuse backfill-algorithm-incremental

**Affected issues**  
ARC-1975

**How has this been tested?**  
Unit test & local

**Whats Next?**
Turn on FF.
