### PR TITLE
Arc 1975 fix commits from date var all time

### DIFF
--- a/src/routes/api/api-router.ts
+++ b/src/routes/api/api-router.ts
@@ -21,6 +21,7 @@ import { ReEncryptGitHubServerAppKeysPost } from "./ghes-app-encryption-ctx/re-e
 import { ApiConfigurationRouter } from "routes/api/configuration/api-configuration-router";
 import { DataCleanupRouter } from "./data-cleanup/data-cleanup-router";
 import { ApiResetSubscriptionFailedTasks } from "./api-reset-subscription-failed-tasks";
+import { RecoverCommitsFromDatePost } from "./commits-from-date/recover-commits-from-dates";
 
 export const ApiRouter = Router();
 
@@ -140,6 +141,7 @@ ApiRouter.use("/db-migration", DBMigrationsRouter);
 ApiRouter.post("/recover-client-key", RecoverClientKeyPost);
 ApiRouter.post("/re-encrypt-ghes-app", ReEncryptGitHubServerAppKeysPost);
 ApiRouter.use("/data-cleanup", DataCleanupRouter);
+ApiRouter.post("/recover-commits-from-date", RecoverCommitsFromDatePost);
 
 ApiRouter.use("/jira", ApiJiraRouter);
 ApiRouter.use("/:installationId", param("installationId").isInt(), returnOnValidationError, ApiInstallationRouter);

--- a/src/routes/api/commits-from-date/recover-commits-from-dates.ts
+++ b/src/routes/api/commits-from-date/recover-commits-from-dates.ts
@@ -1,0 +1,62 @@
+import { Request, Response } from "express";
+import { Subscription } from "models/subscription";
+import { Op } from "sequelize";
+import { getLogger } from "config/logger";
+import safeJsonStringify from "safe-json-stringify";
+
+const DEFAULT_BATCH_SIZE = 5000;
+
+export const RecoverCommitsFromDatePost = async (req: Request, res: Response): Promise<void> => {
+
+	const log = getLogger("RecoverCommitsFromDatePost");
+
+	try {
+
+		const startSubscriptionId = Number(req.query.startSubscriptionId) || 0;
+		const batchSize = Number(req.query.batchSize) || DEFAULT_BATCH_SIZE;
+
+		const info = (msg: string) => {
+			log.info(msg);
+			res.write(msg + "\n");
+		};
+
+		res.status(200);
+
+		info(`Start recovering commits from date for Subscription starting from ${startSubscriptionId} with batch size ${batchSize}`);
+
+		const subscriptionToBeUpdated: Subscription[] = await Subscription.findAll({
+			where: {
+				[Op.and]: {
+					"backfillSince": {
+						[Op.lt]: new Date(1980, 1, 1)
+					},
+					"id": {
+						[Op.gt]: startSubscriptionId
+					}
+				}
+			},
+			order: [ ["id", "ASC"] ]
+		});
+		info(`Found ${subscriptionToBeUpdated.length} subscriptions potentially to look at`);
+
+		let count = 0;
+		let lastId: number | undefined;
+		for (const sub of subscriptionToBeUpdated) {
+			if (sub.backfillSince?.getFullYear() === 1970) {
+				//just double check it is the default year for backfill all time
+				await sub.update({
+					backfillSince: null
+				});
+				count++;
+			}
+			lastId = sub.id;
+		}
+		info(`${count} subscriptions updated, last subscription id is ${lastId})`);
+
+		res.end();
+
+	} catch (e) {
+		log.error({ err: e }, "Error happen when recovering commits from date");
+		res.end(`Error happen when recovering commits from date: ${safeJsonStringify(e)}`);
+	}
+};

--- a/src/routes/api/commits-from-date/recover-commits-from-dates.ts
+++ b/src/routes/api/commits-from-date/recover-commits-from-dates.ts
@@ -25,6 +25,7 @@ export const RecoverCommitsFromDatePost = async (req: Request, res: Response): P
 		info(`Start recovering commits from date for Subscription starting from ${startSubscriptionId} with batch size ${batchSize}`);
 
 		const subscriptionToBeUpdated: Subscription[] = await Subscription.findAll({
+			limit: batchSize,
 			where: {
 				[Op.and]: {
 					"backfillSince": {

--- a/src/sync/sync-utils.test.ts
+++ b/src/sync/sync-utils.test.ts
@@ -20,6 +20,7 @@ describe("findOrStartSync", () => {
 		const JIRA_INSTALLATION_ID = 1111;
 		const JIRA_CLIENT_KEY = "jira-client-key";
 		const CUTOFF_IN_MSECS = 1000;
+		const CUTOFF_IN_MSECS__DISABLED = -1;
 		describe("commit since date", () => {
 			let subscription: Subscription;
 			beforeEach(async () => {
@@ -45,6 +46,24 @@ describe("findOrStartSync", () => {
 				await findOrStartSync(subscription, getLogger("test"), true, undefined, undefined, undefined);
 				expect(sqsQueues.backfill.sendMessage).toBeCalledWith(
 					expect.objectContaining({ commitsFromDate: targetCommitsFromDate.toISOString() }),
+					expect.anything(), expect.anything());
+			});
+			it("should  send undefined commit since date in the msg payload if flag is set to -1 for main commits from date", async () => {
+				when(jest.mocked(numberFlag))
+					.calledWith(NumberFlags.SYNC_MAIN_COMMIT_TIME_LIMIT, expect.anything(), jiraHost)
+					.mockResolvedValue(CUTOFF_IN_MSECS__DISABLED);
+				await findOrStartSync(subscription, getLogger("test"), true, undefined, undefined, undefined);
+				expect(sqsQueues.backfill.sendMessage).toBeCalledWith(
+					expect.objectContaining({ commitsFromDate: undefined }),
+					expect.anything(), expect.anything());
+			});
+			it("should  send undefined commit since date in the msg payload if flag is set to -1 for branch commits from date", async () => {
+				when(jest.mocked(numberFlag))
+					.calledWith(NumberFlags.SYNC_BRANCH_COMMIT_TIME_LIMIT, expect.anything(), jiraHost)
+					.mockResolvedValue(CUTOFF_IN_MSECS__DISABLED);
+				await findOrStartSync(subscription, getLogger("test"), true, undefined, undefined, undefined);
+				expect(sqsQueues.backfill.sendMessage).toBeCalledWith(
+					expect.objectContaining({ branchCommitsFromDate: undefined }),
 					expect.anything(), expect.anything());
 			});
 		});

--- a/src/sync/sync-utils.ts
+++ b/src/sync/sync-utils.ts
@@ -110,8 +110,8 @@ export const getCommitSinceDate = async (jiraHost: string, flagName: NumberFlags
 		return new Date(commitsFromDate);
 	}
 	const timeCutoffMsecs = await numberFlag(flagName, NaN, jiraHost);
-	if (!timeCutoffMsecs) {
-		return;
+	if (!timeCutoffMsecs || timeCutoffMsecs === -1) {
+		return undefined;
 	}
 	return new Date(Date.now() - timeCutoffMsecs);
 };


### PR DESCRIPTION
**What's in this PR?**
1. Fix how to determine the commits from date
2. Add admin api to recover existing commits from date.

**Why**
Current in the ff launch darkly, the "disable" state return a large number `1654506600000` <-- which is roughly like 1970-10-08. The origin logic has flaw, it takes it to be the commitsFromDate.
The fix is to use -1 as indicator for disable state so that it is more stable.

**Added feature flags**
Related to sync-main-commit-time-limit and sync-branch-commit-time-limit

**Affected issues**  
ARC-1975

**How has this been tested?**  
Unit test and local db test.

**Whats Next?**
N/A
