### PR TITLE
ARC-2040 Clean up FF RENEW_GITHUB_TOKEN

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -18,8 +18,7 @@ export enum BooleanFlags {
 	SEND_PR_COMMENTS_TO_JIRA = "send-pr-comments-to-jira_zy5ib",
 	USE_SHARED_PR_TRANSFORM = "use-shared-pr-transform",
 	USE_BACKFILL_ALGORITHM_INCREMENTAL = "backfill-algorithm-incremental",
-	REPO_CREATED_EVENT = "repo-created-event",
-	RENEW_GITHUB_TOKEN = "renew-github-token"
+	REPO_CREATED_EVENT = "repo-created-event"
 }
 
 export enum StringFlags {

--- a/src/routes/github/github-oauth-router.test.ts
+++ b/src/routes/github/github-oauth-router.test.ts
@@ -7,19 +7,10 @@ import nock from "nock";
 import { envVars } from "config/env";
 import { DatabaseStateCreator } from "test/utils/database-state-creator";
 import { GitHubServerApp } from "models/github-server-app";
-import { when } from "jest-when";
-import { booleanFlag, BooleanFlags } from "config/feature-flags";
 
 jest.mock("config/feature-flags");
 
 describe("github-oauth-router", () => {
-
-	beforeEach(() => {
-		when(booleanFlag).calledWith(
-			BooleanFlags.RENEW_GITHUB_TOKEN,
-			expect.anything()
-		).mockResolvedValue(true);
-	});
 
 	describe("GithubOAuthCallbackGet", () => {
 

--- a/src/routes/github/github-oauth-router.ts
+++ b/src/routes/github/github-oauth-router.ts
@@ -6,7 +6,6 @@ import { envVars } from "config/env";
 import { Errors } from "config/errors";
 import { createAnonymousClientByGitHubAppId } from "~/src/util/get-github-client-config";
 import { createHashWithSharedSecret } from "utils/encryption";
-import { BooleanFlags, booleanFlag } from "config/feature-flags";
 import { GitHubServerApp } from "models/github-server-app";
 import { GithubServerAppMiddleware } from "middleware/github-server-app-middleware";
 import { GitHubAppConfig } from "~/src/sqs/sqs.types";
@@ -153,7 +152,7 @@ export const GithubAuthMiddleware = async (req: Request, res: Response, next: Ne
 		return next();
 	} catch (e) {
 		req.log.debug(`Github token is not valid.`);
-		if (await booleanFlag(BooleanFlags.RENEW_GITHUB_TOKEN, res.locals.jiraHost) && req.session?.githubRefreshToken) {
+		if (req.session?.githubRefreshToken) {
 			req.log.debug(`Trying to renew Github token...`);
 			const token = await renewGitHubToken(req.session.githubRefreshToken, res.locals.gitHubAppConfig, res.locals.jiraHost, logger);
 			if (token) {


### PR DESCRIPTION
**What's in this PR?**
Removed FF  RENEW_GITHUB_TOKEN

**Why**
This FF is enabled in production for last one month, so cleaning up.

**Affected issues**  
[ARC-2040]

[ARC-2040]: https://softwareteams.atlassian.net/browse/ARC-2040