### PR TITLE
ARC-2052 - adding temp logs to try and track down issue with gh/config response times

### DIFF
--- a/src/github/client/github-anonymous-client.ts
+++ b/src/github/client/github-anonymous-client.ts
@@ -1,6 +1,7 @@
 import Logger from "bunyan";
 import { AxiosResponse } from "axios";
 import { GitHubClient, GitHubConfig } from "./github-client";
+import { getLogger } from "config/logger";
 
 export interface CreatedGitHubAppResponse {
 	id: number;
@@ -64,7 +65,9 @@ export class GitHubAnonymousClient extends GitHubClient {
 		});
 	}
 
-	public async renewGitHubToken(refreshToken: string,clientId: string,	clientSecret: string): Promise<{ accessToken: string, refreshToken: string }> {
+	public async renewGitHubToken(refreshToken: string, clientId: string,	clientSecret: string): Promise<{ accessToken: string, refreshToken: string }> {
+		const logger = getLogger("GitHubAnonymousClient");
+		logger.info("GitHubAnonymousClient trying to renewGitHubToken");
 		const res = await this.axios.post(`/login/oauth/access_token`,
 			{
 				refresh_token: refreshToken,

--- a/src/routes/github/configuration/github-configuration-get.ts
+++ b/src/routes/github/configuration/github-configuration-get.ts
@@ -126,6 +126,9 @@ const removeFailedConnectionsFromDb = async (logger: Logger, installations: Inst
 };
 
 export const GithubConfigurationGet = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+	req.log.info({ method: req.method, requestUrl: req.originalUrl }, "Request started");
+	const requestStartTime = new Date().getTime();
+
 	const {
 		jiraHost,
 		githubToken,
@@ -144,6 +147,8 @@ export const GithubConfigurationGet = async (req: Request, res: Response, next: 
 		: req.log.debug("Displaying orgs that have GitHub Cloud app installed.");
 
 	const gitHubProduct = gitHubAppId ? "server" : "cloud";
+
+	req.log.info({ method: req.method, requestUrl: req.originalUrl }, `Request for type ${gitHubProduct}`);
 
 	sendAnalytics(AnalyticsEventTypes.ScreenEvent, {
 		name: AnalyticsScreenEventsEnum.ConnectAnOrgScreenEventName,
@@ -235,6 +240,7 @@ export const GithubConfigurationGet = async (req: Request, res: Response, next: 
 			gitHubAppUuid
 		});
 
+		req.log.info({ method: req.method, requestUrl: req.originalUrl }, `Request finished in ${(new Date().getTime() - requestStartTime) / 1000} seconds`);
 		req.log.debug(`rendered page`);
 
 	} catch (err) {

--- a/src/routes/github/github-oauth-router.ts
+++ b/src/routes/github/github-oauth-router.ts
@@ -231,6 +231,7 @@ const appendJiraHostIfNeeded = (url: string, jiraHost: string): string => {
 };
 
 const renewGitHubToken = async (githubRefreshToken: string, gitHubAppConfig: GitHubAppConfig, jiraHost: string, logger: Logger) => {
+	logger.info("Trying to renewGitHubToken");
 	try {
 		const clientSecret = await getCloudOrGHESAppClientSecret(gitHubAppConfig, jiraHost);
 		if (clientSecret) {


### PR DESCRIPTION
**What's in this PR?**
Added some temporary logs.

**Why**
To try and help us figure out why our response times our so slow for /github/configuration. Focused only on the GET in this PR as the response times are typically worse for this method (although POST ain't great). 

**Affected issues**  
ARC-2052

**How has this been tested?**  
Locally

**Whats Next?**
Check out the logs once this is in prod to see if we can narrow down where the issue is coming from.