### PR TITLE
ARC-1995-PART-ONE added new failed code column to the reposyncstates

### DIFF
--- a/db/migrations/20230310104700-add-reposync-failedcode-col.js
+++ b/db/migrations/20230310104700-add-reposync-failedcode-col.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = {
+	up: async (queryInterface, Sequelize) => {
+		await queryInterface.addColumn("RepoSyncStates", "failedCode", { type: Sequelize.INTEGER , allowNull: true });
+	},
+
+	down: async (queryInterface) => {
+		await queryInterface.removeColumn("RepoSyncStates", "failedCode");
+	}
+};

--- a/db/migrations/20230310104700-add-reposync-failedcode-col.js
+++ b/db/migrations/20230310104700-add-reposync-failedcode-col.js
@@ -2,7 +2,7 @@
 
 module.exports = {
 	up: async (queryInterface, Sequelize) => {
-		await queryInterface.addColumn("RepoSyncStates", "failedCode", { type: Sequelize.INTEGER , allowNull: true });
+		await queryInterface.addColumn("RepoSyncStates", "failedCode", { type: Sequelize.STRING , allowNull: true });
 	},
 
 	down: async (queryInterface) => {


### PR DESCRIPTION
**What's in this PR?**
New column added to Reposyncstates so we can track the failed states for skipped tasks during backfill,
It is an integer instead of a string because we intend to collate the results and and changes to the string values will be a massive pain.
