### PR TITLE
ARC-1997: refactor usage of SQS in backfill to remove cyclic dependency

### DIFF
--- a/src/sqs/backfill.test.ts
+++ b/src/sqs/backfill.test.ts
@@ -51,7 +51,7 @@ describe("backfill", () => {
 			const mockedProcessor = jest.fn();
 			mocked(processInstallation).mockReturnValue(mockedProcessor);
 			mockedProcessor.mockRejectedValue(new Error("something went horribly wrong"));
-			await backfillQueueMessageHandler(BACKFILL_MESSAGE_CONTEXT).catch(e => getLogger("test").warn(e));
+			await backfillQueueMessageHandler({ queue: undefined })(BACKFILL_MESSAGE_CONTEXT).catch(e => getLogger("test").warn(e));
 			expect(sentryCaptureExceptionMock).toBeCalled();
 		});
 

--- a/src/sqs/backfill.test.ts
+++ b/src/sqs/backfill.test.ts
@@ -51,7 +51,7 @@ describe("backfill", () => {
 			const mockedProcessor = jest.fn();
 			mocked(processInstallation).mockReturnValue(mockedProcessor);
 			mockedProcessor.mockRejectedValue(new Error("something went horribly wrong"));
-			await backfillQueueMessageHandler({ queue: undefined })(BACKFILL_MESSAGE_CONTEXT).catch(e => getLogger("test").warn(e));
+			await backfillQueueMessageHandler(jest.fn())(BACKFILL_MESSAGE_CONTEXT).catch(e => getLogger("test").warn(e));
 			expect(sentryCaptureExceptionMock).toBeCalled();
 		});
 

--- a/src/sqs/backfill.ts
+++ b/src/sqs/backfill.ts
@@ -3,44 +3,54 @@ import * as Sentry from "@sentry/node";
 import { AxiosErrorEventDecorator } from "models/axios-error-event-decorator";
 import { SentryScopeProxy } from "models/sentry-scope-proxy";
 import { BackfillMessagePayload, MessageHandler, SQSMessageContext } from "./sqs.types";
+import { SqsQueue } from "~/src/sqs/sqs";
 
-export const backfillQueueMessageHandler: MessageHandler<BackfillMessagePayload> = async (context: SQSMessageContext<BackfillMessagePayload>) => {
-	const sentry = new Sentry.Hub(Sentry.getCurrentHub().getClient());
-	sentry.configureScope((scope) =>
-		scope.addEventProcessor(AxiosErrorEventDecorator.decorate)
-	);
-	sentry.configureScope((scope) =>
-		scope.addEventProcessor(SentryScopeProxy.processEvent)
-	);
+export const backfillQueueMessageHandler =
+	(backfillQueueHolder: { queue: SqsQueue<BackfillMessagePayload> | undefined }): MessageHandler<BackfillMessagePayload> =>
+		async (context: SQSMessageContext<BackfillMessagePayload>) => {
+			const sentry = new Sentry.Hub(Sentry.getCurrentHub().getClient());
+			sentry.configureScope((scope) =>
+				scope.addEventProcessor(AxiosErrorEventDecorator.decorate)
+			);
+			sentry.configureScope((scope) =>
+				scope.addEventProcessor(SentryScopeProxy.processEvent)
+			);
 
-	const { installationId, jiraHost } = context.payload;
-	context.log = context.log.child({
-		jiraHost,
-		gitHubInstallationId: installationId,
-		traceId: Date.now()
-	});
+			const { installationId, jiraHost } = context.payload;
+			context.log = context.log.child({
+				jiraHost,
+				gitHubInstallationId: installationId,
+				traceId: Date.now()
+			});
 
-	const backfillData = { ...context.payload };
+			const backfillData = { ...context.payload };
 
-	if (!backfillData.startTime) {
-		backfillData.startTime = new Date().toISOString();
-	}
+			if (!backfillData.startTime) {
+				backfillData.startTime = new Date().toISOString();
+			}
 
-	try {
-		const processor = await processInstallation();
-		await processor(backfillData, sentry, context.log);
-	} catch (err) {
-		sentry.setExtra("job", {
-			id: context.message.MessageId,
-			attemptsMade: parseInt(context.message.Attributes?.ApproximateReceiveCount || "1"),
-			timestamp: new Date(),
-			data: context.payload
-		});
+			try {
+				const processor = await processInstallation((message, delay, logger) => {
+					if (backfillQueueHolder.queue) {
+						return backfillQueueHolder.queue.sendMessage(message, delay, logger);
+					} else {
+						logger.error("Cannot send a message: queue is not initialised yet. Should never happen!");
+						throw new Error("Queue is not ready");
+					}
+				});
+				await processor(backfillData, sentry, context.log);
+			} catch (err) {
+				sentry.setExtra("job", {
+					id: context.message.MessageId,
+					attemptsMade: parseInt(context.message.Attributes?.ApproximateReceiveCount || "1"),
+					timestamp: new Date(),
+					data: context.payload
+				});
 
-		sentry.setTag("jiraHost", context.payload.jiraHost);
-		sentry.setTag("queue", "sqs-backfill");
-		sentry.captureException(err);
+				sentry.setTag("jiraHost", context.payload.jiraHost);
+				sentry.setTag("queue", "sqs-backfill");
+				sentry.captureException(err);
 
-		throw err;
-	}
-};
+				throw err;
+			}
+		};

--- a/src/sqs/backfill.ts
+++ b/src/sqs/backfill.ts
@@ -3,10 +3,10 @@ import * as Sentry from "@sentry/node";
 import { AxiosErrorEventDecorator } from "models/axios-error-event-decorator";
 import { SentryScopeProxy } from "models/sentry-scope-proxy";
 import { BackfillMessagePayload, MessageHandler, SQSMessageContext } from "./sqs.types";
-import { SqsQueue } from "~/src/sqs/sqs";
+import { SQS } from "aws-sdk";
 
 export const backfillQueueMessageHandler =
-	(backfillQueueHolder: { queue: SqsQueue<BackfillMessagePayload> | undefined }): MessageHandler<BackfillMessagePayload> =>
+	(sendSQSBackfillMessage: (message, delaySec, logger) => Promise<SQS.SendMessageResult>): MessageHandler<BackfillMessagePayload> =>
 		async (context: SQSMessageContext<BackfillMessagePayload>) => {
 			const sentry = new Sentry.Hub(Sentry.getCurrentHub().getClient());
 			sentry.configureScope((scope) =>
@@ -30,14 +30,7 @@ export const backfillQueueMessageHandler =
 			}
 
 			try {
-				const processor = await processInstallation((message, delay, logger) => {
-					if (backfillQueueHolder.queue) {
-						return backfillQueueHolder.queue.sendMessage(message, delay, logger);
-					} else {
-						logger.error("Cannot send a message: queue is not initialised yet. Should never happen!");
-						throw new Error("Queue is not ready");
-					}
-				});
+				const processor = await processInstallation(sendSQSBackfillMessage);
 				await processor(backfillData, sentry, context.log);
 			} catch (err) {
 				sentry.setExtra("job", {

--- a/src/sqs/queues.ts
+++ b/src/sqs/queues.ts
@@ -15,14 +15,10 @@ const logger = getLogger("sqs-queues");
 
 let backfillQueue: SqsQueue<BackfillMessagePayload> | undefined = undefined;
 
-const backfillQueueMessageSender = (message, delaySec, logger) => {
-	if (backfillQueue) {
-		return backfillQueue.sendMessage(message, delaySec, logger);
-	} else {
-		logger.error("Cannot send a message: queue is not initialised yet. Should never happen!");
-		throw new Error("Queue is not ready");
-	}
-};
+const backfillQueueMessageSender = (message, delaySec, logger) =>
+	// Given the single-threaded nature of Node.js, backfillQueue is always initialised
+	// because SqsQueue is not triggering messageHandler from ctor
+	backfillQueue!.sendMessage(message, delaySec, logger);
 
 backfillQueue = new SqsQueue<BackfillMessagePayload>(
 	{

--- a/src/sqs/queues.ts
+++ b/src/sqs/queues.ts
@@ -12,8 +12,13 @@ const LONG_POLLING_INTERVAL_SEC = 3;
 const logger = getLogger("sqs-queues");
 
 // TODO: Make this a class
-export const sqsQueues = {
-	backfill: new SqsQueue<BackfillMessagePayload>({
+
+const backfillQueueHolder: { queue: SqsQueue<BackfillMessagePayload> | undefined } = {
+	queue: undefined
+};
+
+backfillQueueHolder.queue = new SqsQueue<BackfillMessagePayload>(
+	{
 		queueName: "backfill",
 		queueUrl: envVars.SQS_BACKFILL_QUEUE_URL,
 		queueRegion: envVars.SQS_BACKFILL_QUEUE_REGION,
@@ -21,9 +26,12 @@ export const sqsQueues = {
 		timeoutSec: 10 * 60,
 		maxAttempts: 3
 	},
-	backfillQueueMessageHandler,
+	backfillQueueMessageHandler(backfillQueueHolder),
 	jiraAndGitHubErrorsHandler
-	),
+);
+
+export const sqsQueues = {
+	backfill: backfillQueueHolder.queue,
 
 	push: new SqsQueue<PushQueueMessagePayload>({
 		queueName: "push",

--- a/src/sync/build.test.ts
+++ b/src/sync/build.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires,@typescript-eslint/no-explicit-any */
 import { removeInterceptor } from "nock";
 import { processInstallation } from "./installation";
-import { sqsQueues } from "../sqs/queues";
 import { getLogger } from "config/logger";
 import { Hub } from "@sentry/types/dist/hub";
 import { BackfillMessagePayload } from "../sqs/sqs.types";
@@ -18,11 +17,11 @@ import { getBuildTask } from "./build";
 import { createInstallationClient } from "~/src/util/get-github-client-config";
 
 
-jest.mock("../sqs/queues");
 jest.mock("config/feature-flags");
 
 describe("sync/builds", () => {
 	const sentry: Hub = { setUser: jest.fn() } as any;
+	const mockBackfillQueueSendMessage = jest.fn();
 
 	const makeExpectedJiraResponse = (builds) => ({
 		builds,
@@ -96,8 +95,8 @@ describe("sync/builds", () => {
 			}
 		]);
 
-		await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
-		expect(sqsQueues.backfill.sendMessage).toBeCalledWith(data, 0, expect.anything());
+		await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
+		expect(mockBackfillQueueSendMessage).toBeCalledWith(data, 0, expect.anything());
 	});
 
 	it("should get proper jira payload that within from date when increment ff on", async () => {
@@ -168,8 +167,8 @@ describe("sync/builds", () => {
 			.post("/rest/builds/0.1/bulk")
 			.reply(200);
 
-		await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
-		expect(sqsQueues.backfill.sendMessage).toBeCalledWith(data, 0, expect.anything());
+		await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
+		expect(mockBackfillQueueSendMessage).toBeCalledWith(data, 0, expect.anything());
 		expect(nock.isDone()).toBeTruthy();
 		expect((await RepoSyncState.findByPk(repoSyncState!.id)).buildCursor).toEqual(String(Number(ORIGINAL_BUILDS_CURSOR) + 5));
 	});
@@ -203,8 +202,8 @@ describe("sync/builds", () => {
 			.post("/rest/builds/0.1/bulk")
 			.reply(200);
 
-		await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
-		expect(sqsQueues.backfill.sendMessage).toBeCalledWith(data, 0, expect.anything());
+		await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
+		expect(mockBackfillQueueSendMessage).toBeCalledWith(data, 0, expect.anything());
 		pageNocks.forEach(nock => {
 			expect(nock.isDone()).toBeTruthy();
 		});
@@ -227,7 +226,7 @@ describe("sync/builds", () => {
 				.reply(200, []);
 		});
 
-		await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+		await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
 		expect((await RepoSyncState.findByPk(repoSyncState!.id)).buildStatus).toEqual("complete");
 	});
 
@@ -297,8 +296,8 @@ describe("sync/builds", () => {
 			}
 		]);
 
-		await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
-		expect(sqsQueues.backfill.sendMessage).toBeCalledWith(data, 0, expect.anything());
+		await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
+		expect(mockBackfillQueueSendMessage).toBeCalledWith(data, 0, expect.anything());
 	});
 
 	it("should not call Jira if no issue keys are present", async () => {
@@ -319,7 +318,7 @@ describe("sync/builds", () => {
 		const interceptor = jiraNock.post(/.*/);
 		const scope = interceptor.reply(200);
 
-		await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+		await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
 		expect(scope).not.toBeDone();
 		removeInterceptor(interceptor);
 	});
@@ -335,7 +334,7 @@ describe("sync/builds", () => {
 		const interceptor = jiraNock.post(/.*/);
 		const scope = interceptor.reply(200);
 
-		await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+		await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
 		expect(scope).not.toBeDone();
 		removeInterceptor(interceptor);
 	});

--- a/src/sync/commits.test.ts
+++ b/src/sync/commits.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires,@typescript-eslint/no-explicit-any */
 import { removeInterceptor } from "nock";
 import { processInstallation } from "./installation";
-import { sqsQueues } from "../sqs/queues";
 import { getLogger } from "config/logger";
 import { Hub } from "@sentry/types/dist/hub";
 import { BackfillMessagePayload } from "../sqs/sqs.types";
@@ -15,7 +14,6 @@ import { DatabaseStateCreator } from "test/utils/database-state-creator";
 import { when } from "jest-when";
 import { numberFlag, NumberFlags } from "config/feature-flags";
 
-jest.mock("../sqs/queues");
 jest.mock("config/feature-flags");
 
 describe("sync/commits", () => {
@@ -26,7 +24,7 @@ describe("sync/commits", () => {
 	});
 
 	describe("for cloud", () => {
-		const mockBackfillQueueSendMessage = jest.mocked(sqsQueues.backfill.sendMessage);
+		const mockBackfillQueueSendMessage = jest.fn();
 
 		const makeExpectedJiraResponse = (commits) => ({
 			preventTransitions: true,
@@ -110,7 +108,7 @@ describe("sync/commits", () => {
 			];
 			createJiraNock(commits);
 
-			await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+			await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
 			await verifyMessageSent(data);
 		});
 
@@ -145,7 +143,7 @@ describe("sync/commits", () => {
 			];
 			createJiraNock(commits);
 
-			await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+			await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
 			await verifyMessageSent(data);
 		});
 
@@ -212,7 +210,7 @@ describe("sync/commits", () => {
 			];
 			createJiraNock(commits);
 
-			await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+			await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
 			await verifyMessageSent(data);
 		});
 
@@ -224,7 +222,7 @@ describe("sync/commits", () => {
 			const interceptor = jiraNock.post(/.*/);
 			const scope = interceptor.reply(200);
 
-			await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+			await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
 			expect(scope).not.toBeDone();
 			removeInterceptor(interceptor);
 		});
@@ -236,7 +234,7 @@ describe("sync/commits", () => {
 			const interceptor = jiraNock.post(/.*/);
 			const scope = interceptor.reply(200);
 
-			await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+			await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
 			expect(scope).not.toBeDone();
 			removeInterceptor(interceptor);
 		});
@@ -334,7 +332,7 @@ describe("sync/commits", () => {
 			];
 			await createJiraNock(commits);
 
-			await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+			await expect(processInstallation(jest.fn())(data, sentry, getLogger("test"))).toResolve();
 		});
 
 	});

--- a/src/sync/deployment.test.ts
+++ b/src/sync/deployment.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires,@typescript-eslint/no-explicit-any */
 import { removeInterceptor } from "nock";
 import { processInstallation } from "./installation";
-import { sqsQueues } from "../sqs/queues";
 import { getLogger } from "config/logger";
 import { Hub } from "@sentry/types/dist/hub";
 import { BackfillMessagePayload } from "../sqs/sqs.types";
@@ -18,13 +17,12 @@ import { createInstallationClient } from "~/src/util/get-github-client-config";
 import { getDeploymentTask } from "./deployment";
 import { RepoSyncState } from "models/reposyncstate";
 
-jest.mock("../sqs/queues");
 jest.mock("config/feature-flags");
 
 describe("sync/deployments", () => {
 	const installationId = DatabaseStateCreator.GITHUB_INSTALLATION_ID;
 	const sentry: Hub = { setUser: jest.fn() } as any;
-	const mockBackfillQueueSendMessage = jest.mocked(sqsQueues.backfill.sendMessage);
+	const mockBackfillQueueSendMessage = jest.fn();
 	const makeExpectedJiraResponse = (deployments) => ({
 		deployments,
 		properties: {
@@ -242,7 +240,7 @@ describe("sync/deployments", () => {
 					}]
 			}]);
 
-			await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+			await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
 			await verifyMessageSent(data);
 		});
 
@@ -409,7 +407,7 @@ describe("sync/deployments", () => {
 				}
 			]);
 
-			await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+			await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
 			await verifyMessageSent(data);
 		});
 
@@ -435,7 +433,7 @@ describe("sync/deployments", () => {
 			const interceptor = jiraNock.post(/.*/);
 			const scope = interceptor.reply(200);
 
-			await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+			await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
 			expect(scope).not.toBeDone();
 			removeInterceptor(interceptor);
 		});
@@ -447,7 +445,7 @@ describe("sync/deployments", () => {
 			const interceptor = jiraNock.post(/.*/);
 			const scope = interceptor.reply(200);
 
-			await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+			await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
 			expect(scope).not.toBeDone();
 			removeInterceptor(interceptor);
 		});
@@ -627,7 +625,7 @@ describe("sync/deployments", () => {
 					}]
 			}]);
 
-			await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+			await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
 			await verifyMessageSent(data);
 		});
 

--- a/src/sync/installation.test.ts
+++ b/src/sync/installation.test.ts
@@ -6,12 +6,13 @@ import { DeduplicatorResult } from "~/src/sync/deduplicator";
 import { getLogger } from "config/logger";
 import { Hub } from "@sentry/types/dist/hub";
 import { GithubClientGraphQLError, RateLimitingError } from "~/src/github/client/github-client-errors";
-import { Repository, Subscription } from "models/subscription";
+import { Repository } from "models/subscription";
 import { mockNotFoundErrorOctokitGraphql, mockOtherOctokitRequestErrors } from "test/mocks/error-responses";
 import { v4 as UUID } from "uuid";
 import { ConnectionTimedOutError, Sequelize } from "sequelize";
 import { AxiosError, AxiosResponse } from "axios";
 import { createAnonymousClient } from "utils/get-github-client-config";
+import { DatabaseStateCreator } from "test/utils/database-state-creator";
 
 const mockedExecuteWithDeduplication = jest.fn();
 jest.mock("~/src/sync/deduplicator", () => ({
@@ -23,21 +24,28 @@ jest.mock("~/src/sync/deduplicator", () => ({
 
 describe("sync/installation", () => {
 
+	let JOB_DATA;
+	let JOB_DATA_GHES;
+
+	beforeEach(async () => {
+		await new DatabaseStateCreator().create();
+		JOB_DATA = { installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost };
+		JOB_DATA_GHES = {
+			installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID,
+			jiraHost,
+			gitHubAppConfig: {
+				gitHubAppId: GITHUB_APP_ID,
+				appId: 2,
+				clientId: "client_id",
+				gitHubBaseUrl: "http://ghes.server",
+				gitHubApiUrl: "http://ghes.server",
+				uuid: UUID()
+			}
+		};
+	});
+
 	const TEST_LOGGER = getLogger("test");
-	const JOB_DATA = { installationId: 1, jiraHost: "http://foo" };
 	const GITHUB_APP_ID = 123;
-	const JOB_DATA_GHES = {
-		installationId: 1,
-		jiraHost: "http://foo-ghes",
-		gitHubAppConfig: {
-			gitHubAppId: GITHUB_APP_ID,
-			appId: 2,
-			clientId: "client_id",
-			gitHubBaseUrl: "http://ghes.server",
-			gitHubApiUrl: "http://ghes.server",
-			uuid: UUID()
-		}
-	};
 
 	const TEST_REPO: Repository = {
 		id: 123,
@@ -49,8 +57,6 @@ describe("sync/installation", () => {
 	};
 
 	const TASK: Task = { task: "commit", repositoryId: 123, repository: TEST_REPO };
-
-	const TEST_SUBSCRIPTION: Subscription = {} as any;
 
 	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 	// @ts-ignore
@@ -89,14 +95,14 @@ describe("sync/installation", () => {
 		it("should process the installation with deduplication for cloud", async () => {
 			await processInstallation(jest.fn())(JOB_DATA, sentry, TEST_LOGGER);
 			expect(mockedExecuteWithDeduplication.mock.calls.length).toBe(1);
-			expect(mockedExecuteWithDeduplication).toBeCalledWith(`i-1-http://foo-ghaid-cloud`, expect.anything());
+			expect(mockedExecuteWithDeduplication).toBeCalledWith(`i-${DatabaseStateCreator.GITHUB_INSTALLATION_ID}-${jiraHost}-ghaid-cloud`, expect.anything());
 		});
 
 		it("should process the installation with deduplication for GHES", async () => {
 			const sendSqsMessage = jest.fn();
 			await processInstallation(sendSqsMessage)(JOB_DATA_GHES, sentry, TEST_LOGGER);
 			expect(mockedExecuteWithDeduplication.mock.calls.length).toBe(1);
-			expect(mockedExecuteWithDeduplication).toBeCalledWith(`i-1-http://foo-ghes-ghaid-${GITHUB_APP_ID}`, expect.anything());
+			expect(mockedExecuteWithDeduplication).toBeCalledWith(`i-${DatabaseStateCreator.GITHUB_INSTALLATION_ID}-${jiraHost}-ghaid-${GITHUB_APP_ID}`, expect.anything());
 		});
 
 		it("should reschedule the job if deduplicator is unsure", async () => {
@@ -169,7 +175,7 @@ describe("sync/installation", () => {
 				new RateLimitingError(
 					{ response: axiosResponse } as unknown as AxiosError
 				),
-				JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask
+				JOB_DATA, TASK, TEST_LOGGER, scheduleNextTask
 			);
 
 			expect(scheduleNextTask).toBeCalledWith(14322);
@@ -191,7 +197,7 @@ describe("sync/installation", () => {
 
 			await handleBackfillError(new RateLimitingError({
 				response: axiosResponse
-			} as unknown as AxiosError), JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
+			} as unknown as AxiosError), JOB_DATA, TASK, TEST_LOGGER, scheduleNextTask);
 			expect(scheduleNextTask).toBeCalledWith(0);
 			expect(updateStatusSpy).toHaveBeenCalledTimes(0);
 			expect(failRepoSpy).toHaveBeenCalledTimes(0);
@@ -216,7 +222,7 @@ describe("sync/installation", () => {
 				status: 403
 			};
 
-			await handleBackfillError(probablyRateLimitError, JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
+			await handleBackfillError(probablyRateLimitError, JOB_DATA, TASK, TEST_LOGGER, scheduleNextTask);
 			expect(scheduleNextTask).toBeCalledWith(14322);
 			expect(updateStatusSpy).toHaveBeenCalledTimes(0);
 			expect(failRepoSpy).toHaveBeenCalledTimes(0);
@@ -230,7 +236,7 @@ describe("sync/installation", () => {
 			try {
 				await client.getMainPage(1000);
 			} catch (err) {
-				await handleBackfillError(err, JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
+				await handleBackfillError(err, JOB_DATA, TASK, TEST_LOGGER, scheduleNextTask);
 			}
 
 			expect(scheduleNextTask).toHaveBeenCalledTimes(0);
@@ -240,14 +246,14 @@ describe("sync/installation", () => {
 
 		it("Repository ignored if GraphQL not found error", async () => {
 
-			await handleBackfillError(new GithubClientGraphQLError({ } as AxiosResponse, mockNotFoundErrorOctokitGraphql.errors), JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
+			await handleBackfillError(new GithubClientGraphQLError({ } as AxiosResponse, mockNotFoundErrorOctokitGraphql.errors), JOB_DATA, TASK, TEST_LOGGER, scheduleNextTask);
 			expect(scheduleNextTask).toHaveBeenCalledTimes(0);
 			expect(updateStatusSpy).toHaveBeenCalledTimes(1);
 			expect(failRepoSpy).toHaveBeenCalledTimes(0);
 		});
 
 		it("Repository failed if some kind of unknown error", async () => {
-			await handleBackfillError(mockOtherOctokitRequestErrors, JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
+			await handleBackfillError(mockOtherOctokitRequestErrors, JOB_DATA, TASK, TEST_LOGGER, scheduleNextTask);
 			expect(scheduleNextTask).toHaveBeenCalledTimes(0);
 			expect(updateStatusSpy).toHaveBeenCalledTimes(0);
 			expect(failRepoSpy).toHaveBeenCalledTimes(1);
@@ -273,7 +279,7 @@ describe("sync/installation", () => {
 				status: 403
 			};
 
-			await handleBackfillError(abuseDetectionError, JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
+			await handleBackfillError(abuseDetectionError, JOB_DATA, TASK, TEST_LOGGER, scheduleNextTask);
 			expect(scheduleNextTask).toHaveBeenCalledWith(60_000);
 			expect(updateStatusSpy).toHaveBeenCalledTimes(0);
 			expect(failRepoSpy).toHaveBeenCalledTimes(0);
@@ -282,7 +288,7 @@ describe("sync/installation", () => {
 		it("5s delay if connection timeout", async () => {
 			const connectionTimeoutErr = "connect ETIMEDOUT";
 
-			await handleBackfillError(connectionTimeoutErr, JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
+			await handleBackfillError(connectionTimeoutErr, JOB_DATA, TASK, TEST_LOGGER, scheduleNextTask);
 			expect(scheduleNextTask).toHaveBeenCalledWith(5_000);
 			expect(updateStatusSpy).toHaveBeenCalledTimes(0);
 			expect(failRepoSpy).toHaveBeenCalledTimes(0);
@@ -291,7 +297,7 @@ describe("sync/installation", () => {
 		it("30s delay if cannot connect", async () => {
 			const connectionRefusedError = "connect ECONNREFUSED 10.255.0.9:26272";
 
-			await handleBackfillError(connectionRefusedError, JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
+			await handleBackfillError(connectionRefusedError, JOB_DATA, TASK, TEST_LOGGER, scheduleNextTask);
 			expect(scheduleNextTask).toHaveBeenCalledWith(30_000);
 			expect(updateStatusSpy).toHaveBeenCalledTimes(0);
 			expect(failRepoSpy).toHaveBeenCalledTimes(0);
@@ -300,7 +306,7 @@ describe("sync/installation", () => {
 		it("30s delay if cannot connect to database", async () => {
 			const connectionRefusedError = new ConnectionTimedOutError(new Error("foo"));
 
-			await handleBackfillError(connectionRefusedError, JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
+			await handleBackfillError(connectionRefusedError, JOB_DATA, TASK, TEST_LOGGER, scheduleNextTask);
 			expect(scheduleNextTask).toHaveBeenCalledWith(30_000);
 			expect(updateStatusSpy).toHaveBeenCalledTimes(0);
 			expect(failRepoSpy).toHaveBeenCalledTimes(0);
@@ -322,7 +328,7 @@ describe("sync/installation", () => {
 				sequelizeConnectionError = err;
 			}
 
-			await handleBackfillError(sequelizeConnectionError, JOB_DATA, TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
+			await handleBackfillError(sequelizeConnectionError, JOB_DATA, TASK, TEST_LOGGER, scheduleNextTask);
 			expect(scheduleNextTask).toHaveBeenCalledWith(30_000);
 			expect(updateStatusSpy).toHaveBeenCalledTimes(0);
 			expect(failRepoSpy).toHaveBeenCalledTimes(0);
@@ -332,7 +338,7 @@ describe("sync/installation", () => {
 			const connectionTimeoutErr = "an error that doesnt match";
 			const MOCK_REPO_TASK: Task = { task: "repository", repositoryId: 0, repository: TEST_REPO };
 
-			await handleBackfillError(connectionTimeoutErr, JOB_DATA, MOCK_REPO_TASK, TEST_SUBSCRIPTION, TEST_LOGGER, scheduleNextTask);
+			await handleBackfillError(connectionTimeoutErr, JOB_DATA, MOCK_REPO_TASK, TEST_LOGGER, scheduleNextTask);
 			expect(scheduleNextTask).toHaveBeenCalledTimes(0);
 			expect(updateStatusSpy).toHaveBeenCalledTimes(0);
 			expect(failRepoSpy).toHaveBeenCalledTimes(1);

--- a/src/sync/pull-requests.test.ts
+++ b/src/sync/pull-requests.test.ts
@@ -282,7 +282,7 @@ describe("sync/pull-request", () => {
 
 				jiraNock.post("/rest/devinfo/0.10/bulk", buildJiraPayload("1")).reply(200);
 
-				await expect(processInstallation()({
+				await expect(processInstallation(jest.fn())({
 					installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID,
 					jiraHost
 				}, sentry, getLogger("test"))).toResolve();
@@ -341,7 +341,7 @@ describe("sync/pull-request", () => {
 
 			jiraNock.post("/rest/devinfo/0.10/bulk", buildJiraPayload("1")).reply(200);
 
-			await expect(processInstallation()({
+			await expect(processInstallation(jest.fn())({
 				installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID,
 				jiraHost
 			}, sentry, getLogger("test"))).toResolve();
@@ -398,7 +398,7 @@ describe("sync/pull-request", () => {
 
 			jiraNock.post("/rest/devinfo/0.10/bulk", buildJiraPayload("1", 2)).reply(200);
 
-			await expect(processInstallation()({
+			await expect(processInstallation(jest.fn())({
 				installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID,
 				jiraHost
 			}, sentry, getLogger("test"))).toResolve();
@@ -429,7 +429,7 @@ describe("sync/pull-request", () => {
 				.get("/repos/integrations/test-repo-name/pulls?per_page=100&page=6&state=all&sort=created&direction=desc")
 				.reply(200, []);
 
-			await expect(processInstallation()({
+			await expect(processInstallation(jest.fn())({
 				installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID,
 				jiraHost
 			}, sentry, getLogger("test"))).toResolve();
@@ -448,7 +448,7 @@ describe("sync/pull-request", () => {
 			const interceptor = jiraNock.post(/.*/);
 			const scope = interceptor.reply(200);
 
-			await expect(processInstallation()({
+			await expect(processInstallation(jest.fn())({
 				installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID,
 				jiraHost
 			}, sentry, getLogger("test"))).toResolve();
@@ -465,7 +465,7 @@ describe("sync/pull-request", () => {
 			const interceptor = jiraNock.post(/.*/);
 			const scope = interceptor.reply(200);
 
-			await expect(processInstallation()({
+			await expect(processInstallation(jest.fn())({
 				installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID,
 				jiraHost
 			}, sentry, getLogger("test"))).toResolve();
@@ -597,7 +597,7 @@ describe("sync/pull-request", () => {
 				}
 			};
 
-			await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+			await expect(processInstallation(jest.fn())(data, sentry, getLogger("test"))).toResolve();
 		});
 	});
 
@@ -637,7 +637,7 @@ describe("sync/pull-request", () => {
 				jiraNock.post("/rest/devinfo/0.10/bulk", buildJiraPayloadOldCloud("1")).reply(200);
 
 
-				await expect(processInstallation()({
+				await expect(processInstallation(jest.fn())({
 					installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID,
 					jiraHost
 				}, sentry, getLogger("test"))).toResolve();
@@ -654,7 +654,7 @@ describe("sync/pull-request", () => {
 			const interceptor = jiraNock.post(/.*/);
 			const scope = interceptor.reply(200);
 
-			await expect(processInstallation()({
+			await expect(processInstallation(jest.fn())({
 				installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID,
 				jiraHost
 			}, sentry, getLogger("test"))).toResolve();
@@ -671,7 +671,7 @@ describe("sync/pull-request", () => {
 			const interceptor = jiraNock.post(/.*/);
 			const scope = interceptor.reply(200);
 
-			await expect(processInstallation()({
+			await expect(processInstallation(jest.fn())({
 				installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID,
 				jiraHost
 			}, sentry, getLogger("test"))).toResolve();
@@ -723,7 +723,7 @@ describe("sync/pull-request", () => {
 				}
 			};
 
-			await expect(processInstallation()(data, sentry, getLogger("test"))).toResolve();
+			await expect(processInstallation(jest.fn())(data, sentry, getLogger("test"))).toResolve();
 		});
 	});
 });


### PR DESCRIPTION
**What's in this PR?**
Replacing calling sqs in backfill with dependency injection. It all comes down to the change of signatures of
 - processInstallation
 - doProcessInstallation
 - markCurrentTaskAsFailedAndContinue

The rest is just to make the code work with the new signature...

**Why**
To streamline the dependency path in the code and to avoid cyclic dependencies. To handle backfilling, we need more calls from SQS "package" to backfill, therefore trying to simplify it beforehand.