### PR TITLE
Arc 2084 fix missing data on pr

### DIFF
--- a/src/github/client/github-installation-client.ts
+++ b/src/github/client/github-installation-client.ts
@@ -209,9 +209,9 @@ export class GitHubInstallationClient extends GitHubClient {
 		);
 	};
 
-	public listWorkflowRuns = async (owner: string, repo: string, per_page, cursor?: number, fromDate?: Date): Promise<AxiosResponse<ActionsListRepoWorkflowRunsResponseEnhanced>> => {
+	public listWorkflowRuns = async (owner: string, repo: string, per_page, cursor?: number): Promise<AxiosResponse<ActionsListRepoWorkflowRunsResponseEnhanced>> => {
 		return await this.get<ActionsListRepoWorkflowRunsResponseEnhanced>(`/repos/{owner}/{repo}/actions/runs`,
-			{ per_page, page: cursor, ...(fromDate ? { "created": `>=${fromDate.toISOString()}` } : {}) },
+			{ per_page, page: cursor },
 			{ owner, repo }
 		);
 	};

--- a/src/sync/build.test.ts
+++ b/src/sync/build.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires,@typescript-eslint/no-explicit-any */
+import { cloneDeep } from "lodash";
 import { removeInterceptor } from "nock";
 import { processInstallation } from "./installation";
 import { getLogger } from "config/logger";
@@ -102,49 +103,6 @@ describe("sync/builds", () => {
 
 		await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
 		expect(mockBackfillQueueSendMessage).toBeCalledWith(data, 0, expect.anything());
-	});
-
-	it("should get proper jira payload that within from date when increment ff on", async () => {
-		const data: BackfillMessagePayload = { installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, commitsFromDate: "2023-01-01" };
-
-		when(booleanFlag).calledWith(BooleanFlags.USE_BACKFILL_ALGORITHM_INCREMENTAL, jiraHost).mockResolvedValue(true);
-
-		githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-		githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-
-		githubNock
-			.get(`/repos/integrations/test-repo-name/actions/runs?per_page=20&page=1&created=%3E%3D2023-01-01T00:00:00.000Z`)
-			.reply(200, buildFixture);
-
-		githubNock.get(`/repos/integrations/integration-test-jira/compare/BASE_REF...HEAD_REF`)
-			.reply(200, compareReferencesFixture);
-
-		const gitHubClient = await createInstallationClient(DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, getLogger("test"), undefined);
-		expect(await getBuildTask(
-			getLogger("test"),
-			gitHubClient,
-			jiraHost,
-			{
-				id: repoSyncState.repoId,
-				name: repoSyncState.repoName,
-				full_name: repoSyncState.repoFullName,
-				owner: { login: repoSyncState.repoOwner },
-				html_url: repoSyncState.repoUrl,
-				updated_at: repoSyncState.repoUpdatedAt?.toISOString()
-			},
-			undefined,
-			20,
-			data
-		)).toEqual({
-			edges: expect.anything(),
-			jiraPayload: expect.objectContaining({
-				id: "1",
-				name: "test-repo-name",
-				builds: expect.arrayContaining([expect.objectContaining({
-					"buildNumber": 59
-				})])
-			})
-		});
 	});
 
 	const NUMBER_OF_PARALLEL_FETCHES = 10;
@@ -329,6 +287,145 @@ describe("sync/builds", () => {
 		await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
 		expect(scope).not.toBeDone();
 		removeInterceptor(interceptor);
+	});
+
+	describe("incremental backfill", () => {
+
+		let repoSyncState: RepoSyncState;
+		beforeEach(async () => {
+			when(booleanFlag).calledWith(
+				BooleanFlags.USE_BACKFILL_ALGORITHM_INCREMENTAL,
+				jiraHost
+			).mockResolvedValue(true);
+			const dbState = await new DatabaseStateCreator()
+				.withActiveRepoSyncState()
+				.repoSyncStatePendingForDeployments()
+				.create();
+			repoSyncState = dbState.repoSyncState!;
+		});
+
+		it("should not miss build data when page contains older build", async () => {
+
+			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
+			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
+			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
+
+			githubNock.get(`/repos/integrations/integration-test-jira/compare/BASE_REF...HEAD_REF`).reply(200, compareReferencesFixture);
+			githubNock.get(`/repos/integrations/integration-test-jira/compare/BASE_REF...HEAD_REF`).reply(200, compareReferencesFixture);
+
+			const HALF_MONTH_IN_MILLISEC = 1 * 15 * 24 * 60 * 60 * 1000;
+			const ONE_MONTH_IN_MILLISEC = 1 * 31 * 24 * 60 * 60 * 1000;
+
+			const dateNow = new Date();
+			const dateOneMonthAgo = new Date(new Date().getTime() - ONE_MONTH_IN_MILLISEC);
+			const twoBuilds = {
+				"total_count": 2,
+				"workflow_runs": [
+					Object.assign({}, cloneDeep(buildFixture.workflow_runs[0]), {
+						"created_at": dateNow.toISOString(),
+						"updated_at": dateNow.toISOString()
+					}),
+					Object.assign({}, cloneDeep(buildFixture.workflow_runs[0]), {
+						"created_at": dateOneMonthAgo.toISOString(),
+						"updated_at": dateOneMonthAgo.toISOString()
+					})
+				]
+			};
+			githubNock
+				.get(`/repos/integrations/test-repo-name/actions/runs?per_page=2&page=1`)
+				.reply(200, twoBuilds);
+
+			const gitHubClient = await createInstallationClient(DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, getLogger("test"), undefined);
+			const result = await getBuildTask(
+				getLogger("test"),
+				gitHubClient,
+				jiraHost,
+				{
+					id: repoSyncState.repoId,
+					name: repoSyncState.repoName,
+					full_name: repoSyncState.repoFullName,
+					owner: { login: repoSyncState.repoOwner },
+					html_url: repoSyncState.repoUrl,
+					updated_at: repoSyncState.repoUpdatedAt?.toISOString()
+				},
+				undefined,
+				2,
+				{
+					jiraHost,
+					installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID,
+					commitsFromDate: new Date((new Date().getTime()) - HALF_MONTH_IN_MILLISEC).toISOString()
+				}
+			);
+
+			expect(result).toEqual({
+				edges: [expect.objectContaining({
+					total_count: 2,
+					cursor: JSON.stringify({ perPage: 2, pageNo: 2 })
+				})],
+				jiraPayload: expect.objectContaining({
+					builds: [expect.objectContaining({
+						lastUpdated: dateNow.toISOString()
+					}), expect.objectContaining({
+						lastUpdated: dateOneMonthAgo.toISOString()
+					})]
+				})
+			});
+		});
+
+		it("should not include build data when all data are older build", async () => {
+
+			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
+
+			const HALF_MONTH_IN_MILLISEC = 1 * 15 * 24 * 60 * 60 * 1000;
+			const ONE_MONTH_IN_MILLISEC = 1 * 31 * 24 * 60 * 60 * 1000;
+			const TWO_MONTH_IN_MILLISEC = 2 * 31 * 24 * 60 * 60 * 1000;
+
+			const dateOneMonthAgo = new Date(new Date().getTime() - ONE_MONTH_IN_MILLISEC);
+			const dateTwoMonthAgo = new Date(new Date().getTime() - TWO_MONTH_IN_MILLISEC);
+			const twoBuilds = {
+				"total_count": 2,
+				"workflow_runs": [
+					Object.assign({}, cloneDeep(buildFixture.workflow_runs[0]), {
+						"created_at": dateOneMonthAgo.toISOString(),
+						"updated_at": dateOneMonthAgo.toISOString()
+					}),
+					Object.assign({}, cloneDeep(buildFixture.workflow_runs[0]), {
+						"created_at": dateTwoMonthAgo.toISOString(),
+						"updated_at": dateTwoMonthAgo.toISOString()
+					})
+				]
+			};
+			githubNock
+				.get(`/repos/integrations/test-repo-name/actions/runs?per_page=2&page=1`)
+				.reply(200, twoBuilds);
+
+			const gitHubClient = await createInstallationClient(DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, getLogger("test"), undefined);
+			const result = await getBuildTask(
+				getLogger("test"),
+				gitHubClient,
+				jiraHost,
+				{
+					id: repoSyncState.repoId,
+					name: repoSyncState.repoName,
+					full_name: repoSyncState.repoFullName,
+					owner: { login: repoSyncState.repoOwner },
+					html_url: repoSyncState.repoUrl,
+					updated_at: repoSyncState.repoUpdatedAt?.toISOString()
+				},
+				undefined,
+				2,
+				{
+					jiraHost,
+					installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID,
+					commitsFromDate: new Date((new Date().getTime()) - HALF_MONTH_IN_MILLISEC).toISOString()
+				}
+			);
+
+			expect(result).toEqual({
+				edges: [],
+				jiraPayload: undefined
+			});
+		});
 	});
 
 });

--- a/src/sync/pull-request.ts
+++ b/src/sync/pull-request.ts
@@ -121,18 +121,22 @@ const doGetPullRequestTask = async (
 	const nextPageNo = getNextPage(logger, headers) || (pageSizeAwareCursor.pageNo + 1);
 	const nextPageCursorStr = pageSizeAwareCursor.copyWithPageNo(nextPageNo).serialise();
 
-	let filteredEdges = edges;
 	if (await booleanFlag(BooleanFlags.USE_BACKFILL_ALGORITHM_INCREMENTAL, jiraHost)) {
 		//Rest api: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests
 		//Because GitHub rest api  doesn't support supply a from date in the query param,
 		//So we have to do a filter after we fetch the data and stop (via return []) once the date has passed.
 		const fromDate = messagePayload?.commitsFromDate ? new Date(messagePayload.commitsFromDate) : undefined;
-		filteredEdges = filterEdgesSinceFromDate(edges, fromDate);
+		if (areAllEdgesEarlierThanFromDate(edges, fromDate)) {
+			return {
+				edges: [],
+				jiraPayload: undefined
+			};
+		}
 	}
 
 	// Attach the "cursor" (next page number) to each edge, because the function that uses this data
 	// fetches the cursor from one of the edges instead of letting us return it explicitly.
-	const edgesWithCursor: PullRequestWithCursor[] = filteredEdges.map((edge) => ({ ...edge, cursor: nextPageCursorStr }));
+	const edgesWithCursor: PullRequestWithCursor[] = edges.map((edge) => ({ ...edge, cursor: nextPageCursorStr }));
 
 	// TODO: change this to reduce
 	const pullRequests = (
@@ -182,13 +186,13 @@ const doGetPullRequestTask = async (
 	};
 };
 
-const filterEdgesSinceFromDate = (edges: Octokit.PullsListResponseItem[], fromDate: Date | undefined) => {
+const areAllEdgesEarlierThanFromDate = (edges: Octokit.PullsListResponseItem[], fromDate: Date | undefined): boolean => {
 
-	if (!fromDate) return edges;
+	if (!fromDate) return false;
 
-	return edges.filter(edge => {
+	return edges.every(edge => {
 		const edgeCreatedAt = new Date(edge.created_at);
-		return edgeCreatedAt.getTime() > fromDate.getTime();
+		return edgeCreatedAt.getTime() < fromDate.getTime();
 	});
 
 };

--- a/src/sync/pull-requests.test.ts
+++ b/src/sync/pull-requests.test.ts
@@ -721,6 +721,7 @@ describe("sync/pull-request", () => {
 				_.cloneDeep(pullRequestList[0])
 			];
 
+			const HALF_MONTH_IN_MILLISEC = 1 * 15 * 24 * 60 * 60 * 1000;
 			const ONE_MONTH_IN_MILLISEC = 1 * 31 * 24 * 60 * 60 * 1000;
 			twoPRs[0].created_at = new Date().toISOString();
 			twoPRs[1].created_at = new Date((new Date().getTime()) - ONE_MONTH_IN_MILLISEC).toISOString();
@@ -747,7 +748,7 @@ describe("sync/pull-request", () => {
 				{
 					jiraHost,
 					installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID,
-					commitsFromDate: "2023-01-01T00:00:00Z"
+					commitsFromDate: new Date((new Date().getTime()) - HALF_MONTH_IN_MILLISEC).toISOString()
 				}
 			);
 			expect(result).toEqual({


### PR DESCRIPTION
**What's in this PR?**
Return the PR data that could be missing if page returned contains data older than backfill from date.

**Why**
We don't want to miss any data.
I think the problem essentially lies in:
For graphQL it should be fine
For rest api, whenever we try to “filtering”, either on our consumer side (pullrequest) or from the github api side (build), it won’t work. It will miss data as the page size can be large, and bump to next page will miss data. Instead, if we “over fetch” instead of “filtering”, then it should be fine. Only drawback is user might see date earlier than their specified backfill date. But I think we can accept that for now.

**Added feature flags**
use incremental flag

**Affected issues**  
ARC-2084

**How has this been tested?**  
Unit test

**Whats Next?**
