### PR TITLE
NONE: add reset failed task endpoint

### DIFF
--- a/src/routes/api/api-reset-subscription-failed-tasks.ts
+++ b/src/routes/api/api-reset-subscription-failed-tasks.ts
@@ -1,0 +1,39 @@
+import { Request, Response } from "express";
+import { RepoSyncState } from "models/reposyncstate";
+import { Subscription } from "models/subscription";
+
+export const ApiResetSubscriptionFailedTasks = async (req: Request, res: Response): Promise<void> => {
+	const subscriptionId = req.body.subscriptionId;
+	const targetTasks = req.body.targetTasks as string[] || ["pull", "branch", "commit", "build", "deployment"];
+
+	if (!subscriptionId) {
+		res.status(400).send("please provide subscriptionId");
+		return;
+	}
+
+	const subscription = await Subscription.findByPk(subscriptionId);
+
+	if (!subscription) {
+		res.status(400).send("subscription not found");
+		return;
+	}
+
+	const log: any[] = [];
+
+	const repoSyncStates = await RepoSyncState.findAllFromSubscription(subscription);
+	await Promise.all(repoSyncStates.map(async (repoSyncState) => {
+		let updated = false;
+		targetTasks.forEach(targetTask => {
+			if (repoSyncState[`${targetTask}Status`] === "failed") {
+				repoSyncState[`${targetTask}Status`] = null;
+				log.push({ repoSyncStateId: repoSyncState.id, targetTask });
+				updated = true;
+			}
+		});
+		if (updated) {
+			await repoSyncState.save();
+		}
+	}));
+
+	res.json(log);
+};

--- a/src/routes/api/api-router.ts
+++ b/src/routes/api/api-router.ts
@@ -20,6 +20,7 @@ import { RecoverClientKeyPost } from "./client-key/recover-client-key";
 import { ReEncryptGitHubServerAppKeysPost } from "./ghes-app-encryption-ctx/re-encrypt-ghes-app-keys";
 import { ApiConfigurationRouter } from "routes/api/configuration/api-configuration-router";
 import { DataCleanupRouter } from "./data-cleanup/data-cleanup-router";
+import { ApiResetSubscriptionFailedTasks } from "./api-reset-subscription-failed-tasks";
 
 export const ApiRouter = Router();
 
@@ -80,6 +81,11 @@ ApiRouter.post(
 	body("targetTasks").optional().isArray(),
 	returnOnValidationError,
 	ApiResyncPost
+);
+
+ApiRouter.post(
+	`/reset-subscription-failed-tasks`,
+	ApiResetSubscriptionFailedTasks
 );
 
 // Hash incoming values with GLOBAL_HASH_SECRET.

--- a/test/utils/database-state-creator.ts
+++ b/test/utils/database-state-creator.ts
@@ -18,6 +18,7 @@ export class DatabaseStateCreator {
 	private withActiveRepoSyncStateFlag: boolean;
 	private pendingForPrs: boolean;
 	private pendingForBranches: boolean;
+	private failedForBranches: boolean;
 	private pendingForCommits: boolean;
 	private pendingForBuilds: boolean;
 	private pendingForDeployments: boolean;
@@ -77,6 +78,11 @@ export class DatabaseStateCreator {
 		return this;
 	}
 
+	public repoSyncStateFailedForBranches() {
+		this.failedForBranches = true;
+		return this;
+	}
+
 	public async create(): Promise<CreatorResult> {
 		const installation  = await Installation.create({
 			jiraHost,
@@ -114,7 +120,9 @@ export class DatabaseStateCreator {
 			repoPushedAt: new Date(),
 			repoUpdatedAt: new Date(),
 			repoCreatedAt: new Date(),
-			branchStatus: this.pendingForBranches ? "pending" : "complete",
+			branchStatus: this.pendingForBranches ? "pending" : (
+				this.failedForBranches ? "failed" : "complete"
+			),
 			commitStatus: this.pendingForCommits ? "pending" : "complete",
 			pullStatus: this.pendingForPrs ? "pending" : "complete",
 			buildStatus: this.pendingForBuilds ? "pending" : "complete",


### PR DESCRIPTION
**What's in this PR?**
Adding admin endpoint to reset failed tasks

**Why**
we have no way now
