### PR TITLE
add jira host to log to help debug support issue

### DIFF
--- a/src/routes/github/create-branch/github-create-branch-post.ts
+++ b/src/routes/github/create-branch/github-create-branch-post.ts
@@ -92,7 +92,7 @@ export const GithubCreateBranchPost = async (req: Request, res: Response): Promi
 		};
 		statsd.increment(metricCreateBranch.created, tags);
 	} catch (err) {
-		req.log.error({ err }, "Error creating branch");
+		req.log.error({ err, jiraHost }, "Error creating branch");
 
 		if (err.status === 403) {
 			const user = await gitHubUserClient.getUser();


### PR DESCRIPTION
**What's in this PR?**
Adding `jiraHost` to the create branch error log

**Why**
Trying to help with a support issue and there's no issue way to connect the Jira instance to the error :sigh:

**Whats Next?**
Get customer to try creating a branch again and search the logs with the jiraHost :awesome: