### PR TITLE
None refactor parallel fetching into common component

### DIFF
--- a/src/sync/parallel-page-fetcher.test.ts
+++ b/src/sync/parallel-page-fetcher.test.ts
@@ -1,0 +1,94 @@
+import { fetchNextPagesInParallel } from "~/src/sync/parallel-page-fetcher";
+
+describe("fetchNextPagesInParallel", () => {
+
+	test("fetches data from multiple pages and merges the results", async () => {
+		const singlePageFetchFactory = jest.fn().mockImplementation((pageCursor) => {
+			const edges = [{
+				cursor: pageCursor,
+				node: { id: "id" + pageCursor }
+			}];
+			const jiraPayload = {
+				pullRequests: [{ id: "pid" + pageCursor }],
+				builds: [{ id: "bid" + pageCursor }]
+			};
+			return Promise.resolve({ edges, jiraPayload });
+		});
+		const fetchedData = await fetchNextPagesInParallel(3, 1, singlePageFetchFactory);
+		expect(fetchedData).toEqual({
+			edges: [
+				{ cursor: 1, node: { id: "id1" } },
+				{ cursor: 2, node: { id: "id2" } },
+				{ cursor: 3, node: { id: "id3" } }
+			],
+			jiraPayload: {
+				pullRequests: [{ id: "pid1" }, { id: "pid2" }, { id: "pid3" }],
+				builds: [{ id: "bid1" }, { id: "bid2" }, { id: "bid3" }]
+			}
+		});
+	});
+
+	test("can fetch just one page", async () => {
+		const singlePageFetchFactory = jest.fn().mockImplementation((pageCursor) => {
+			const edges = [{
+				cursor: pageCursor,
+				node: { id: "id" + pageCursor }
+			}];
+			const jiraPayload = {
+				foo: "bar",
+				pullRequests: [{ id: "pid" + pageCursor }],
+				builds: [{ id: "bid" + pageCursor }]
+			};
+			return Promise.resolve({ edges, jiraPayload });
+		});
+		const fetchedData = await fetchNextPagesInParallel(1, 1, singlePageFetchFactory);
+		expect(fetchedData).toEqual({
+			edges: [
+				{ cursor: 1, node: { id: "id1" } }
+			],
+			jiraPayload: {
+				foo: "bar",
+				pullRequests: [{ id: "pid1" }],
+				builds: [{ id: "bid1" }]
+			}
+		});
+	});
+
+	test("returns the first page if 2nd one is empty", async () => {
+		const singlePageFetchFactory = jest.fn().mockImplementation((pageCursor) => {
+			if (pageCursor == 2) {
+				return Promise.resolve({
+					edges: [],
+					jiraPayload: undefined
+				});
+			}
+			const edges = [{
+				cursor: pageCursor,
+				node: { id: "id" + pageCursor }
+			}];
+			const jiraPayload = { pullRequests: [{ id: "pid" + pageCursor }] };
+			return Promise.resolve({ edges, jiraPayload });
+		});
+		const fetchedData = await fetchNextPagesInParallel(2, 1, singlePageFetchFactory);
+		expect(fetchedData).toEqual({
+			edges: [
+				{ cursor: 1, node: { id: "id1" } }
+			],
+			jiraPayload: { pullRequests: [{ id: "pid1" }] }
+		});
+	});
+
+	test("returns empty page if both are empty", async () => {
+		const singlePageFetchFactory = jest.fn().mockImplementation(() => {
+			return Promise.resolve({
+				edges: [],
+				jiraPayload: undefined
+			});
+		});
+		const fetchedData = await fetchNextPagesInParallel(2, 1, singlePageFetchFactory);
+		expect(fetchedData).toEqual({
+			edges: [ ],
+			jiraPayload: undefined
+		});
+	});
+});

--- a/src/sync/parallel-page-fetcher.ts
+++ b/src/sync/parallel-page-fetcher.ts
@@ -9,7 +9,7 @@ const mergeJiraPayload = (jiraPayload1?: any, jiraPayload2?: any) => {
 	const pullRequests = [...(jiraPayload1?.pullRequests || []), ...(jiraPayload2?.pullRequests || [])];
 	const builds = [...(jiraPayload1?.builds || []), ...(jiraPayload2?.builds || [])];
 
-	if (pullRequests.length == 0 && builds.length == 0) {
+	if (pullRequests.length === 0 && builds.length === 0) {
 		return undefined;
 	}
 

--- a/src/sync/parallel-page-fetcher.ts
+++ b/src/sync/parallel-page-fetcher.ts
@@ -15,8 +15,8 @@ const mergeJiraPayload = (jiraPayload1?: any, jiraPayload2?: any) => {
 
 	return {
 		...(jiraPayload1 || jiraPayload2),
-		... (pullRequests.length > 0 ? { pullRequests } : {}),
-		... (builds.length > 0 ? { builds } : {})
+		...(pullRequests.length > 0 ? { pullRequests } : {}),
+		...(builds.length > 0 ? { builds } : {})
 	};
 };
 

--- a/src/sync/parallel-page-fetcher.ts
+++ b/src/sync/parallel-page-fetcher.ts
@@ -1,0 +1,45 @@
+import { TaskPayload } from "~/src/sync/sync.types";
+
+const mergeJiraPayload = (jiraPayload1?: any, jiraPayload2?: any) => {
+	if (!jiraPayload1 && !jiraPayload2) {
+		return undefined;
+	}
+
+	// TODO: add more
+	const pullRequests = [...(jiraPayload1?.pullRequests || []), ...(jiraPayload2?.pullRequests || [])];
+	const builds = [...(jiraPayload1?.builds || []), ...(jiraPayload2?.builds || [])];
+
+	if (pullRequests.length == 0 && builds.length == 0) {
+		return undefined;
+	}
+
+	return {
+		...(jiraPayload1 || jiraPayload2),
+		... (pullRequests.length > 0 ? { pullRequests } : {}),
+		... (builds.length > 0 ? { builds } : {})
+	};
+};
+
+export const fetchNextPagesInParallel = async (
+	pagesToFetch: number,
+	nextPageCursor: number,
+	singlePageFetchFactory: (pageCursor: number) => Promise<TaskPayload>
+): Promise<TaskPayload> => {
+	const tasks = Array.from(
+		{
+			length: pagesToFetch
+		},
+		(_, index) => singlePageFetchFactory(nextPageCursor + index)
+	);
+	const fetchedData = await Promise.all(tasks);
+	return fetchedData.reduce((prev, curr) => {
+		return {
+			edges: [...(prev.edges || []), ...(curr.edges || [])],
+			jiraPayload:
+				mergeJiraPayload(prev.jiraPayload, curr.jiraPayload)
+		};
+	}, {
+		edges: [],
+		jiraPayload: undefined
+	});
+};

--- a/src/sync/pull-request.ts
+++ b/src/sync/pull-request.ts
@@ -80,15 +80,13 @@ export const getPullRequestTask = async (
 					scaledPageSize
 				)
 		);
-		if ((data.edges?.length || 0) > 0) {
-			data.edges!.forEach(edge => {
-				// Cursor is scaled... scaling back!
-				// original pages: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-				// scaled pages:   ----1--------, --------2-----
-				// Same as above: the counter starts from 1, therefore need to deduct it first and then add back to the result
-				edge.cursor = 1 + (edge.cursor - 1) * limitedPageSizeCoef;
-			});
-		}
+		(data.edges || []).forEach(edge => {
+			// Cursor is scaled... scaling back!
+			// original pages: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+			// scaled pages:   ----1--------, --------2-----
+			// Same as above: the counter starts from 1, therefore need to deduct it first and then add back to the result
+			edge.cursor = 1 + (edge.cursor - 1) * limitedPageSizeCoef;
+		});
 
 		return data;
 	}

--- a/src/sync/pull-request.ts
+++ b/src/sync/pull-request.ts
@@ -80,7 +80,7 @@ export const getPullRequestTask = async (
 					scaledPageSize
 				)
 		);
-		if ((data.edges?.length) || 0 > 0) {
+		if ((data.edges?.length || 0) > 0) {
 			data.edges!.forEach(edge => {
 				// Cursor is scaled... scaling back!
 				// original pages: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,

--- a/src/sync/pull-request.ts
+++ b/src/sync/pull-request.ts
@@ -15,6 +15,7 @@ import { getPullRequestReviews } from "~/src/transforms/util/github-get-pull-req
 import { getGithubUser } from "services/github/user";
 import { booleanFlag, BooleanFlags, numberFlag, NumberFlags } from "config/feature-flags";
 import { isEmpty } from "lodash";
+import { fetchNextPagesInParallel } from "~/src/sync/parallel-page-fetcher";
 
 /**
  * Find the next page number from the response headers.
@@ -43,17 +44,6 @@ type Headers = AxiosResponseHeaders & {
 
 type PullRequestWithCursor = { cursor: number } & Octokit.PullsListResponseItem;
 
-const mergeJiraPayload = (jiraPayload1?: any, jiraPayload2?: any) => {
-	if (!jiraPayload1 && !jiraPayload2) {
-		return undefined;
-	}
-
-	return {
-		...(jiraPayload1 || jiraPayload2),
-		pullRequests: [...(jiraPayload1?.pullRequests || []), ...(jiraPayload2?.pullRequests || [])]
-	};
-};
-
 export const getPullRequestTask = async (
 	logger: Logger,
 	gitHubInstallationClient: GitHubInstallationClient,
@@ -70,42 +60,37 @@ export const getPullRequestTask = async (
 		// Fetch in parallel instead. Given that's an expermient for a single customer, let's not
 		// overcomplicate it too much and limit ourselves to 2 pages.
 		const limitedPageSizeCoef = Math.min(5, pageSizeCoef);
-		const shouldFetchNextPage = pageSizeCoef > 5;
-
-		const prFetchJobs: Promise<any>[] = [];
+		const shouldFetchNextPageInParallel = pageSizeCoef > 5;
 
 		const scaledPageSize = perPage * limitedPageSizeCoef;
-		const scaledCursor = Math.max(1, Math.floor(Number(cursor) / limitedPageSizeCoef));
 
-		prFetchJobs.push(doGetPullRequestTask(
-			logger, gitHubInstallationClient, jiraHost, repository,
+		// Cursor 1, 2, 3, 4, 5 should be mapped to scaled cursor 1;
+		// Cursor 6, 7, 8, 9, 10 shoul be mapped to scaled cursor 2;
+		// etc
+		// Given that the page counter starts from 1, we need to deduct 1 first and then add 1 back to the outcome
+		const scaledCursor = 1 + Math.floor((Number(cursor) - 1) / limitedPageSizeCoef);
+
+		const data = await fetchNextPagesInParallel(
+			shouldFetchNextPageInParallel ? 2 : 1,
 			scaledCursor,
-			scaledPageSize
-		));
-
-		if (shouldFetchNextPage) {
-			logger.info("Fetch second page in parallel");
-			prFetchJobs.push(doGetPullRequestTask(
-				logger, gitHubInstallationClient, jiraHost, repository,
-				scaledCursor + 1,
-				scaledPageSize
-			));
+			(scaledPageNoToFetch) =>
+				doGetPullRequestTask(
+					logger, gitHubInstallationClient, jiraHost, repository,
+					scaledPageNoToFetch,
+					scaledPageSize
+				)
+		);
+		if ((data.edges?.length) || 0 > 0) {
+			data.edges!.forEach(edge => {
+				// Cursor is scaled... scaling back!
+				// original pages: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+				// scaled pages:   ----1--------, --------2-----
+				// Same as above: the counter starts from 1, therefore need to deduct it first and then add back to the result
+				edge.cursor = 1 + (edge.cursor - 1) * limitedPageSizeCoef;
+			});
 		}
 
-		const [page1, page2] = await Promise.all(prFetchJobs);
-
-		const mergeResult = {
-			edges: [...(page1?.edges || []), ...(page2?.edges || [])],
-			jiraPayload:
-				mergeJiraPayload(page1?.jiraPayload, page2?.jiraPayload)
-		};
-
-		const nextPageCursor = Number(cursor) + (shouldFetchNextPage ? limitedPageSizeCoef * 2 : limitedPageSizeCoef);
-
-		mergeResult.edges.forEach((edge) => {
-			edge.cursor = nextPageCursor;
-		});
-		return mergeResult;
+		return data;
 	}
 };
 

--- a/src/sync/pull-requests.test.ts
+++ b/src/sync/pull-requests.test.ts
@@ -329,8 +329,12 @@ describe("sync/pull-request", () => {
 					html_url: "integrations-url"
 				});
 
+			//
+			// Original pages: 123456789012345678901345
+			// Scaled pages  : 111112222233333444445555
+			// Cursor pointing to the original scale (21) should point to scaled page 5
 			const nock = githubNock
-				.get("/repos/integrations/test-repo-name/pulls?per_page=100&page=4&state=all&sort=created&direction=desc")
+				.get("/repos/integrations/test-repo-name/pulls?per_page=100&page=5&state=all&sort=created&direction=desc")
 				.reply(200, pullRequestList);
 
 			jiraNock.post("/rest/devinfo/0.10/bulk", buildJiraPayload("1")).reply(200);
@@ -383,11 +387,11 @@ describe("sync/pull-request", () => {
 				});
 
 			const nockPage1 = githubNock
-				.get("/repos/integrations/test-repo-name/pulls?per_page=100&page=4&state=all&sort=created&direction=desc")
+				.get("/repos/integrations/test-repo-name/pulls?per_page=100&page=5&state=all&sort=created&direction=desc")
 				.reply(200, pullRequestList);
 
 			const nockPage2 = githubNock
-				.get("/repos/integrations/test-repo-name/pulls?per_page=100&page=5&state=all&sort=created&direction=desc")
+				.get("/repos/integrations/test-repo-name/pulls?per_page=100&page=6&state=all&sort=created&direction=desc")
 				.reply(200, pullRequestList);
 
 			jiraNock.post("/rest/devinfo/0.10/bulk", buildJiraPayload("1", 2)).reply(200);
@@ -416,11 +420,11 @@ describe("sync/pull-request", () => {
 			}
 
 			const nockPage1 = githubNock
-				.get("/repos/integrations/test-repo-name/pulls?per_page=100&page=4&state=all&sort=created&direction=desc")
+				.get("/repos/integrations/test-repo-name/pulls?per_page=100&page=5&state=all&sort=created&direction=desc")
 				.reply(200, []);
 
 			const nockPage2 = githubNock
-				.get("/repos/integrations/test-repo-name/pulls?per_page=100&page=5&state=all&sort=created&direction=desc")
+				.get("/repos/integrations/test-repo-name/pulls?per_page=100&page=6&state=all&sort=created&direction=desc")
 				.reply(200, []);
 
 			await expect(processInstallation()({


### PR DESCRIPTION
**What's in this PR?**
Refactoring parallel fetching logic into a common component that could be used across different entities

**Why**
1. Want to do same for builds
2. We might want to extend it to other big customers

**Added feature flags**
Already behind one.

**Whats Next?**
Use it to fetch builds in parallel

