### PR TITLE
ARC-1996  Adding commitFrom column

### DIFF
--- a/db/migrations/20230309051227-add-commit-from.js
+++ b/db/migrations/20230309051227-add-commit-from.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn("RepoSyncStates", "commitFrom", { type: Sequelize.DATE, allowNull: true });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn("RepoSyncStates", "commitFrom");
+  }
+};


### PR DESCRIPTION
**What's in this PR?**
Adding `commitFrom` column in `RepoSyncStates` table. This will be used to hold the actual sync date for commits during incremental backfilling.

**Affected issues**  
[Arc-1996]
