### PR TITLE
avoid processing metrics for deployment queue when it has been rate limited

### DIFF
--- a/src/github/deployment.ts
+++ b/src/github/deployment.ts
@@ -29,7 +29,7 @@ export const processDeployment = async (
 	gitHubInstallationId: number,
 	rootLogger: Logger,
 	gitHubAppId: number | undefined,
-	rateLimited: boolean | undefined
+	rateLimited?: boolean
 ) => {
 
 	const logger = rootLogger.child({

--- a/src/github/deployment.ts
+++ b/src/github/deployment.ts
@@ -28,7 +28,8 @@ export const processDeployment = async (
 	jiraHost: string,
 	gitHubInstallationId: number,
 	rootLogger: Logger,
-	gitHubAppId: number | undefined
+	gitHubAppId: number | undefined,
+	rateLimited: boolean | undefined
 ) => {
 
 	const logger = rootLogger.child({
@@ -71,7 +72,8 @@ export const processDeployment = async (
 		}, "Jira API rejected deployment!");
 	}
 
-	emitWebhookProcessedMetrics(
+	// TODO - remove the rate limited test once valid metrics have been decided
+	!rateLimited && emitWebhookProcessedMetrics(
 		webhookReceivedDate.getTime(),
 		"deployment_status",
 		logger,

--- a/src/sqs/deployment.ts
+++ b/src/sqs/deployment.ts
@@ -24,6 +24,7 @@ export const deploymentQueueMessageHandler: MessageHandler<DeploymentMessagePayl
 		jiraHost,
 		installationId,
 		context.log,
-		messagePayload.gitHubAppConfig?.gitHubAppId
+		messagePayload.gitHubAppConfig?.gitHubAppId,
+		messagePayload.rateLimited
 	);
 };

--- a/src/sqs/sqs.test.ts
+++ b/src/sqs/sqs.test.ts
@@ -194,7 +194,7 @@ describe("SQS", () => {
 			await waitUntil(async () => expect(queueDeletionSpy).toBeCalledTimes(1));
 			await waitUntil(async () => expect(queueSendSpy).toBeCalledWith(expect.objectContaining({
 				DelaySeconds: 123,
-				MessageBody: JSON.stringify(payload)
+				MessageBody: JSON.stringify({ ...payload, rateLimited: true })
 			})));
 			expect(Date.now() - time).toBeGreaterThanOrEqual(1000); // wait 1 second to make sure everything's processed
 		});

--- a/src/sqs/sqs.ts
+++ b/src/sqs/sqs.ts
@@ -273,11 +273,11 @@ export class SqsQueue<MessagePayload extends BaseMessagePayload> {
 
 			const rateLimitCheckResult = await preemptiveRateLimitCheck(context, this);
 			if (rateLimitCheckResult.isExceedThreshold) {
-				//We have found out that the rate limite quota has been used and exceed the configured threshold.
-				//Next step is to postpone the processing.
-				//For rate limiting, we don't want to use the changeVisibilityTimeout as that will make msg lands in the DLQ and lost.
-				//Therefore sendign a new msg instead of keep polling github until rate limit is raised.
-				const { MessageId } = await this.sendMessage(payload, rateLimitCheckResult.resetTimeInSeconds, context.log);
+				// We have found out that the rate limit quota has been used and exceed the configured threshold.
+				// Next step is to postpone the processing.
+				// For rate limiting, we don't want to use the changeVisibilityTimeout as that will make msg lands in the DLQ and lost.
+				// Therefore, sending a new msg instead of keep polling GitHub until rate limit is raised.
+				const { MessageId } = await this.sendMessage({ ...payload, rateLimited: true }, rateLimitCheckResult.resetTimeInSeconds, context.log);
 				await this.deleteMessage(context);
 				context.log.info({ newMessageId: MessageId, deletedMessageId: message.MessageId }, "Preemptive rate limit threshold exceeded, rescheduled new one and deleted the origin msg");
 				return;

--- a/src/sqs/sqs.types.ts
+++ b/src/sqs/sqs.types.ts
@@ -150,6 +150,7 @@ export type DeploymentMessagePayload = BaseMessagePayload & {
 	// The original webhook payload from GitHub. We don't need to worry about the SQS size limit because metrics show
 	// that payload size for deployment_status webhooks maxes out at 13KB.
 	webhookPayload: WebhookPayloadDeploymentStatus,
+	rateLimited?: boolean
 }
 
 export type PushQueueMessagePayload = BaseMessagePayload & {

--- a/src/util/preemptive-rate-limit.test.ts
+++ b/src/util/preemptive-rate-limit.test.ts
@@ -97,7 +97,7 @@ describe("Preemptive rate limit check - Cloud", () => {
 		});
 	});
 
-	it(`Should not attempt to preempt when invalid quene name`, async () => {
+	it(`Should not attempt to preempt when invalid queue name`, async () => {
 		sqsQueue.queueName = "cats";
 		expect(await preemptiveRateLimitCheck(message, sqsQueue)).toEqual({
 			isExceedThreshold: false

--- a/src/util/preemptive-rate-limit.ts
+++ b/src/util/preemptive-rate-limit.ts
@@ -6,8 +6,8 @@ import { SqsQueue } from "~/src/sqs/sqs";
 import type { BaseMessagePayload } from "~/src/sqs/sqs.types";
 
 // List of queues we want to apply the preemptive rate limiting on
-const TARGETTED_QUEUES = ["backfill", "deployment"];
-export const DEFAULT_PREEMPTY_RATELIMIT_DELAY_IN_SECONDS = 10 * 60; //10 minutes
+const TARGETED_QUEUES = ["backfill", "deployment"];
+export const DEFAULT_PREEMPTY_RATELIMIT_DELAY_IN_SECONDS = 10 * 60; // 10 minutes
 
 type PreemptyRateLimitCheckResult = {
 	isExceedThreshold: boolean;
@@ -17,7 +17,7 @@ type PreemptyRateLimitCheckResult = {
 // Fetch the rate limit from GitHub API and check if the usages has exceeded the preemptive threshold
 export const preemptiveRateLimitCheck = async <T extends BaseMessagePayload>(context: SQSMessageContext<T>, sqsQueue: SqsQueue<T>) : Promise<PreemptyRateLimitCheckResult> => {
 
-	if (!TARGETTED_QUEUES.includes(sqsQueue.queueName))
+	if (!TARGETED_QUEUES.includes(sqsQueue.queueName))
 	{
 		return { isExceedThreshold: false };
 	}


### PR DESCRIPTION
Temporary change to stop Deployments SLO 

Avoid processing metrics for deployment queue when it has been rate limited.

Will have a seperate discussion on this implementation, I would prefer we tracked both rate limited and non but that will be covered in the DACI.
