### PR TITLE
ARC-2054 Adding tootip

### DIFF
--- a/views/partials/jira-configuration-table.hbs
+++ b/views/partials/jira-configuration-table.hbs
@@ -88,6 +88,7 @@
                   <span class="jiraConfiguration__info__backfillDate">
                       {{#if connection.backfillSince}}
                         Backfilled from: <span class="jiraConfiguration__info__backfillDate-label" data-backfill-since="{{ toISOString connection.backfillSince }}">{{ connection.backfillSince }}</span>
+                        <span class="jiraConfiguration__table__backfillInfoIcon aui-icon aui-iconfont-info-filled" title="If you want to backfill more data, choose &quot;Continue backfill&quot; in the settings menu on the right">Information</span>
                       {{else}}
                         All commits backfilled
                       {{/if}}


### PR DESCRIPTION
**What's in this PR?**
Adding tooltip next to `Backfilled from <date>` to  tell users about the Continue backfill functionality
![Screenshot 2023-03-27 at 4 06 00 pm](https://user-images.githubusercontent.com/14277763/227846192-31a7a77d-a8e6-4d92-9962-66255f55ff30.png)


**Why**
To inform users about continue backfill functionality 

**Added feature flags**
backfill-algorithm-incremental

**Affected issues**  
[ARC-2054]

**How has this been tested?**  
Local



[ARC-2054]: https://softwareteams.atlassian.net/browse/ARC-2054