### PR TITLE
Arc 2033 apply backfill from date on deployment  turn on desc

### DIFF
--- a/src/github/client/github-installation-client.ts
+++ b/src/github/client/github-installation-client.ts
@@ -17,7 +17,6 @@ import {
 	ViewerRepositoryCountQuery,
 	getDeploymentsResponse,
 	getDeploymentsQuery,
-	getDeploymentsQueryByCreatedAtDesc,
 	SearchedRepositoriesResponse
 } from "./github-queries";
 import {
@@ -254,18 +253,6 @@ export class GitHubInstallationClient extends GitHubClient {
 
 	public async getDeploymentsPage(owner: string, repoName: string, perPage?: number, cursor?: string | number): Promise<getDeploymentsResponse> {
 		const response = await this.graphql<getDeploymentsResponse>(getDeploymentsQuery,
-			await this.installationAuthenticationHeaders(),
-			{
-				owner,
-				repo: repoName,
-				per_page: perPage,
-				cursor
-			});
-		return response?.data?.data;
-	}
-
-	public async getDeploymentsPageByCreatedAtDesc(owner: string, repoName: string, perPage?: number, cursor?: string | number): Promise<getDeploymentsResponse> {
-		const response = await this.graphql<getDeploymentsResponse>(getDeploymentsQueryByCreatedAtDesc,
 			await this.installationAuthenticationHeaders(),
 			{
 				owner,

--- a/src/github/client/github-queries.ts
+++ b/src/github/client/github-queries.ts
@@ -362,46 +362,9 @@ export type getDeploymentsResponse = {
 	}
 };
 
-export const getDeploymentsQueryByCreatedAtDesc = `query ($owner: String!, $repo: String!, $per_page: Int!, $cursor: String) {
-  repository(owner: $owner, name: $repo){
-    deployments(first: $per_page, after: $cursor, orderBy: { direction: DESC, field: CREATED_AT }) {
-      edges {
-        cursor
-        node {
-					createdAt
-          repository {
-            id: databaseId
-            node_id: id
-            name
-            owner {
-              login
-            }
-          }
-          databaseId
-          commitOid
-          task
-          ref {
-            name
-            id
-          }
-          environment
-          description
-          latestStatus {
-            environmentUrl
-            logUrl
-            state
-            id
-            updatedAt
-          }
-        }
-      }
-    }
-  }
-}`;
-
 export const getDeploymentsQuery = `query ($owner: String!, $repo: String!, $per_page: Int!, $cursor: String) {
   repository(owner: $owner, name: $repo){
-    deployments(first: $per_page, after: $cursor) {
+    deployments(first: $per_page, after: $cursor, orderBy: { direction: DESC, field: CREATED_AT }) {
       edges {
         cursor
         node {

--- a/src/routes/api/commits-from-date/reset-failed-and-pending-deployment-cursors.ts
+++ b/src/routes/api/commits-from-date/reset-failed-and-pending-deployment-cursors.ts
@@ -29,10 +29,7 @@ export const ResetFailedAndPendingDeploymentCursorPost = async (req: Request, re
 			where: {
 				[Op.and]: {
 					"deploymentStatus": {
-						[Op.or]: {
-							[Op.is]: undefined,
-							[Op.in]: ["pending", "failed"]
-						}
+						[Op.in]: ["pending", "failed"]
 					},
 					"id": {
 						[Op.gte]: startRepoSyncStatesId

--- a/src/sync/deployment.test.ts
+++ b/src/sync/deployment.test.ts
@@ -8,7 +8,7 @@ import { BackfillMessagePayload } from "../sqs/sqs.types";
 
 import deploymentNodesFixture from "fixtures/api/graphql/deployment-nodes.json";
 import mixedDeploymentNodes from "fixtures/api/graphql/deployment-nodes-mixed.json";
-import { getDeploymentsQuery, getDeploymentsQueryByCreatedAtDesc } from "~/src/github/client/github-queries";
+import { getDeploymentsQuery } from "~/src/github/client/github-queries";
 import { waitUntil } from "test/utils/wait-until";
 import { DatabaseStateCreator } from "test/utils/database-state-creator";
 import { GitHubServerApp } from "models/github-server-app";
@@ -90,7 +90,7 @@ describe("sync/deployments", () => {
 
 			githubNock
 				.post("/graphql", {
-					query: getDeploymentsQueryByCreatedAtDesc,
+					query: getDeploymentsQuery,
 					variables: {
 						owner: "integrations",
 						repo: "test-repo-name",


### PR DESCRIPTION
**What's in this PR?**
Use the desc in sort order when getting deployments data.

**Why**
I was planning to use FF `USE_BACKFILL_ALGORITHM_INCREMENTAL` to controller the rollout of this `desc ordering` for deployment. But I realised we are going to do percentage rollout of that ff, and I can't really tell which is which when calling the admin api to reset cursor for failed/pending deployment. 
So I'd like to have this turn on and ready now instead of later.

**Added feature flags**
N/A

**Affected issues**  
ARC-2033

**How has this been tested?**  
Unit test and local

**Whats Next?**
N/A
