### PR TITLE
ARC-1997: move remnants of error handling from sync/installations to sqs

### DIFF
--- a/src/config/metric-names.ts
+++ b/src/config/metric-names.ts
@@ -39,6 +39,7 @@ export const metricSyncStatus = {
 
 export const metricTaskStatus = {
 	complete: `${server}.task-status.complete`,
+	pending: `${server}.task-status.pending`,
 	failed: `${server}.task-status.failed`
 };
 

--- a/src/github/client/github-client-errors.ts
+++ b/src/github/client/github-client-errors.ts
@@ -52,7 +52,7 @@ export class GithubClientInvalidPermissionsError extends GithubClientError {
 	}
 }
 
-export class GithubNotFoundError extends GithubClientError {
+export class GithubClientNotFoundError extends GithubClientError {
 	constructor(cause: AxiosError) {
 		super("Not found", cause);
 	}

--- a/src/github/client/github-client-interceptors.test.ts
+++ b/src/github/client/github-client-interceptors.test.ts
@@ -1,6 +1,6 @@
 import { createAnonymousClient } from "utils/get-github-client-config";
 import { getLogger } from "config/logger";
-import { GithubClientInvalidPermissionsError, GithubNotFoundError } from "~/src/github/client/github-client-errors";
+import { GithubClientInvalidPermissionsError, GithubClientNotFoundError } from "~/src/github/client/github-client-errors";
 
 describe("github-client-interceptors", () => {
 	it("correctly maps invalid permission error", async () => {
@@ -32,7 +32,7 @@ describe("github-client-interceptors", () => {
 		} catch (err) {
 			error = err;
 		}
-		expect(error!).toBeInstanceOf(GithubNotFoundError);
+		expect(error!).toBeInstanceOf(GithubClientNotFoundError);
 	});
 
 

--- a/src/github/client/github-client-interceptors.ts
+++ b/src/github/client/github-client-interceptors.ts
@@ -4,7 +4,7 @@ import {
 	GithubClientTimeoutError,
 	GithubClientInvalidPermissionsError,
 	GithubClientRateLimitingError,
-	GithubNotFoundError
+	GithubClientNotFoundError
 } from "./github-client-errors";
 import Logger from "bunyan";
 import { statsd } from "config/statsd";
@@ -147,7 +147,7 @@ export const handleFailedRequest = (rootLogger: Logger) =>
 			}
 
 			if (status === 404) {
-				const mappedError = new GithubNotFoundError(err);
+				const mappedError = new GithubClientNotFoundError(err);
 				logger.warn({
 					err: mappedError,
 					remote: response.data.message

--- a/src/github/client/github-client.nock.test.ts
+++ b/src/github/client/github-client.nock.test.ts
@@ -5,7 +5,7 @@ import { GitHubClient, GitHubConfig } from "~/src/github/client/github-client";
 import { getLogger } from "config/logger";
 import {
 	GithubClientInvalidPermissionsError,
-	GithubClientRateLimitingError, GithubNotFoundError
+	GithubClientRateLimitingError, GithubClientNotFoundError
 } from "~/src/github/client/github-client-errors";
 
 class TestGitHubClient extends GitHubClient {
@@ -128,7 +128,7 @@ describe("GitHub Client (nock)", () => {
 			} catch (caught) {
 				err = caught;
 			}
-			expect(err!).toBeInstanceOf(GithubNotFoundError);
+			expect(err!).toBeInstanceOf(GithubClientNotFoundError);
 		});
 	});
 

--- a/src/github/client/github-client.ts
+++ b/src/github/client/github-client.ts
@@ -6,7 +6,7 @@ import { GraphQlQueryResponse } from "~/src/github/client/github-client.types";
 import {
 	buildAxiosStubErrorForGraphQlErrors,
 	GithubClientGraphQLError, GithubClientInvalidPermissionsError,
-	GithubClientRateLimitingError, GithubNotFoundError
+	GithubClientRateLimitingError, GithubClientNotFoundError
 } from "~/src/github/client/github-client-errors";
 import {
 	handleFailedRequest, instrumentFailedRequest, instrumentRequest,
@@ -112,7 +112,7 @@ export class GitHubClient {
 
 			} else if (graphqlErrors.find(graphQLError => graphQLError.type == "NOT_FOUND")) {
 				this.logger.info({ err }, "Mapping GraphQL error to not found");
-				return Promise.reject(new GithubNotFoundError(buildAxiosStubErrorForGraphQlErrors(response)));
+				return Promise.reject(new GithubClientNotFoundError(buildAxiosStubErrorForGraphQlErrors(response)));
 			}
 			return Promise.reject(err);
 		}

--- a/src/sqs/backfill-error-handler.test.ts
+++ b/src/sqs/backfill-error-handler.test.ts
@@ -8,38 +8,101 @@ import { Task } from "~/src/sync/sync.types";
 import { DatabaseStateCreator } from "test/utils/database-state-creator";
 import _ from "lodash";
 import { RepoSyncState } from "models/reposyncstate";
-import { GithubClientInvalidPermissionsError } from "~/src/github/client/github-client-errors";
+import {
+	GithubClientError,
+	GithubClientInvalidPermissionsError, GithubClientNotFoundError, GithubClientRateLimitingError
+} from "~/src/github/client/github-client-errors";
 import { AxiosError } from "axios";
+import { createAnonymousClient } from "utils/get-github-client-config";
+import { JiraClientError } from "~/src/jira/client/axios";
+import { JiraClient } from "models/jira-client";
+import { Installation } from "models/installation";
+
+const TEST_REPO: Repository = {
+	id: 123,
+	name: "Test",
+	full_name: "Test/Test",
+	owner: { login: "test" },
+	html_url: "https://test",
+	updated_at: "1234"
+};
 
 describe("backfillErrorHandler", () => {
-	const mockPayload = {
-		repository: {
-			id: 0,
-			name: "string",
-			full_name: "string",
-			html_url: "string",
-			owner: "string"
-		},
-		shas: [],
-		jiraHost: "string",
-		installationId: 0,
-		webhookId: "string"
+	const MOCKED_TIMESTAMP_MSECS = 12_345_678;
+
+	let installation: Installation;
+	let subscription: Subscription;
+	let repoSyncState: RepoSyncState;
+	let task: Task;
+	let sendMessageMock: jest.Mock;
+
+	beforeEach(async () => {
+		mockSystemTime(MOCKED_TIMESTAMP_MSECS);
+
+		const ret = await new DatabaseStateCreator().withActiveRepoSyncState().create();
+		installation = ret.installation;
+		subscription = ret.subscription;
+		repoSyncState = ret.repoSyncState!;
+
+		task = { task: "commit", repositoryId: repoSyncState?.repoId, repository: _.cloneDeep(TEST_REPO) };
+		sendMessageMock = jest.fn();
+	});
+
+	const createRateLimitingError = async (resetTime: number): Promise<GithubClientRateLimitingError | undefined> => {
+		gheNock.get("/")
+			.reply(403, {}, {
+				"access-control-allow-origin": "*",
+				"connection": "close",
+				"content-type": "application/json; charset=utf-8",
+				"date": "Fri, 04 Mar 2022 21:09:27 GMT",
+				"x-ratelimit-limit": "8900",
+				"x-ratelimit-remaining": "0",
+				"x-ratelimit-reset": "" + resetTime,
+				"x-ratelimit-resource": "core",
+				"x-ratelimit-used": "2421"
+			});
+
+		const client = await createAnonymousClient(gheUrl, jiraHost, getLogger("test"));
+		try {
+			await client.getMainPage(1000);
+		} catch (err) {
+			return err;
+		}
+		return undefined;
 	};
 
-	const TEST_REPO: Repository = {
-		id: 123,
-		name: "Test",
-		full_name: "Test/Test",
-		owner: { login: "test" },
-		html_url: "https://test",
-		updated_at: "1234"
+	const create500FromGitHub = async (): Promise<GithubClientError | undefined> => {
+		gheNock.get("/")
+			.reply(500);
+
+		const client = await createAnonymousClient(gheUrl, jiraHost, getLogger("test"));
+		try {
+			await client.getMainPage(1000);
+		} catch (err) {
+			return err;
+		}
+		return undefined;
 	};
 
-	const TASK: Task = { task: "commit", repositoryId: 123, repository: TEST_REPO };
+	const create500FromJira = async (): Promise<JiraClientError | undefined> => {
+		const client = await JiraClient.getNewClient(installation, getLogger("test"));
+
+		jiraNock.get(/.*/).reply(500, { });
+
+		try {
+			await client.appPropertiesGet();
+		} catch (ex) {
+			return ex;
+		}
+		return undefined;
+	};
 
 	const createContext = (receiveCount: number, lastAttempt: boolean): SQSMessageContext<BackfillMessagePayload> =>
 		({
-			receiveCount, lastAttempt, log: getLogger("test"), message: {}, payload: mockPayload
+			receiveCount, lastAttempt, log: getLogger("test"), message: {}, payload: {
+				jiraHost,
+				installationId: subscription.gitHubInstallationId
+			}
 		});
 
 	it("retries unknown errors with exponential timeout", async () => {
@@ -86,7 +149,31 @@ describe("backfillErrorHandler", () => {
 			sequelizeConnectionError = err;
 		}
 
-		const result = await backfillErrorHandler(jest.fn())(new TaskError(TASK, sequelizeConnectionError), createContext(2, false));
+		const result = await backfillErrorHandler(jest.fn())(new TaskError(task, sequelizeConnectionError), createContext(2, false));
+		expect(result).toEqual({
+			isFailure: true,
+			retryDelaySec: 540,
+			retryable: true
+		});
+	});
+
+	it("retries 500s from GitHub with exponential timeout", async () => {
+		const result = await backfillErrorHandler(jest.fn())(
+			new TaskError(task, (await create500FromGitHub())!),
+			createContext(2, false)
+		);
+		expect(result).toEqual({
+			isFailure: true,
+			retryDelaySec: 540,
+			retryable: true
+		});
+	});
+
+	it("retries 500s from Jira with exponential timeout", async () => {
+		const result = await backfillErrorHandler(jest.fn())(
+			new TaskError(task, (await create500FromJira())!),
+			createContext(2, false)
+		);
 		expect(result).toEqual({
 			isFailure: true,
 			retryDelaySec: 540,
@@ -95,19 +182,10 @@ describe("backfillErrorHandler", () => {
 	});
 
 	it("marks task as failed and reschedules message on last attempt", async () => {
-		const { subscription, repoSyncState } = await new DatabaseStateCreator().withActiveRepoSyncState().create();
-
-		const context = createContext(5, true);
-		context.payload = {
-			jiraHost,
-			installationId: subscription.gitHubInstallationId
-		};
-
-		const task = _.cloneDeep(TASK);
-		task.repositoryId = repoSyncState?.repoId || -1;
-
-		const sendMessageMock = jest.fn();
-		const result = await backfillErrorHandler(sendMessageMock)(new TaskError(task, new Error("boom")), context);
+		const result = await backfillErrorHandler(sendMessageMock)(
+			new TaskError(task, new Error("boom")),
+			createContext(5, true)
+		);
 
 		expect(result).toEqual({
 			isFailure: false
@@ -120,19 +198,10 @@ describe("backfillErrorHandler", () => {
 	});
 
 	it("marks task as failed and reschedules message on permission error", async () => {
-		const { subscription, repoSyncState } = await new DatabaseStateCreator().withActiveRepoSyncState().create();
-
-		const context = createContext(5, true);
-		context.payload = {
-			jiraHost,
-			installationId: subscription.gitHubInstallationId
-		};
-
-		const task = _.cloneDeep(TASK);
-		task.repositoryId = repoSyncState?.repoId || -1;
-
-		const sendMessageMock = jest.fn();
-		const result = await backfillErrorHandler(sendMessageMock)(new TaskError(task, new GithubClientInvalidPermissionsError({ } as unknown as AxiosError)), context);
+		const result = await backfillErrorHandler(sendMessageMock)(
+			new TaskError(task, new GithubClientInvalidPermissionsError({ } as unknown as AxiosError)),
+			createContext(5, true)
+		);
 
 		expect(result).toEqual({
 			isFailure: false
@@ -143,5 +212,53 @@ describe("backfillErrorHandler", () => {
 		expect(sendMessageMock.mock.calls[0][1]).toEqual(0);
 		expect((await RepoSyncState.findByPk(repoSyncState!.id)).commitStatus).toEqual("failed");
 		expect((await Subscription.findByPk(repoSyncState!.subscriptionId)).syncWarning).toEqual("Invalid permissions for commit task");
+	});
+
+	it("reschedules rate-limited errors with the correct delay", async () => {
+		const RATE_LIMIT_RESET_TIMESTAMP_SECS = 12360;
+
+		const context = createContext(3, false);
+		const result =  await backfillErrorHandler(sendMessageMock)(
+			new TaskError(
+				task,
+				(await createRateLimitingError(RATE_LIMIT_RESET_TIMESTAMP_SECS))!
+			),
+			context
+		);
+
+		expect(sendMessageMock).toBeCalledWith(context.payload, (RATE_LIMIT_RESET_TIMESTAMP_SECS * 1000 - MOCKED_TIMESTAMP_MSECS) / 1000, expect.anything());
+		expect(result.isFailure).toBeFalsy();
+	});
+
+	it("reschedules rate-limited errors with the correct delay when header points to the past", async () => {
+		const RATE_LIMIT_RESET_TIMESTAMP_SECS = 12;
+
+		const context = createContext(3, false);
+		const result =  await backfillErrorHandler(sendMessageMock)(
+			new TaskError(
+				task,
+				(await createRateLimitingError(RATE_LIMIT_RESET_TIMESTAMP_SECS))!
+			),
+			context
+		);
+
+		expect(sendMessageMock).toBeCalledWith(context.payload, 0, expect.anything());
+		expect(result.isFailure).toBeFalsy();
+	});
+
+	it("not found error marks the task as done and continues", async () => {
+		const result = await backfillErrorHandler(sendMessageMock)(
+			new TaskError(task, new GithubClientNotFoundError({ } as unknown as AxiosError)),
+			createContext(3, false)
+		);
+
+		expect(result).toEqual({
+			isFailure: false
+		});
+		expect(sendMessageMock.mock.calls[0][0]).toEqual(
+			{ installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost }
+		);
+		expect(sendMessageMock.mock.calls[0][1]).toEqual(0);
+		expect((await RepoSyncState.findByPk(repoSyncState!.id)).commitStatus).toEqual("complete");
 	});
 });

--- a/src/sqs/backfill-error-handler.ts
+++ b/src/sqs/backfill-error-handler.ts
@@ -21,9 +21,6 @@ const handleTaskError = async (sendSQSBackfillMessage: (message, delaySec, logge
 	});
 	log.info("Handling error task");
 
-	// TODO: add more task-related logic: e.g. mark as complete for 404; retry on RateLimiting errors etc
-
-
 	if (cause instanceof GithubClientInvalidPermissionsError) {
 		log.warn("InvalidPermissionError: marking the task as failed and continue with the next one");
 		await markCurrentTaskAsFailedAndContinue(context.payload, task, true, sendSQSBackfillMessage, log);

--- a/src/sqs/backfill-error-handler.ts
+++ b/src/sqs/backfill-error-handler.ts
@@ -1,10 +1,16 @@
 import { BackfillMessagePayload, ErrorHandler, ErrorHandlingResult, SQSMessageContext } from "~/src/sqs/sqs.types";
-import { markCurrentTaskAsFailedAndContinue, TaskError } from "~/src/sync/installation";
+import {
+	markCurrentTaskAsFailedAndContinue,
+	TaskError,
+	updateTaskStatusAndContinue
+} from "~/src/sync/installation";
 import { Task } from "~/src/sync/sync.types";
 import { handleUnknownError } from "~/src/sqs/error-handlers";
 import Logger from "bunyan";
 import { SQS } from "aws-sdk";
-import { GithubClientInvalidPermissionsError } from "~/src/github/client/github-client-errors";
+import {
+	GithubClientInvalidPermissionsError, GithubClientNotFoundError, GithubClientRateLimitingError
+} from "~/src/github/client/github-client-errors";
 
 const handleTaskError = async (sendSQSBackfillMessage: (message, delaySec, logger) => Promise<SQS.SendMessageResult>, task: Task, cause: Error, context: SQSMessageContext<BackfillMessagePayload>, rootLogger: Logger
 ) => {
@@ -21,6 +27,31 @@ const handleTaskError = async (sendSQSBackfillMessage: (message, delaySec, logge
 	if (cause instanceof GithubClientInvalidPermissionsError) {
 		log.warn("InvalidPermissionError: marking the task as failed and continue with the next one");
 		await markCurrentTaskAsFailedAndContinue(context.payload, task, true, sendSQSBackfillMessage, log);
+		return {
+			isFailure: false
+		};
+	}
+
+	if (cause instanceof GithubClientRateLimitingError) {
+		const delayMs = Math.max(cause.rateLimitReset * 1000 - Date.now(), 0);
+
+		// Always schedule a new message: rate-limiting might take long and we
+		// don't want to exhaust all retries
+		if (delayMs) {
+			log.info({ delay: delayMs }, `Delaying job for ${delayMs}ms`);
+			await sendSQSBackfillMessage(context.payload, delayMs / 1000, log);
+		} else {
+			log.info("Rate limit was reset already. Scheduling next task");
+			await sendSQSBackfillMessage(context.payload, 0, log);
+		}
+		return {
+			isFailure: false
+		};
+	}
+
+	if (cause instanceof GithubClientNotFoundError) {
+		log.info("Repo was deleted, marking the task as completed");
+		await updateTaskStatusAndContinue(context.payload, { edges: [] }, task,  log, sendSQSBackfillMessage);
 		return {
 			isFailure: false
 		};

--- a/src/sync/installation.test.ts
+++ b/src/sync/installation.test.ts
@@ -1,6 +1,5 @@
 import {
 	getTargetTasks,
-	handleBackfillError,
 	isRetryableWithSmallerRequest, markCurrentTaskAsFailedAndContinue,
 	processInstallation,
 	TaskError, updateTaskStatusAndContinue
@@ -10,15 +9,10 @@ import { DeduplicatorResult } from "~/src/sync/deduplicator";
 import { getLogger } from "config/logger";
 import { Hub } from "@sentry/types/dist/hub";
 import {
-	GithubClientError,
-	GithubClientRateLimitingError,
-	GithubNotFoundError
+	GithubClientNotFoundError
 } from "~/src/github/client/github-client-errors";
 import { Repository, Subscription, SyncStatus } from "models/subscription";
 import { v4 as UUID } from "uuid";
-import { ConnectionTimedOutError } from "sequelize";
-import { AxiosError } from "axios";
-import { createAnonymousClient } from "utils/get-github-client-config";
 import { DatabaseStateCreator } from "test/utils/database-state-creator";
 import { RepoSyncState } from "models/reposyncstate";
 import { branchesNoLastCursor } from "fixtures/api/graphql/branch-queries";
@@ -178,113 +172,28 @@ describe("sync/installation", () => {
 
 			expect(sendSqsMessage).toBeCalledTimes(1);
 		});
-	});
 
-	describe("handleBackfillError", () => {
-
-		const scheduleNextTask = jest.fn();
-		const MOCKED_TIMESTAMP_MSECS = 12_345_678;
-
-		beforeEach(() => {
-			mockSystemTime(MOCKED_TIMESTAMP_MSECS);
-		});
-
-		it("Rate limiting error will be retried with the correct delay", async () => {
-			const RATE_LIMIT_RESET_TIMESTAMP_SECS = 12360;
-			gheNock.get("/")
-				.reply(403, {}, {
-					"access-control-allow-origin": "*",
-					"connection": "close",
-					"content-type": "application/json; charset=utf-8",
-					"date": "Fri, 04 Mar 2022 21:09:27 GMT",
-					"x-ratelimit-limit": "8900",
-					"x-ratelimit-remaining": "0",
-					"x-ratelimit-reset": "" + RATE_LIMIT_RESET_TIMESTAMP_SECS,
-					"x-ratelimit-resource": "core",
-					"x-ratelimit-used": "2421"
-				});
-
-			const client = await createAnonymousClient(gheUrl, jiraHost, getLogger("test"));
-			try {
-				await client.getMainPage(1000);
-			} catch (err) {
-				await handleBackfillError(err, MESSAGE_PAYLOAD, TASK, TEST_LOGGER, scheduleNextTask);
-			}
-
-			expect(scheduleNextTask).toBeCalledWith(MESSAGE_PAYLOAD, (RATE_LIMIT_RESET_TIMESTAMP_SECS * 1000 - MOCKED_TIMESTAMP_MSECS) / 1000, expect.anything());
-			expect((await RepoSyncState.findByPk(repoSyncState.id)!).status).toEqual("pending");
-		});
-
-		it("No delay if rate limit already reset", async () => {
-			const axiosResponse = {
-				data: "Rate Limit",
-				status: 403,
-				statusText: "RateLimit",
-				headers: {
-					"x-ratelimit-reset": "12345",
-					"x-ratelimit-remaining": "0"
-				},
-				config: {}
-			};
-
-			await handleBackfillError(new GithubClientRateLimitingError({
-				response: axiosResponse
-			} as unknown as AxiosError), MESSAGE_PAYLOAD, TASK, TEST_LOGGER, scheduleNextTask);
-			expect(scheduleNextTask).toBeCalledWith(MESSAGE_PAYLOAD, 0, expect.anything());
-			expect((await RepoSyncState.findByPk(repoSyncState.id)!).status).toEqual("pending");
-		});
-
-		it("Task ignored if not found error", async () => {
-			gheNock.get("/")
+		it("should rethrow GitHubClient error", async () => {
+			const sendSqsMessage = jest.fn();
+			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
+			githubNock
+				.post("/graphql")
+				.times(2)
+				.query(true)
 				.reply(404, {});
 
-			const client = await createAnonymousClient(gheUrl, jiraHost, getLogger("test"));
+			let err: TaskError;
 			try {
-				await client.getMainPage(1000);
-			} catch (err) {
-				await handleBackfillError(err, MESSAGE_PAYLOAD, TASK, TEST_LOGGER, scheduleNextTask);
-			}
+				await processInstallation(sendSqsMessage)(MESSAGE_PAYLOAD, sentry, TEST_LOGGER);
+				await mockedExecuteWithDeduplication.mock.calls[0][1]();
 
-			expect(scheduleNextTask).toHaveBeenCalledTimes(1);
-			expect((await RepoSyncState.findByPk(repoSyncState.id)!).branchStatus).toEqual("complete");
-		});
-
-		it("Repository ignored if not found error", async () => {
-			await handleBackfillError(new GithubNotFoundError({ } as AxiosError), MESSAGE_PAYLOAD, TASK, TEST_LOGGER, scheduleNextTask);
-			expect(scheduleNextTask).toHaveBeenCalledTimes(1);
-			expect((await RepoSyncState.findByPk(repoSyncState.id)!).branchStatus).toEqual("complete");
-		});
-
-		it("rethrows unknown error", async () => {
-			const connectionRefusedError = new ConnectionTimedOutError(new Error("foo"));
-
-			let err;
-			try {
-				await handleBackfillError(connectionRefusedError, MESSAGE_PAYLOAD, TASK, TEST_LOGGER, scheduleNextTask);
 			} catch (caught) {
 				err = caught;
 			}
-			expect(err).toBeInstanceOf(TaskError);
-			expect(err.task).toEqual(TASK);
-			expect(err.cause).toBeInstanceOf(ConnectionTimedOutError);
-			expect((await RepoSyncState.findByPk(repoSyncState.id)!).branchStatus).toEqual("pending");
+			expect(err!).toBeInstanceOf(TaskError);
+			expect(err!.task!.task).toEqual("branch");
+			expect(err!.cause).toBeInstanceOf(GithubClientNotFoundError);
 		});
-
-		it("rethrows github error", async () => {
-			const connectionRefusedError = new GithubClientError("foo", { code: "foo" } as unknown as AxiosError);
-
-			let err;
-			try {
-				await handleBackfillError(connectionRefusedError, MESSAGE_PAYLOAD, TASK, TEST_LOGGER, scheduleNextTask);
-			} catch (caught) {
-				err = caught;
-			}
-			expect(err).toBeInstanceOf(TaskError);
-			expect(err.task).toEqual(TASK);
-			expect(err.cause).toBeInstanceOf(GithubClientError);
-			expect((await RepoSyncState.findByPk(repoSyncState.id)!).branchStatus).toEqual("pending");
-		});
-
 	});
 
 	describe("getTargetTasks", () => {
@@ -362,6 +271,16 @@ describe("sync/installation", () => {
 		let data: BackfillMessagePayload;
 		let sub: Subscription;
 		let repoSync: RepoSyncState;
+
+		const TEST_REPO: Repository = {
+			id: REPO_ID,
+			name: "Test",
+			full_name: "Test/Test",
+			owner: { login: "test" },
+			html_url: "https://test",
+			updated_at: "1234"
+		};
+
 		beforeEach(async ()=> {
 			sub = await Subscription.install({ host: jiraHost, installationId: GITHUB_INSTALLATION_ID, gitHubAppId: undefined, hashedClientKey: "client-key" });
 			repoSync = await RepoSyncState.create({
@@ -376,13 +295,23 @@ describe("sync/installation", () => {
 		});
 
 		it("should skip update backfill from date if task is branch", async () => {
-			await updateTaskStatusAndContinue(data, { edges: [], jiraPayload: undefined }, "branch", REPO_ID, getLogger("test"), jest.fn());
+			const task: Task = {
+				task: "branch",
+				repositoryId: REPO_ID,
+				repository: TEST_REPO
+			};
+			await updateTaskStatusAndContinue(data, { edges: [], jiraPayload: undefined }, task, getLogger("test"), jest.fn());
 			await repoSync.reload();
 			expect(repoSync.branchFrom).toBeNull();
 		});
 
 		it("should skip update backfill from date if task is repository", async () => {
-			await updateTaskStatusAndContinue(data, { edges: [], jiraPayload: undefined }, "repository", REPO_ID, getLogger("test"), jest.fn());
+			const task: Task = {
+				task: "repository",
+				repositoryId: 0,
+				repository: TEST_REPO
+			};
+			await updateTaskStatusAndContinue(data, { edges: [], jiraPayload: undefined }, task, getLogger("test"), jest.fn());
 			await repoSync.reload();
 			expect(repoSync.branchFrom).toBeNull();
 			expect(repoSync.commitFrom).toBeNull();
@@ -391,30 +320,35 @@ describe("sync/installation", () => {
 			expect(repoSync.deploymentFrom).toBeNull();
 		});
 
-		describe.each(["pull", "commit", "build", "deployment"] as TaskType[])("Update jobs status for each tasks", (task: TaskType) => {
-			const colTaskFrom = `${task}From`;
-			it(`${task}: should update backfill from date upon success complete and existing backfill date is empty`, async () => {
-				await updateTaskStatusAndContinue(data, { edges: [], jiraPayload: undefined }, task, REPO_ID, getLogger("test"), jest.fn());
+		describe.each(["pull", "commit", "build", "deployment"] as TaskType[])("Update jobs status for each tasks", (taskType: TaskType) => {
+			const colTaskFrom = `${taskType}From`;
+			const task: Task = {
+				task: taskType,
+				repositoryId: REPO_ID,
+				repository: TEST_REPO
+			};
+			it(`${taskType}: should update backfill from date upon success complete and existing backfill date is empty`, async () => {
+				await updateTaskStatusAndContinue(data, { edges: [], jiraPayload: undefined }, task, getLogger("test"), jest.fn());
 				await repoSync.reload();
 				expect(repoSync[colTaskFrom]!.toISOString()).toEqual(commitsFromDate.toISOString());
 			});
-			it(`${task}: should update backfill from date upon success complete and new backfill date is earlier`, async () => {
+			it(`${taskType}: should update backfill from date upon success complete and new backfill date is earlier`, async () => {
 				repoSync.pullFrom = new Date(commitsFromDate.getTime() + 100000);
 				await repoSync.save();
-				await updateTaskStatusAndContinue(data, { edges: [], jiraPayload: undefined }, task, REPO_ID, getLogger("test"), jest.fn());
+				await updateTaskStatusAndContinue(data, { edges: [], jiraPayload: undefined }, task, getLogger("test"), jest.fn());
 				await repoSync.reload();
 				expect(repoSync[colTaskFrom]!.toISOString()).toEqual(commitsFromDate.toISOString());
 			});
-			it(`${task}: should skip update backfill from date upon success complete and new backfill date is more recent`, async () => {
+			it(`${taskType}: should skip update backfill from date upon success complete and new backfill date is more recent`, async () => {
 				const oldDate = new Date(commitsFromDate.getTime() - 100000);
 				repoSync[colTaskFrom]= oldDate;
 				await repoSync.save();
-				await updateTaskStatusAndContinue(data, { edges: [], jiraPayload: undefined }, task, REPO_ID, getLogger("test"), jest.fn());
+				await updateTaskStatusAndContinue(data, { edges: [], jiraPayload: undefined }, task, getLogger("test"), jest.fn());
 				await repoSync.reload();
 				expect(repoSync[colTaskFrom]!.toISOString()).toEqual(oldDate.toISOString());
 			});
-			it(`${task}: should not update backfill from date is job is not complete`, async () => {
-				await updateTaskStatusAndContinue(data, { edges: [ { cursor: "abcd" } ], jiraPayload: undefined }, "pull", REPO_ID, getLogger("test"), jest.fn());
+			it(`${taskType}: should not update backfill from date is job is not complete`, async () => {
+				await updateTaskStatusAndContinue(data, { edges: [ { cursor: "abcd" } ], jiraPayload: undefined }, task, getLogger("test"), jest.fn());
 				await repoSync.reload();
 				expect(repoSync.pullFrom).toBeNull();
 			});

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -276,7 +276,7 @@ const doProcessInstallation = async (data: BackfillMessagePayload, sentry: Hub, 
 		if (taskPayload.jiraPayload) {
 			const jiraClient = await getJiraClient(
 				subscription.jiraHost,
-				taskPayload.jiraPayload,
+				gitHubInstallationId,
 				data.gitHubAppConfig?.gitHubAppId,
 				logger
 			);

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -18,9 +18,6 @@ import { Deduplicator, DeduplicatorResult, RedisInProgressStorageWithTimeout } f
 import { getRedisInfo } from "config/redis-info";
 import { BackfillMessagePayload } from "../sqs/sqs.types";
 import { Hub } from "@sentry/types/dist/hub";
-import {
-	GithubClientRateLimitingError, GithubNotFoundError
-} from "../github/client/github-client-errors";
 import { getRepositoryTask } from "~/src/sync/discovery";
 import { createInstallationClient } from "~/src/util/get-github-client-config";
 import { getCloudOrServerFromGitHubAppId } from "utils/get-cloud-or-server";
@@ -103,15 +100,13 @@ const getFromDateKey = (type: TaskType) => `${type}From`;
  * @param data
  * @param taskResultPayload - when edges.length is 0 or undefined, the task is considered to be completed
  * @param task
- * @param repositoryId
  * @param logger
  * @param sendBackfillMessage
  */
 export const updateTaskStatusAndContinue = async (
 	data: BackfillMessagePayload,
 	taskResultPayload: TaskResultPayload,
-	task: TaskType,
-	repositoryId: number,
+	task: Task,
 	logger: Logger,
 	sendBackfillMessage: (message, delay, logger) => Promise<unknown>
 ): Promise<void> => {
@@ -123,6 +118,7 @@ export const updateTaskStatusAndContinue = async (
 		logger.info("Organization has been deleted. Other active syncs will continue.");
 		return;
 	}
+	const gitHubProduct = getCloudOrServerFromGitHubAppId(subscription.gitHubAppId);
 	const { edges } = taskResultPayload;
 	const isComplete = !edges?.length;
 
@@ -130,26 +126,28 @@ export const updateTaskStatusAndContinue = async (
 
 	logger.info({ status }, "Updating job status");
 
-	const updateRepoSyncFields: { [x: string]: string | Date} = { [getStatusKey(task)]: status };
+	const updateRepoSyncFields: { [x: string]: string | Date} = { [getStatusKey(task.task)]: status };
 
-	//Set the complete date on success for tasks.
-	//Skip branches as it sync all history
-	if (isComplete && allTasksExceptBranch.includes(task) && data.commitsFromDate) {
-		const repoSync = await RepoSyncState.findByRepoId(subscription, repositoryId);
-		if (repoSync) {
-			const newFromDate =  new Date(data.commitsFromDate);
-			const existingFromDate = repoSync[getFromDateKey(task)];
-			if (!existingFromDate || newFromDate.getTime() < existingFromDate.getTime()) {
-				updateRepoSyncFields[getFromDateKey(task)] = newFromDate;
+	if (isComplete) {
+		//Skip branches as it sync all history
+		if (allTasksExceptBranch.includes(task.task) && data.commitsFromDate) {
+			const repoSync = await RepoSyncState.findByRepoId(subscription, task.repositoryId);
+			if (repoSync) {
+				const newFromDate =  new Date(data.commitsFromDate);
+				const existingFromDate = repoSync[getFromDateKey(task.task)];
+				if (!existingFromDate || newFromDate.getTime() < existingFromDate.getTime()) {
+					updateRepoSyncFields[getFromDateKey(task.task)] = newFromDate;
+				}
 			}
 		}
+
+		statsd.increment(metricTaskStatus.complete, [`type:${task.task}`, `gitHubProduct:${gitHubProduct}`]);
+	} else {
+		updateRepoSyncFields[getCursorKey(task.task)] = edges![edges!.length - 1].cursor;
+		statsd.increment(metricTaskStatus.pending, [`type:${task.task}`, `gitHubProduct:${gitHubProduct}`]);
 	}
 
-	if ((edges?.length || 0) > 0) {
-		updateRepoSyncFields[getCursorKey(task)] = edges![edges!.length - 1].cursor;
-	}
-
-	await updateRepo(subscription, repositoryId, updateRepoSyncFields);
+	await updateRepo(subscription, task.repositoryId, updateRepoSyncFields);
 	await sendBackfillMessage(data, 0, logger);
 };
 
@@ -210,7 +208,34 @@ const markSyncAsCompleteAndStop = async (data: BackfillMessagePayload, subscript
 	logger.info({ startTime, endTime, timeDiff, gitHubProduct }, "Sync status is complete");
 };
 
-// TODO: type queues
+const sendPayloadToJira = async (task: TaskType, jiraClient, jiraPayload, sentry: Hub, logger: Logger) => {
+	try {
+		switch (task) {
+			case "build":
+				await jiraClient.workflow.submit(jiraPayload, {
+					preventTransitions: true,
+					operationType: "BACKFILL"
+				});
+				break;
+			case "deployment":
+				await jiraClient.deployment.submit(jiraPayload, {
+					preventTransitions: true,
+					operationType: "BACKFILL"
+				});
+				break;
+			default:
+				await jiraClient.devinfo.repository.update(jiraPayload, {
+					preventTransitions: true,
+					operationType: "BACKFILL"
+				});
+		}
+	} catch (err) {
+		logger.warn({ err }, "Failed to send data to Jira");
+		sendJiraFailureToSentry(err, sentry);
+		throw err;
+	}
+};
+
 const doProcessInstallation = async (data: BackfillMessagePayload, sentry: Hub, rootLogger: Logger, sendBackfillMessage: (message, delay, logger) => Promise<unknown>): Promise<void> => {
 	const { installationId: gitHubInstallationId, jiraHost } = data;
 	const subscription = await findSubscriptionForMessage(data);
@@ -231,115 +256,50 @@ const doProcessInstallation = async (data: BackfillMessagePayload, sentry: Hub, 
 		commitsFromDate: data.commitsFromDate
 	});
 
-	if (!nextTask) {
-		await markSyncAsCompleteAndStop(data, subscription, logger);
-		return;
-	}
-
-	await subscription.update({ syncStatus: "ACTIVE" });
-
-	const { task, cursor, repository } = nextTask;
-
-	logger.info("Starting task");
-
-	const processor = tasks[task];
-
 	try {
+		if (!nextTask) {
+			await markSyncAsCompleteAndStop(data, subscription, logger);
+			return;
+		}
+
+		await subscription.update({ syncStatus: "ACTIVE" });
+
+		const { task, cursor, repository } = nextTask;
+
+		logger.info("Starting task");
 
 		const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraHost, logger, data.gitHubAppConfig?.gitHubAppId);
+
 		// TODO: increase page size to 100 and remove scaling logic from commits, prs and builds
+		const processor = tasks[task];
 		const taskPayload = await processor(logger, gitHubInstallationClient, jiraHost, repository, cursor, 20, data);
 		if (taskPayload.jiraPayload) {
-			try {
-				// In "try" because it could fail if cryptor throws a error, and we don't want to kill the whole backfilling in this case
-				const jiraClient = await getJiraClient(
-					subscription.jiraHost,
-					gitHubInstallationId,
-					data.gitHubAppConfig?.gitHubAppId,
-					logger
-				);
-				switch (task) {
-					case "build":
-						await jiraClient.workflow.submit(taskPayload.jiraPayload, {
-							preventTransitions: true,
-							operationType: "BACKFILL"
-						});
-						break;
-					case "deployment":
-						await jiraClient.deployment.submit(taskPayload.jiraPayload, {
-							preventTransitions: true,
-							operationType: "BACKFILL"
-						});
-						break;
-					default:
-						await jiraClient.devinfo.repository.update(taskPayload.jiraPayload, {
-							preventTransitions: true,
-							operationType: "BACKFILL"
-						});
-				}
-			} catch (err) {
-				logger.warn({ err }, "Failed to send data to Jira");
-				sendJiraFailureToSentry(err, sentry);
-				throw err;
-			}
+			const jiraClient = await getJiraClient(
+				subscription.jiraHost,
+				taskPayload.jiraPayload,
+				data.gitHubAppConfig?.gitHubAppId,
+				logger
+			);
+			await sendPayloadToJira(task, jiraClient, taskPayload.jiraPayload, sentry, logger);
 		}
 
 		await updateTaskStatusAndContinue(
 			data,
 			taskPayload,
-			task,
-			nextTask.repositoryId,
+			nextTask,
 			logger,
 			sendBackfillMessage
 		);
 
-		statsd.increment(metricTaskStatus.complete, [`type:${nextTask.task}`, `gitHubProduct:${gitHubProduct}`]);
-
 	} catch (err) {
-		await handleBackfillError(err, data, nextTask, logger, sendBackfillMessage);
-	}
-};
-
-// TODO: killwithfire once we move all error handling to SQS error handler
-/**
- * Handles an error and takes action based on the error type and parameters
- */
-export const handleBackfillError = async (
-	err: Error,
-	data: BackfillMessagePayload,
-	nextTask: Task,
-	rootLogger: Logger,
-	sendBackfillMessage: (message, delay, logger) => Promise<unknown>): Promise<void> => {
-
-	const logger = rootLogger.child({ err });
-
-	// TODO: rethrow as TaskError and handle in SQS error handler
-	if (err instanceof GithubClientRateLimitingError) {
-		const delayMs = Math.max(err.rateLimitReset * 1000 - Date.now(), 0);
-
-		if (delayMs) {
-			// if not NaN or 0
-			logger.info({ delay: delayMs }, `Delaying job for ${delayMs}ms`);
-			await sendBackfillMessage(data, delayMs / 1000, logger);
+		if (nextTask) {
+			logger.info({ err, nextTask }, "rethrowing as a task error");
+			throw new TaskError(nextTask, err);
 		} else {
-			//Retry immediately if rate limiting reset already
-			logger.info("Rate limit was reset already. Scheduling next task");
-			await sendBackfillMessage(data, 0, logger);
+			logger.info({ err, nextTask }, "task is undefined, rethrowing as it is");
+			throw err;
 		}
-		return;
 	}
-
-	// TODO: throw TaskError and handle in SQS error handler
-	// Continue sync when a 404/NOT_FOUND is returned from GitHub
-	if (err instanceof GithubNotFoundError) {
-		// No edges left to process since the repository doesn't exist
-		logger.info("Repo was deleted, marking the task as completed");
-		await updateTaskStatusAndContinue(data, { edges: [] }, nextTask.task, nextTask.repositoryId, logger, sendBackfillMessage);
-		return;
-	}
-
-	logger.info("Rethrow unknown error to retry in SQS error handler");
-	throw new TaskError(nextTask, err);
 };
 
 const findSubscriptionForMessage = (data: BackfillMessagePayload) =>


### PR DESCRIPTION
**What's in this PR?**
Removing all error handling from sync/installations to SQS error handler

**Why**
To leverage SQS retries instead of relying on ad-hoc logic and make the code cleaner
