### PR TITLE
Added space between GHE and cloud cards and made them same width

### DIFF
--- a/static/css/jira-select-github-product.css
+++ b/static/css/jira-select-github-product.css
@@ -46,6 +46,7 @@
 .jiraSelectGitHubProduct__options__card.vertical {
     flex-direction: column;
     padding: 2em;
+    max-width: 40%;
 }
 
 .jiraSelectGitHubProduct__options__card.horizontal {


### PR DESCRIPTION
**What's in this PR?**
Set a max width on the cards so that they have a delightful space in the middle and are the same width

**Before**
<img width="784" alt="Screen Shot 2023-03-27 at 11 49 12 AM" src="https://user-images.githubusercontent.com/3848691/227809759-39fe1f0e-09e1-487d-9b81-744788cef7e2.png">


**After**
<img width="888" alt="Screen Shot 2023-03-27 at 11 47 47 AM" src="https://user-images.githubusercontent.com/3848691/227809763-9644e6f1-10ad-43cb-99ba-a659899947b8.png">


