### PR TITLE
ARC-1997: minor refactoring and removing UGC from logs

### DIFF
--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -111,6 +111,26 @@ const censorUrl = (url) => {
 	return url;
 };
 
+const MSG_WITH_REGEX = /^(.*) Repository with the name '(.*)\/(.*)'.$/;
+
+const censorMessage = (msg) => {
+	if (!msg) {
+		return msg;
+	}
+	if (typeof msg === "string") {
+		if (msg.match(MSG_WITH_REGEX)) {
+			return msg.replace(MSG_WITH_REGEX, (_, prefix, orgName, repoName) => {
+				return [
+					prefix,
+					"Repository with the name",
+					`'${createHashWithSharedSecret(orgName)}/${createHashWithSharedSecret(repoName)}'.`
+				].join(" ");
+			});
+		}
+	}
+	return msg;
+};
+
 const headersSerializer = (headers) => {
 	if (!headers) {
 		return headers;
@@ -168,6 +188,15 @@ const graphQlErrorsSerializer = (errors: Array<any>) => (
 	}
 );
 
+const sanitiseStackTrace = (stack: string) => {
+	const splitAndSanitised = stack.split("\n").map(line => line.trim()).filter(line => line.startsWith("at "));
+	if (splitAndSanitised.length > 10) {
+		return splitAndSanitised.splice(0, 10).join("\n") + "\n...";
+	} else {
+		return splitAndSanitised.join("\n");
+	}
+};
+
 const errorSerializer = (err) => {
 	if (!err) {
 		return err;
@@ -182,11 +211,13 @@ const errorSerializer = (err) => {
 	const res = {
 		...err,
 		... (err.cause && err.cause !== err ? { cause: errorSerializer(err.cause) } : { }),
-		message: err.message,
+		message: censorMessage(err.message),
 		config: axiosConfigSerializer(err.config),
 		response: responseSerializer(err.response, false, !err.request),
 		request: requestSerializer(err.request),
-		... (err.errors && Array.isArray(err.errors) ? graphQlErrorsSerializer(err.errors) : {})
+		... (err.errors && Array.isArray(err.errors) ? graphQlErrorsSerializer(err.errors) : { }),
+		... (err.task ? { task: taskSerializer(err.task) } : { }),
+		... (err.stack ? { stack: sanitiseStackTrace(err.stack.toString()) } : { })
 	};
 
 	delete res.toJSON;

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -111,15 +111,15 @@ const censorUrl = (url) => {
 	return url;
 };
 
-const MSG_WITH_REGEX = /^(.*) Repository with the name '(.*)\/(.*)'.$/;
+const MSG_WITH_REPO_NAME_REGEX = /^(.*) Repository with the name '(.*)\/(.*)'.$/;
 
 const censorMessage = (msg) => {
 	if (!msg) {
 		return msg;
 	}
 	if (typeof msg === "string") {
-		if (msg.match(MSG_WITH_REGEX)) {
-			return msg.replace(MSG_WITH_REGEX, (_, prefix, orgName, repoName) => {
+		if (msg.match(MSG_WITH_REPO_NAME_REGEX)) {
+			return msg.replace(MSG_WITH_REPO_NAME_REGEX, (_, prefix, orgName, repoName) => {
 				return [
 					prefix,
 					"Repository with the name",

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -269,12 +269,12 @@ const doProcessInstallation = async (data: BackfillMessagePayload, sentry: Hub, 
 		commitsFromDate: data.commitsFromDate
 	});
 
-	try {
-		if (!nextTask) {
-			await markSyncAsCompleteAndStop(data, subscription, logger);
-			return;
-		}
+	if (!nextTask) {
+		await markSyncAsCompleteAndStop(data, subscription, logger);
+		return;
+	}
 
+	try {
 		await subscription.update({ syncStatus: "ACTIVE" });
 
 		const { task, cursor, repository } = nextTask;
@@ -305,13 +305,8 @@ const doProcessInstallation = async (data: BackfillMessagePayload, sentry: Hub, 
 		);
 
 	} catch (err) {
-		if (nextTask) {
-			logger.info({ err, nextTask }, "rethrowing as a task error");
-			throw new TaskError(nextTask, err);
-		} else {
-			logger.info({ err, nextTask }, "task is undefined, rethrowing as it is");
-			throw err;
-		}
+		logger.info({ err, nextTask }, "rethrowing as a task error");
+		throw new TaskError(nextTask, err);
 	}
 };
 


### PR DESCRIPTION
**What's in this PR?**
 - simplify try/catch logic in sync/installation a little bit
 - remove more UGC from logs
 - log stacktraces

**Why**
 - cause it simplifies code
 - cause we don't want to log UGC
 - cause stracktraces are helpful
 
