### PR TITLE
ARC-1837: Apply preemptive rate limiting to the deployment queue

### DIFF
--- a/src/sqs/deployment.test.ts
+++ b/src/sqs/deployment.test.ts
@@ -4,8 +4,38 @@ import { Subscription } from "models/subscription";
 import { waitUntil } from "test/utils/wait-until";
 import { sqsQueues } from "../sqs/queues";
 import { createWebhookApp, WebhookApp } from "test/utils/create-webhook-app";
-
+import { when } from "jest-when";
+import { numberFlag, NumberFlags } from "config/feature-flags";
 import deploymentStatusBasic from "fixtures/deployment_status-basic.json";
+
+jest.mock("config/feature-flags");
+
+const mockGitHubRateLimit = (limit: number, remaining: number, resetTime: number) => {
+	githubUserTokenNock(1234);
+	githubNock.get(`/rate_limit`)
+		.reply(200, {
+			"resources": {
+				"core": {
+					"limit": limit,
+					"remaining": remaining,
+					"reset": resetTime
+				},
+				"graphql": {
+					"limit": 5000,
+					"remaining": 5000,
+					"reset": resetTime
+				}
+			}
+		});
+};
+
+const mockRatelimitThreshold = (threshold: number) => {
+	when(numberFlag).calledWith(
+		NumberFlags.PREEMPTIVE_RATE_LIMIT_THRESHOLD,
+		expect.anything(),
+		expect.anything()
+	).mockResolvedValue(threshold);
+};
 
 describe("Deployment Webhook", () => {
 	let app: WebhookApp;
@@ -16,6 +46,10 @@ describe("Deployment Webhook", () => {
 	});
 
 	beforeEach(async () => {
+
+		mockGitHubRateLimit(100, 90, 100000);
+		mockRatelimitThreshold(100);
+
 		app = await createWebhookApp();
 
 		await Subscription.create({

--- a/src/util/preemptive-rate-limit.ts
+++ b/src/util/preemptive-rate-limit.ts
@@ -6,7 +6,7 @@ import { SqsQueue } from "~/src/sqs/sqs";
 import type { BaseMessagePayload } from "~/src/sqs/sqs.types";
 
 // List of queues we want to apply the preemptive rate limiting on
-const TARGETTED_QUEUES = ["backfill"];
+const TARGETTED_QUEUES = ["backfill", "deployment"];
 export const DEFAULT_PREEMPTY_RATELIMIT_DELAY_IN_SECONDS = 10 * 60; //10 minutes
 
 type PreemptyRateLimitCheckResult = {


### PR DESCRIPTION
**What's in this PR?**
Applying preemptive rate limiting to the deployment queue

**Why**
Because according to our investigations, most of the failures from deployments that end up going to the DLQ are from rate-limiting failures.

**Added feature flags**

**Affected issues**  
ARC-1837

**How has this been tested?**  
_Include how to test if applicable_

**Whats Next?**
Monitoring on Splunk and SignalFx for the next week or so. We expect to see a big drop on the number of messages in the DLQ.
