### PR TITLE
Gather api hit count metrics

### DIFF
--- a/src/config/logger.test.ts
+++ b/src/config/logger.test.ts
@@ -483,7 +483,7 @@ describe("logger behaviour", () => {
 			gheNock.get("/")
 				.reply(200, {}, { "foo": "bar" });
 
-			const client = await createAnonymousClient(gheUrl, jiraHost, getLogger("test"));
+			const client = await createAnonymousClient(gheUrl, jiraHost, { trigger: "test" }, getLogger("test"));
 
 			const response = await client.getMainPage(1000);
 
@@ -559,7 +559,7 @@ describe("logger behaviour", () => {
 					"X-RateLimit-Reset": "1613088454"
 				});
 
-			const client = await createAnonymousClient(gheUrl, jiraHost, logger);
+			const client = await createAnonymousClient(gheUrl, jiraHost, { trigger: "test" }, logger);
 
 			await client.getMainPage(1000).catch(noop);
 

--- a/src/config/metric-names.ts
+++ b/src/config/metric-names.ts
@@ -56,4 +56,3 @@ export const metricCreateBranch = {
 	created: `${server}.create-branch.created`,
 	failed: `${server}.create-branch.failed`
 };
-

--- a/src/github/client/github-anonymous-client.ts
+++ b/src/github/client/github-anonymous-client.ts
@@ -1,6 +1,6 @@
 import Logger from "bunyan";
 import { AxiosResponse } from "axios";
-import { GitHubClient, GitHubConfig } from "./github-client";
+import { GitHubClient, GitHubConfig, Metrics } from "./github-client";
 import { getLogger } from "config/logger";
 
 export interface CreatedGitHubAppResponse {
@@ -16,8 +16,8 @@ export interface CreatedGitHubAppResponse {
  * A GitHub client without any authentication
  */
 export class GitHubAnonymousClient extends GitHubClient {
-	constructor(githubConfig: GitHubConfig, logger: Logger) {
-		super(githubConfig, logger);
+	constructor(githubConfig: GitHubConfig, metrics: Metrics, logger: Logger) {
+		super(githubConfig, metrics, logger);
 	}
 
 	public getMainPage(timeoutMs: number): Promise<AxiosResponse> {

--- a/src/github/client/github-app-client.ts
+++ b/src/github/client/github-app-client.ts
@@ -4,7 +4,7 @@ import { AxiosRequestConfig, AxiosRequestHeaders, AxiosResponse } from "axios";
 import { AppTokenHolder } from "./app-token-holder";
 import { AuthToken } from "~/src/github/client/auth-token";
 import { GITHUB_ACCEPT_HEADER } from "./github-client-constants";
-import { GitHubClient, GitHubConfig } from "./github-client";
+import { GitHubClient, GitHubConfig, Metrics } from "./github-client";
 
 /**
  * A GitHub client that supports authentication as a GitHub app.
@@ -17,11 +17,12 @@ export class GitHubAppClient extends GitHubClient {
 
 	constructor(
 		gitHubConfig: GitHubConfig,
+		metrics: Metrics,
 		logger: Logger,
 		appId: string,
 		privateKey: string
 	) {
-		super(gitHubConfig, logger);
+		super(gitHubConfig, metrics, logger);
 		this.appToken = AppTokenHolder.createAppJwt(privateKey, appId);
 
 		this.axios.interceptors.request.use((config: AxiosRequestConfig) => {

--- a/src/github/client/github-client-cloud.test.ts
+++ b/src/github/client/github-client-cloud.test.ts
@@ -90,7 +90,7 @@ describe("GitHub Client", () => {
 			"installation token"
 		);
 
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), gitHubCloudConfig, jiraHost, getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), gitHubCloudConfig, jiraHost, { trigger: "test" }, getLogger("test"));
 		const pullrequests = await client.getPullRequests(owner, repo, {
 			per_page: pageSize,
 			page
@@ -113,7 +113,7 @@ describe("GitHub Client", () => {
 			"installation token"
 		);
 
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), gitHubCloudConfig, jiraHost, getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), gitHubCloudConfig, jiraHost, { trigger: "test" }, getLogger("test"));
 		const commit = await client.getCommit(owner, repo, sha);
 
 		expect(commit).toBeTruthy();
@@ -150,7 +150,7 @@ describe("GitHub Client", () => {
 			}
 		);
 		mockSystemTime(1000000);
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), gitHubCloudConfig, jiraHost, getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), gitHubCloudConfig, jiraHost, { trigger: "test" }, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});
@@ -177,7 +177,7 @@ describe("GitHub Client", () => {
 			}
 		);
 		mockSystemTime(1000000);
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), gitHubCloudConfig, jiraHost, getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), gitHubCloudConfig, jiraHost, { trigger: "test" }, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});
@@ -200,7 +200,7 @@ describe("GitHub Client", () => {
 			403, { message: "Org has an IP allow list enabled" }
 		);
 		mockSystemTime(1000000);
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), gitHubCloudConfig, jiraHost, getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), gitHubCloudConfig, jiraHost, { trigger: "test" }, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});
@@ -225,7 +225,7 @@ describe("GitHub Client", () => {
 			}
 		);
 		mockSystemTime(1000000);
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), gitHubCloudConfig, jiraHost, getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), gitHubCloudConfig, jiraHost, { trigger: "test" }, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});
@@ -251,7 +251,7 @@ describe("GitHub Client", () => {
 			}
 		);
 		mockSystemTime(1000000);
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), gitHubCloudConfig, jiraHost, getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), gitHubCloudConfig, jiraHost, { trigger: "test" }, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});
@@ -279,7 +279,7 @@ describe("GitHub Client", () => {
 			200, [{ number: 1 }]
 		);
 
-		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), gitHubCloudConfig, jiraHost, getLogger("test"));
+		const client = new GitHubInstallationClient(getInstallationId(githubInstallationId), gitHubCloudConfig, jiraHost, { trigger: "test" }, getLogger("test"));
 		let error: any = undefined;
 		try {
 			await client.getPullRequests("owner", "repo", {});

--- a/src/github/client/github-client-interceptors.test.ts
+++ b/src/github/client/github-client-interceptors.test.ts
@@ -10,7 +10,7 @@ describe("github-client-interceptors", () => {
 		});
 
 		let error: Error;
-		const client = await createAnonymousClient(gheUrl, jiraHost, getLogger("test"));
+		const client = await createAnonymousClient(gheUrl, jiraHost, { trigger: "test" }, getLogger("test"));
 		try {
 			await client.getMainPage(1000);
 		} catch (err) {
@@ -26,7 +26,7 @@ describe("github-client-interceptors", () => {
 		});
 
 		let error: Error;
-		const client = await createAnonymousClient(gheUrl, jiraHost, getLogger("test"));
+		const client = await createAnonymousClient(gheUrl, jiraHost, { trigger: "test" }, getLogger("test"));
 		try {
 			await client.getMainPage(1000);
 		} catch (err) {

--- a/src/github/client/github-client-interceptors.ts
+++ b/src/github/client/github-client-interceptors.ts
@@ -41,7 +41,7 @@ export const setRequestTimeout = async (config: AxiosRequestConfig): Promise<Axi
 
 //TODO Move to util/axios/common-github-webhook-middleware.ts and use with Jira Client
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const sendResponseMetrics = (metricName: string, gitHubProduct: string, response?: any, status?: string | number) => {
+const sendResponseMetrics = (metricName: string, gitHubProduct: string, response?: any, status?: string | number, extraTags?: Record<string, string | undefined>) => {
 	status = `${status || response?.status}`;
 	const requestDurationMs = Number(
 		Date.now() - (response?.config?.requestStartTime || 0)
@@ -53,7 +53,8 @@ const sendResponseMetrics = (metricName: string, gitHubProduct: string, response
 		gitHubProduct,
 		method: response?.config?.method?.toUpperCase(),
 		path: extractPath(response?.config?.originalUrl),
-		status: status
+		status: status,
+		...extraTags
 	};
 
 	statsd.histogram(metricName, requestDurationMs, tags);
@@ -62,14 +63,14 @@ const sendResponseMetrics = (metricName: string, gitHubProduct: string, response
 	return response;
 };
 
-export const instrumentRequest = (metricName, host) =>
+export const instrumentRequest = (metricName, host, extraTags?: Record<string, string | undefined>) =>
 	(response) => {
 		if (!response) {
 			return;
 		}
 
 		const gitHubProduct = getCloudOrServerFromHost(host);
-		return sendResponseMetrics(metricName, gitHubProduct, response);
+		return sendResponseMetrics(metricName, gitHubProduct, response, undefined, extraTags);
 	};
 
 /**
@@ -80,20 +81,20 @@ export const instrumentRequest = (metricName, host) =>
  * @param host - The rest API url for cloud/server
  * @returns {Promise<Error>} a rejected promise with the error inside.
  */
-export const instrumentFailedRequest = (metricName: string, host: string) =>
+export const instrumentFailedRequest = (metricName: string, host: string, extraTags?: Record<string, string | undefined>) =>
 	(error) => {
 		const gitHubProduct = getCloudOrServerFromHost(host);
 		if (error instanceof GithubClientRateLimitingError) {
-			sendResponseMetrics(metricName, gitHubProduct, error.cause?.response, "rateLimiting");
+			sendResponseMetrics(metricName, gitHubProduct, error.cause?.response, "rateLimiting", extraTags);
 		} else if (error instanceof GithubClientBlockedIpError) {
-			sendResponseMetrics(metricName, gitHubProduct, error.cause?.response, "blockedIp");
+			sendResponseMetrics(metricName, gitHubProduct, error.cause?.response, "blockedIp", extraTags);
 			statsd.increment(metricError.blockedByGitHubAllowlist, { gitHubProduct });
 		} else if (error instanceof GithubClientTimeoutError) {
-			sendResponseMetrics(metricName, gitHubProduct, error.cause?.response, "timeout");
+			sendResponseMetrics(metricName, gitHubProduct, error.cause?.response, "timeout", extraTags);
 		} else if (error instanceof GithubClientError) {
-			sendResponseMetrics(metricName, gitHubProduct, error.cause?.response);
+			sendResponseMetrics(metricName, gitHubProduct, error.cause?.response, undefined, extraTags);
 		} else {
-			sendResponseMetrics(metricName, gitHubProduct, error.response);
+			sendResponseMetrics(metricName, gitHubProduct, error.response, undefined, extraTags);
 		}
 		return Promise.reject(error);
 	};

--- a/src/github/client/github-client-server.test.ts
+++ b/src/github/client/github-client-server.test.ts
@@ -83,6 +83,7 @@ describe("GitHub Client", () => {
 				graphqlUrl: gheApiUrl  + "/graphql"
 			},
 			jiraHost,
+			{ trigger: "test" },
 			getLogger("test")
 		);
 

--- a/src/github/client/github-client.nock.test.ts
+++ b/src/github/client/github-client.nock.test.ts
@@ -10,7 +10,7 @@ import {
 
 class TestGitHubClient extends GitHubClient {
 	constructor(config: GitHubConfig) {
-		super(config, getLogger("test"));
+		super(config, { trigger: "test" }, getLogger("test"));
 	}
 	public doTestHttpCall() {
 		return this.axios.get("/", {});

--- a/src/github/client/github-client.test.ts
+++ b/src/github/client/github-client.test.ts
@@ -9,7 +9,7 @@ jest.mock("axios");
 
 class TestGitHubClient extends GitHubClient {
 	constructor(config: GitHubConfig) {
-		super(config, getLogger("test"));
+		super(config, { trigger: "test" }, getLogger("test"));
 	}
 	public doTestGraphqlCall() {
 		return this.graphql("foo", {});

--- a/src/github/client/github-client.ts
+++ b/src/github/client/github-client.ts
@@ -32,7 +32,7 @@ export interface GitHubConfig {
 
 export interface Metrics {
 	trigger: string,
-	sub_trigger?: string,
+	subTrigger?: string,
 }
 
 /**

--- a/src/github/client/github-installation-client.ts
+++ b/src/github/client/github-installation-client.ts
@@ -27,7 +27,7 @@ import {
 } from "./github-client.types";
 import { isChangedFilesError } from "./github-client-errors";
 import { GITHUB_ACCEPT_HEADER } from "./github-client-constants";
-import { GitHubClient, GitHubConfig } from "./github-client";
+import { GitHubClient, GitHubConfig, Metrics } from "./github-client";
 
 /**
  * A GitHub client that supports authentication as a GitHub app.
@@ -45,10 +45,11 @@ export class GitHubInstallationClient extends GitHubClient {
 		githubInstallationId: InstallationId,
 		gitHubConfig: GitHubConfig,
 		jiraHost: string,
+		metrics: Metrics,
 		logger: Logger,
 		gshaId?: number
 	) {
-		super(gitHubConfig, logger);
+		super(gitHubConfig, metrics, logger);
 		this.jiraHost = jiraHost;
 
 		this.installationTokenCache = InstallationTokenCache.getInstance();

--- a/src/github/client/github-user-client.ts
+++ b/src/github/client/github-user-client.ts
@@ -2,7 +2,7 @@ import Logger from "bunyan";
 import { Octokit } from "@octokit/rest";
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { CreateReferenceBody } from "~/src/github/client/github-client.types";
-import { GitHubClient, GitHubConfig } from "./github-client";
+import { GitHubClient, GitHubConfig, Metrics } from "./github-client";
 import {
 	GetRepositoriesQuery,
 	GetRepositoriesResponse, SearchedRepositoriesResponse,
@@ -17,8 +17,8 @@ import { GITHUB_ACCEPT_HEADER } from "./github-client-constants";
 export class GitHubUserClient extends GitHubClient {
 	private readonly userToken: string;
 
-	constructor(userToken: string, githubConfig: GitHubConfig, logger: Logger) {
-		super(githubConfig, logger);
+	constructor(userToken: string, gitHubConfig: GitHubConfig, metrics: Metrics, logger: Logger) {
+		super(gitHubConfig, metrics, logger);
 		this.userToken = userToken;
 
 		this.axios.interceptors.request.use((config: AxiosRequestConfig) => {

--- a/src/github/deployment.ts
+++ b/src/github/deployment.ts
@@ -46,7 +46,10 @@ export const processDeployment = async (
 
 	logger.info("processing deployment message!");
 
-	const jiraPayload: JiraDeploymentBulkSubmitData | undefined = await transformDeployment(newGitHubClient, webhookPayload, jiraHost, logger, gitHubAppId);
+	const metrics = {
+		trigger: "deployment_queue"
+	};
+	const jiraPayload: JiraDeploymentBulkSubmitData | undefined = await transformDeployment(newGitHubClient, webhookPayload, jiraHost, metrics, logger, gitHubAppId);
 
 	logger.info("deployment message transformed");
 

--- a/src/github/issue-comment.ts
+++ b/src/github/issue-comment.ts
@@ -30,7 +30,11 @@ export const issueCommentWebhookHandler = async (
 
 	let linkifiedBody;
 	const gitHubAppId = context.gitHubAppConfig?.gitHubAppId;
-	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraClient.baseURL, context.log, gitHubAppId);
+	const metrics = {
+		trigger: "webhook",
+		subTrigger: "issueComment"
+	};
+	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraClient.baseURL, metrics, context.log, gitHubAppId);
 
 	if (await booleanFlag(BooleanFlags.SEND_PR_COMMENTS_TO_JIRA, jiraHost)){
 		await syncIssueCommentsToJira(jiraClient.baseURL, context, gitHubInstallationClient);

--- a/src/github/issue.ts
+++ b/src/github/issue.ts
@@ -19,7 +19,11 @@ export const issueWebhookHandler = async (context: WebhookContext<WebhookPayload
 	});
 
 	const gitHubAppId = context.gitHubAppConfig?.gitHubAppId;
-	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraClient.baseURL, context.log, gitHubAppId);
+	const metrics = {
+		trigger: "webhook",
+		subTrigger: "issue"
+	};
+	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraClient.baseURL, metrics, context.log, gitHubAppId);
 
 	// TODO: need to create reusable function for unfurling
 	let linkifiedBody;

--- a/src/github/pull-request.ts
+++ b/src/github/pull-request.ts
@@ -34,7 +34,11 @@ export const pullRequestWebhookHandler = async (context: WebhookContext, jiraCli
 	});
 
 	const gitHubAppId = context.gitHubAppConfig?.gitHubAppId;
-	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraClient.baseURL, context.log, gitHubAppId);
+	const metrics = {
+		trigger: "webhook",
+		subTrigger: "pullRequest"
+	};
+	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraClient.baseURL, metrics, context.log, gitHubAppId);
 	let reviews: Octokit.PullsListReviewsResponse = [];
 
 	if (await booleanFlag(BooleanFlags.USE_SHARED_PR_TRANSFORM)) {

--- a/src/github/workflow.ts
+++ b/src/github/workflow.ts
@@ -12,7 +12,11 @@ export const workflowWebhookHandler = async (context: WebhookContext, jiraClient
 	});
 
 	const gitHubAppId = context.gitHubAppConfig?.gitHubAppId;
-	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraClient.baseURL, context.log, gitHubAppId);
+	const metrics = {
+		trigger: "webhook",
+		subTrigger: "workflow"
+	};
+	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraClient.baseURL, metrics, context.log, gitHubAppId);
 	const jiraPayload = await transformWorkflow(gitHubInstallationClient, payload, logger);
 
 	if (!jiraPayload) {

--- a/src/routes/api/installation/api-installation-get.test.ts
+++ b/src/routes/api/installation/api-installation-get.test.ts
@@ -21,7 +21,7 @@ describe("ApiInstallationGet", () => {
 		it("should find correct github app with id", async () => {
 
 			when(jest.mocked(createAppClient))
-				.calledWith(expect.anything(), jiraHost, GHES_GITHUB_APP_ID)
+				.calledWith(expect.anything(), jiraHost, GHES_GITHUB_APP_ID, expect.anything())
 				.mockResolvedValue({ getInstallation: jest.fn() } as any);
 			const res = getRes();
 

--- a/src/routes/api/installation/api-installation-get.test.ts
+++ b/src/routes/api/installation/api-installation-get.test.ts
@@ -33,7 +33,7 @@ describe("ApiInstallationGet", () => {
 			}), res);
 
 			expect(createAppClient)
-				.toBeCalledWith(expect.anything(), undefined, GHES_GITHUB_APP_ID);
+				.toBeCalledWith(expect.anything(), undefined, GHES_GITHUB_APP_ID, { trigger: "api_installation_get" });
 		});
 	});
 	const getReq = (opts: any = {}): any => {

--- a/src/routes/api/installation/api-installation-get.ts
+++ b/src/routes/api/installation/api-installation-get.ts
@@ -10,7 +10,7 @@ export const ApiInstallationGet = async (req: Request, res: Response): Promise<v
 	const gitHubAppId = parseInt(gitHubAppIdStr) || undefined;
 
 	const { jiraHost } = res.locals;
-	const gitHubAppClient = await createAppClient(req.log, jiraHost, gitHubAppId);
+	const gitHubAppClient = await createAppClient(req.log, jiraHost, gitHubAppId, { trigger: "api_installation_get" });
 
 	try {
 		const subscriptions = await Subscription.getAllForInstallation(Number(installationId), gitHubAppId);

--- a/src/routes/github/branch/github-branch-get.ts
+++ b/src/routes/github/branch/github-branch-get.ts
@@ -15,7 +15,7 @@ export const GithubBranchGet = async (req: Request, res: Response): Promise<void
 		return;
 	}
 
-	const gitHubUserClient = await createUserClient(githubToken, jiraHost, req.log, gitHubAppConfig.gitHubAppId);
+	const gitHubUserClient = await createUserClient(githubToken, jiraHost, { trigger: "github-branch-get" }, req.log, gitHubAppConfig.gitHubAppId);
 	try {
 		await gitHubUserClient.getReference(owner, repo, ref);
 		res.sendStatus(200);

--- a/src/routes/github/configuration/github-configuration-get.ts
+++ b/src/routes/github/configuration/github-configuration-get.ts
@@ -76,7 +76,7 @@ const getInstallationsWithAdmin = async (
 ): Promise<InstallationWithAdmin[]> => {
 	return await Promise.all(installations.map(async (installation) => {
 		const errors: Error[] = [];
-		const gitHubClient = await createInstallationClient(installation.id, jiraHost, log, gitHubAppId);
+		const gitHubClient = await createInstallationClient(installation.id, jiraHost, { trigger: "github-configuration-get" }, log, gitHubAppId);
 
 		const numberOfReposPromise = await gitHubClient.getNumberOfReposForInstallation().catch((err) => {
 			errors.push(err);
@@ -156,7 +156,7 @@ export const GithubConfigurationGet = async (req: Request, res: Response, next: 
 		gitHubProduct
 	});
 
-	const gitHubUserClient = await createUserClient(githubToken, jiraHost, log, gitHubAppId);
+	const gitHubUserClient = await createUserClient(githubToken, jiraHost, { trigger: "github-configuration-get" }, log, gitHubAppId);
 
 	req.log.debug("found github token");
 
@@ -184,7 +184,7 @@ export const GithubConfigurationGet = async (req: Request, res: Response, next: 
 			return;
 		}
 
-		const gitHubAppClient = await createAppClient(log, jiraHost, gitHubAppId);
+		const gitHubAppClient = await createAppClient(log, jiraHost, gitHubAppId, { trigger: "github-configuration-get" });
 
 		req.log.debug(`found installation in DB with id ${installation.id}`);
 

--- a/src/routes/github/configuration/github-configuration-post.ts
+++ b/src/routes/github/configuration/github-configuration-post.ts
@@ -60,8 +60,11 @@ export const GithubConfigurationPost = async (req: Request, res: Response): Prom
 	req.log.debug("Received add subscription request");
 
 	try {
-		const gitHubUserClient = await createUserClient(githubToken, jiraHost, req.log, gitHubAppId);
-		const gitHubAppClient = await createAppClient(req.log, jiraHost, gitHubAppId);
+		const metrics = {
+			trigger: "github-configuration-post"
+		};
+		const gitHubUserClient = await createUserClient(githubToken, jiraHost, metrics, req.log, gitHubAppId);
+		const gitHubAppClient = await createAppClient(req.log, jiraHost, gitHubAppId, metrics);
 
 		// Check if the user that posted this has access to the installation ID they're requesting
 		if (!await hasAdminAccess(gitHubAppClient, gitHubUserClient, gitHubInstallationId, req.log)) {

--- a/src/routes/github/create-branch/github-branches-get.ts
+++ b/src/routes/github/create-branch/github-branches-get.ts
@@ -16,7 +16,7 @@ export const GithubBranchesGet = async (req: Request, res: Response): Promise<vo
 	}
 
 	try {
-		const gitHubUserClient = await createUserClient(githubToken, jiraHost, req.log, gitHubAppConfig.gitHubAppId);
+		const gitHubUserClient = await createUserClient(githubToken, jiraHost, { trigger: "github-branches-get" }, req.log, gitHubAppConfig.gitHubAppId);
 		const [ branches, repository ] = await Promise.all([
 			gitHubUserClient.getReferences(owner, repo),
 			gitHubUserClient.getRepository(owner, repo)

--- a/src/routes/github/create-branch/github-create-branch-get.ts
+++ b/src/routes/github/create-branch/github-create-branch-get.ts
@@ -50,7 +50,7 @@ export const GithubCreateBranchGet = async (req: Request, res: Response, next: N
 		return;
 	}
 
-	const gitHubUserClient = await createUserClient(githubToken, jiraHost, req.log, gitHubAppConfig.gitHubAppId);
+	const gitHubUserClient = await createUserClient(githubToken, jiraHost, { trigger: "github-create-branch" }, req.log, gitHubAppConfig.gitHubAppId);
 	const gitHubUser = (await gitHubUserClient.getUser()).data.login;
 	const repos = await getReposBySubscriptions(subscriptions, req.log, jiraHost);
 
@@ -111,7 +111,7 @@ const sortByDateString = (a, b) => {
 const getReposBySubscriptions = async (subscriptions: Subscription[], logger: Logger, jiraHost: string): Promise<Repository[]> => {
 	const repoTasks = subscriptions.map(async (subscription) => {
 		try {
-			const gitHubInstallationClient = await createInstallationClient(subscription.gitHubInstallationId, jiraHost, logger, subscription.gitHubAppId);
+			const gitHubInstallationClient = await createInstallationClient(subscription.gitHubInstallationId, jiraHost, { trigger: "github-create-branch" }, logger, subscription.gitHubAppId);
 			const response = await gitHubInstallationClient.getRepositoriesPage(MAX_REPOS_RETURNED, undefined, "UPDATED_AT");
 			return response.viewer.repositories.edges;
 		} catch (err) {

--- a/src/routes/github/create-branch/github-create-branch-post.ts
+++ b/src/routes/github/create-branch/github-create-branch-post.ts
@@ -73,7 +73,7 @@ export const GithubCreateBranchPost = async (req: Request, res: Response): Promi
 		res.status(400).json({ error: getErrorMessages(400) });
 		return;
 	}
-	const gitHubUserClient = await createUserClient(githubToken, jiraHost, req.log, gitHubAppConfig.gitHubAppId);
+	const gitHubUserClient = await createUserClient(githubToken, jiraHost, { trigger: "github-create-branch" }, req.log, gitHubAppConfig.gitHubAppId);
 
 	try {
 		const baseBranchSha = (await gitHubUserClient.getReference(owner, repo, sourceBranchName)).data.object.sha;

--- a/src/routes/github/github-oauth-router.ts
+++ b/src/routes/github/github-oauth-router.ts
@@ -100,7 +100,10 @@ const GithubOAuthCallbackGet = async (req: Request, res: Response, next: NextFun
 
 	try {
 
-		const gitHubAnonymousClient = await createAnonymousClientByGitHubAppId(gitHubAppConfig.gitHubAppId, jiraHost, logger);
+		const metrics = {
+			trigger: "oauth"
+		};
+		const gitHubAnonymousClient = await createAnonymousClientByGitHubAppId(gitHubAppConfig.gitHubAppId, jiraHost, metrics, logger);
 		const { accessToken, refreshToken } = await gitHubAnonymousClient.exchangeGitHubToken({
 			clientId, clientSecret: gitHubClientSecret, code, state
 		});
@@ -142,7 +145,10 @@ export const GithubAuthMiddleware = async (req: Request, res: Response, next: Ne
 		}
 		req.log.debug("found github token in session. validating token with API.");
 
-		const gitHubAnonymousClient = await createAnonymousClientByGitHubAppId(gitHubAppConfig.gitHubAppId, jiraHost, logger);
+		const metrics = {
+			trigger: "oauth"
+		};
+		const gitHubAnonymousClient = await createAnonymousClientByGitHubAppId(gitHubAppConfig.gitHubAppId, jiraHost, metrics, logger);
 		await gitHubAnonymousClient.checkGitHubToken(githubToken);
 
 		req.log.debug(`Github token is valid, continuing...`);
@@ -235,7 +241,10 @@ const renewGitHubToken = async (githubRefreshToken: string, gitHubAppConfig: Git
 	try {
 		const clientSecret = await getCloudOrGHESAppClientSecret(gitHubAppConfig, jiraHost);
 		if (clientSecret) {
-			const gitHubAnonymousClient = await createAnonymousClientByGitHubAppId(gitHubAppConfig?.gitHubAppId, jiraHost, logger);
+			const metrics = {
+				trigger: "auth-middleware"
+			};
+			const gitHubAnonymousClient = await createAnonymousClientByGitHubAppId(gitHubAppConfig?.gitHubAppId, jiraHost, metrics, logger);
 			const res = await gitHubAnonymousClient.renewGitHubToken(githubRefreshToken, gitHubAppConfig.clientId, clientSecret);
 			return { accessToken: res.accessToken, refreshToken: res.refreshToken };
 		}

--- a/src/routes/github/manifest/github-manifest-complete-get.ts
+++ b/src/routes/github/manifest/github-manifest-complete-get.ts
@@ -25,7 +25,10 @@ export const GithubManifestCompleteGet = async (req: Request, res: Response) => 
 	}
 
 	try {
-		const gitHubClient = await createAnonymousClient(gheHost, jiraHost, req.log);
+		const metrics = {
+			trigger: "manifest"
+		};
+		const gitHubClient = await createAnonymousClient(gheHost, jiraHost, metrics, req.log);
 		const gitHubAppConfig = await gitHubClient.createGitHubApp("" + req.query.code);
 		await GitHubServerApp.install({
 			uuid,

--- a/src/routes/github/repository/github-repository-get.ts
+++ b/src/routes/github/repository/github-repository-get.ts
@@ -60,13 +60,14 @@ export const searchInstallationAndUserRepos = async (repoName, jiraHost, gitHubA
 const getReposBySubscriptions = async (repoName: string, subscriptions: Subscription[], jiraHost: string, githubToken:string, logger: Logger): Promise<RepositoryNode[]> => {
 	const repoTasks = subscriptions.map(async (subscription) => {
 		try {
+			const metrics = { trigger: "github-repo-get" };
 			const [orgName, gitHubInstallationClient, gitHubUserClient] = await Promise.all([
 				getOrgName(subscription, jiraHost, logger).then(orgName => {
 					logger.info({ orgName }, "Found orgName");
 					return orgName;
 				}),
-				createInstallationClient(subscription.gitHubInstallationId, jiraHost, logger, subscription.gitHubAppId),
-				createUserClient(githubToken, jiraHost, logger, subscription.gitHubAppId)
+				createInstallationClient(subscription.gitHubInstallationId, jiraHost, metrics, logger, subscription.gitHubAppId),
+				createUserClient(githubToken, jiraHost, metrics, logger, subscription.gitHubAppId)
 			]);
 
 			const verboseLoggingEnabled = await booleanFlag(BooleanFlags.VERBOSE_LOGGING, jiraHost);
@@ -146,7 +147,8 @@ const sortByScoreAndUpdatedAt = (a, b) => {
 };
 
 const getOrgName = async (subscription: Subscription, jiraHost: string, logger: Logger) => {
-	const gitHubAppClient = await createAppClient(logger, jiraHost, subscription.gitHubAppId);
+	const metrics = { trigger: "github-repo-get" };
+	const gitHubAppClient = await createAppClient(logger, jiraHost, subscription.gitHubAppId, metrics);
 	const response = await gitHubAppClient.getInstallation(subscription.gitHubInstallationId);
 	return response.data?.account?.login;
 };

--- a/src/routes/github/setup/github-setup-get.ts
+++ b/src/routes/github/setup/github-setup-get.ts
@@ -38,7 +38,7 @@ const getInstallationData = async (githubAppClient: GitHubAppClient, githubInsta
 export const GithubSetupGet = async (req: Request, res: Response): Promise<void> => {
 	const { jiraHost, gitHubAppId } = res.locals;
 	const githubInstallationId = Number(req.query.installation_id);
-	const gitHubAppClient = await createAppClient(req.log, jiraHost, gitHubAppId);
+	const gitHubAppClient = await createAppClient(req.log, jiraHost, gitHubAppId, { trigger: "github-setup-get" });
 	const { githubInstallation, info } = await getInstallationData(gitHubAppClient, githubInstallationId, req.log);
 
 	req.addLogFields({ githubInstallationId, appInfo: info });

--- a/src/routes/github/subscription/github-subscription-delete.ts
+++ b/src/routes/github/subscription/github-subscription-delete.ts
@@ -12,8 +12,11 @@ export const GithubSubscriptionDelete = async (req: Request, res: Response): Pro
 	logger.debug("Received DELETE subscription request");
 
 	const gitHubAppId = gitHubAppConfig?.gitHubAppId;
-	const gitHubAppClient = await createAppClient(logger, jiraHost, gitHubAppId);
-	const gitHubUserClient = await createUserClient(githubToken, jiraHost, logger, gitHubAppId);
+	const metrics = {
+		trigger: "github-subscription-delete"
+	};
+	const gitHubAppClient = await createAppClient(logger, jiraHost, gitHubAppId, metrics);
+	const gitHubUserClient = await createUserClient(githubToken, jiraHost, metrics, logger, gitHubAppId);
 	const gitHubProduct = getCloudOrServerFromGitHubAppId(gitHubAppId);
 
 	if (!githubToken) {

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.ts
@@ -92,7 +92,7 @@ export const JiraConnectEnterprisePost = async (
 	req.log.debug(`No existing GitHub apps found for url: ${gheServerURL}. Making request to provided url.`);
 
 	try {
-		const client = await createAnonymousClient(gheServerURL, jiraHost, req.log);
+		const client = await createAnonymousClient(gheServerURL, jiraHost, { trigger: "jira-connect-enterprise-post" }, req.log);
 		const response = await client.getMainPage(TIMEOUT_PERIOD_MS);
 
 		if (!isResponseFromGhe(req.log, response)) {

--- a/src/routes/jira/jira-get.ts
+++ b/src/routes/jira/jira-get.ts
@@ -65,7 +65,7 @@ export const getInstallations = async (subscriptions: Subscription[], log: Logge
 
 const getInstallation = async (subscription: Subscription, gitHubAppId: number | undefined, log: Logger): Promise<AppInstallation> => {
 	const { jiraHost, gitHubInstallationId } = subscription;
-	const gitHubAppClient = await createAppClient(log, jiraHost, gitHubAppId);
+	const gitHubAppClient = await createAppClient(log, jiraHost, gitHubAppId, { trigger: "jira-get" });
 	const gitHubProduct = getCloudOrServerFromGitHubAppId(gitHubAppId);
 
 	try {

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -80,7 +80,7 @@ RootRouter.use("/jira", JiraRouter);
 // On base path, redirect to Github App Marketplace URL
 RootRouter.get("/", jiraSymmetricJwtMiddleware, async (req: Request, res: Response) => {
 	const { jiraHost, gitHubAppId } = res.locals;
-	const gitHubAppClient = await createAppClient(req.log, jiraHost, gitHubAppId);
+	const gitHubAppClient = await createAppClient(req.log, jiraHost, gitHubAppId, { trigger: "root_path" });
 	const { data: info } = await gitHubAppClient.getApp();
 
 	return res.redirect(info.external_url);

--- a/src/services/user-config-service.test.ts
+++ b/src/services/user-config-service.test.ts
@@ -83,16 +83,16 @@ describe("User Config Service", () => {
 	};
 
 	it("should not update config in database when config file hasn't been touched", async () => {
-		await updateRepoConfig(subscription, repoSyncState.repoId, getInstallationId(gitHubInstallationId), ["random.yml", "ignored.yml"]);
-		const config = await getRepoConfig(subscription, getInstallationId(gitHubInstallationId), repoSyncState.repoId, repoSyncState.repoOwner, repoSyncState.repoName);
+		await updateRepoConfig(subscription, repoSyncState.repoId, getInstallationId(gitHubInstallationId), { trigger: "test" }, ["random.yml", "ignored.yml"]);
+		const config = await getRepoConfig(subscription, getInstallationId(gitHubInstallationId), repoSyncState.repoId, repoSyncState.repoOwner, repoSyncState.repoName, { trigger: "test" });
 		expect(config).toBeFalsy();
 	});
 
 	it("should update config in database when config file has been touched", async () => {
 		githubUserTokenNock(gitHubInstallationId);
 		givenGitHubReturnsConfigFile();
-		await updateRepoConfig(subscription, repoSyncState.repoId, getInstallationId(gitHubInstallationId), ["random.yml", "ignored.yml", ".jira/config.yml"]);
-		const config = await getRepoConfig(subscription, getInstallationId(gitHubInstallationId), repoSyncState.repoId, repoSyncState.repoOwner, repoSyncState.repoName);
+		await updateRepoConfig(subscription, repoSyncState.repoId, getInstallationId(gitHubInstallationId), { trigger: "test" }, ["random.yml", "ignored.yml", ".jira/config.yml"]);
+		const config = await getRepoConfig(subscription, getInstallationId(gitHubInstallationId), repoSyncState.repoId, repoSyncState.repoOwner, repoSyncState.repoName, { trigger: "test" });
 		expect(config).toBeTruthy();
 		expect(config?.deployments?.environmentMapping?.development).toHaveLength(4);
 	});
@@ -100,16 +100,16 @@ describe("User Config Service", () => {
 	it("no Write perms case should be tolerated", async () => {
 		githubUserTokenNock(gitHubInstallationId);
 		givenGitHubReturnsAccessNotAllowed();
-		await updateRepoConfig(subscription, repoSyncState.repoId, getInstallationId(gitHubInstallationId), ["random.yml", "ignored.yml", ".jira/config.yml"]);
-		const config = await getRepoConfig(subscription, getInstallationId(gitHubInstallationId), repoSyncState.repoId, repoSyncState.repoOwner, repoSyncState.repoName);
+		await updateRepoConfig(subscription, repoSyncState.repoId, getInstallationId(gitHubInstallationId), { trigger: "test" }, ["random.yml", "ignored.yml", ".jira/config.yml"]);
+		const config = await getRepoConfig(subscription, getInstallationId(gitHubInstallationId), repoSyncState.repoId, repoSyncState.repoOwner, repoSyncState.repoName, { trigger: "test" });
 		expect(config).toBeFalsy();
 	});
 
 	it("should get service ids", async () => {
 		githubUserTokenNock(gitHubInstallationId);
 		givenGitHubReturnsConfigFile();
-		await updateRepoConfig(subscription, repoSyncState.repoId, getInstallationId(gitHubInstallationId), ["random.yml", "ignored.yml", ".jira/config.yml"]);
-		const config = await getRepoConfig(subscription, getInstallationId(gitHubInstallationId), repoSyncState.repoId, repoSyncState.repoOwner, repoSyncState.repoName);
+		await updateRepoConfig(subscription, repoSyncState.repoId, getInstallationId(gitHubInstallationId), { trigger: "test" }, ["random.yml", "ignored.yml", ".jira/config.yml"]);
+		const config = await getRepoConfig(subscription, getInstallationId(gitHubInstallationId), repoSyncState.repoId, repoSyncState.repoOwner, repoSyncState.repoName, { trigger: "test" });
 		expect(config).toBeTruthy();
 		expect(config?.deployments?.services?.ids).toHaveLength(4);
 	});
@@ -122,7 +122,7 @@ describe("User Config Service", () => {
 
 		githubUserTokenNock(gitHubInstallationId);
 		givenGitHubReturnsConfigFile(unknownRepoOwner, unknownRepoName);
-		const config = await getRepoConfig(subscription, getInstallationId(gitHubInstallationId), unknownRepoId, unknownRepoOwner, unknownRepoName);
+		const config = await getRepoConfig(subscription, getInstallationId(gitHubInstallationId), unknownRepoId, unknownRepoOwner, unknownRepoName, { trigger: "test" });
 		expect(config).toBeTruthy();
 		expect(config?.deployments?.environmentMapping?.development).toHaveLength(4);
 	});

--- a/src/sqs/backfill-error-handler.test.ts
+++ b/src/sqs/backfill-error-handler.test.ts
@@ -62,7 +62,7 @@ describe("backfillErrorHandler", () => {
 				"x-ratelimit-used": "2421"
 			});
 
-		const client = await createAnonymousClient(gheUrl, jiraHost, getLogger("test"));
+		const client = await createAnonymousClient(gheUrl, jiraHost, { trigger: "test" }, getLogger("test"));
 		try {
 			await client.getMainPage(1000);
 		} catch (err) {
@@ -75,7 +75,7 @@ describe("backfillErrorHandler", () => {
 		gheNock.get("/")
 			.reply(500);
 
-		const client = await createAnonymousClient(gheUrl, jiraHost, getLogger("test"));
+		const client = await createAnonymousClient(gheUrl, jiraHost, { trigger: "test" }, getLogger("test"));
 		try {
 			await client.getMainPage(1000);
 		} catch (err) {

--- a/src/sqs/branch.ts
+++ b/src/sqs/branch.ts
@@ -13,7 +13,10 @@ export const branchQueueMessageHandler: MessageHandler<BranchMessagePayload> = a
 	});
 
 	const gitHubAppId = messagePayload.gitHubAppConfig?.gitHubAppId;
-	const gitHubInstallationClient = await createInstallationClient(installationId, jiraHost, context.log, gitHubAppId);
+	const metrics = {
+		trigger: "branch_queue"
+	};
+	const gitHubInstallationClient = await createInstallationClient(installationId, jiraHost, metrics, context.log, gitHubAppId);
 	const gitHubProduct = getCloudOrServerFromGitHubAppId(gitHubAppId);
 
 	context.log.info({ gitHubProduct }, "Handling branch message from the SQS queue");

--- a/src/sqs/deployment.ts
+++ b/src/sqs/deployment.ts
@@ -14,7 +14,10 @@ export const deploymentQueueMessageHandler: MessageHandler<DeploymentMessagePayl
 
 	context.log.info("Handling deployment message from the SQS queue");
 
-	const gitHubInstallationClient = await createInstallationClient(installationId, jiraHost, context.log, messagePayload.gitHubAppConfig?.gitHubAppId);
+	const metrics = {
+		trigger: "deployment_queue"
+	};
+	const gitHubInstallationClient = await createInstallationClient(installationId, jiraHost, metrics, context.log, messagePayload.gitHubAppConfig?.gitHubAppId);
 
 	await processDeployment(
 		gitHubInstallationClient,

--- a/src/sqs/push.ts
+++ b/src/sqs/push.ts
@@ -11,6 +11,9 @@ export const pushQueueMessageHandler: MessageHandler<PushQueueMessagePayload> = 
 		gitHubInstallationId: installationId
 	});
 	context.log.info("Handling push message from the SQS queue");
-	const gitHubInstallationClient = await createInstallationClient(installationId, jiraHost, context.log, payload.gitHubAppConfig?.gitHubAppId);
+	const metrics = {
+		trigger: "push_queue"
+	};
+	const gitHubInstallationClient = await createInstallationClient(installationId, jiraHost, metrics, context.log, payload.gitHubAppConfig?.gitHubAppId);
 	await processPush(gitHubInstallationClient, payload, context.log);
 };

--- a/src/sync/build.test.ts
+++ b/src/sync/build.test.ts
@@ -335,7 +335,7 @@ describe("sync/builds", () => {
 				.get(`/repos/integrations/test-repo-name/actions/runs?per_page=2&page=1`)
 				.reply(200, twoBuilds);
 
-			const gitHubClient = await createInstallationClient(DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, getLogger("test"), undefined);
+			const gitHubClient = await createInstallationClient(DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, { trigger: "test" }, getLogger("test"), undefined);
 			const result = await getBuildTask(
 				getLogger("test"),
 				gitHubClient,
@@ -399,7 +399,7 @@ describe("sync/builds", () => {
 				.get(`/repos/integrations/test-repo-name/actions/runs?per_page=2&page=1`)
 				.reply(200, twoBuilds);
 
-			const gitHubClient = await createInstallationClient(DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, getLogger("test"), undefined);
+			const gitHubClient = await createInstallationClient(DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, { trigger: "test" }, getLogger("test"), undefined);
 			const result = await getBuildTask(
 				getLogger("test"),
 				gitHubClient,

--- a/src/sync/deployment.test.ts
+++ b/src/sync/deployment.test.ts
@@ -98,7 +98,7 @@ describe("sync/deployments", () => {
 				.query(true)
 				.reply(200, deploymentNodesFixture);
 
-			const gitHubClient = await createInstallationClient(DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, getLogger("test"), undefined);
+			const gitHubClient = await createInstallationClient(DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, { trigger: "test" }, getLogger("test"), undefined);
 			expect(await getDeploymentTask(getLogger("test"),
 				gitHubClient,
 				jiraHost,

--- a/src/sync/deployment.ts
+++ b/src/sync/deployment.ts
@@ -42,7 +42,11 @@ const getTransformedDeployments = async (deployments, gitHubInstallationClient: 
 				state: deployment.latestStatus?.state
 			}
 		} as WebhookPayloadDeploymentStatus;
-		return transformDeployment(gitHubInstallationClient, deploymentStatus, jiraHost, logger, gitHubAppId);
+		const metrics = {
+			trigger: "backfill",
+			subTrigger: "deployment"
+		};
+		return transformDeployment(gitHubInstallationClient, deploymentStatus, jiraHost, metrics, logger, gitHubAppId);
 	});
 
 	const transformedDeployments = await Promise.all(transformTasks);

--- a/src/sync/discovery.test.ts
+++ b/src/sync/discovery.test.ts
@@ -54,7 +54,7 @@ describe("discovery", () => {
 			}
 		});
 
-		const gitHubClient = await createInstallationClient(DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, getLogger("test"), undefined);
+		const gitHubClient = await createInstallationClient(DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, { trigger: "test" }, getLogger("test"), undefined);
 		expect(await getRepositoryTask(
 			getLogger("test"),
 			gitHubClient,

--- a/src/sync/discovery.ts
+++ b/src/sync/discovery.ts
@@ -59,7 +59,11 @@ export const getRepositoryTask = async (
 	logger.info(`Added ${repositories.length} Repositories to state`);
 	logger.debug(hasNextPage ? "Repository Discovery: Continuing" : "Repository Discovery: finished");
 
-	await updateRepoConfigsFromGitHub(createdRepoSyncStates, githubInstallationClient.githubInstallationId, jiraHost, gitHubAppId);
+	const metrics = {
+		trigger: "backfill",
+		subTrigger: "discovery"
+	};
+	await updateRepoConfigsFromGitHub(createdRepoSyncStates, githubInstallationClient.githubInstallationId, jiraHost, gitHubAppId, metrics);
 
 	return {
 		edges,

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -281,7 +281,11 @@ const doProcessInstallation = async (data: BackfillMessagePayload, sentry: Hub, 
 
 		logger.info("Starting task");
 
-		const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraHost, logger, data.gitHubAppConfig?.gitHubAppId);
+		const metrics = {
+			trigger: "backfill",
+			subTrigger: task
+		};
+		const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraHost, metrics, logger, data.gitHubAppConfig?.gitHubAppId);
 
 		const processor = tasks[task];
 		const nPages = Math.min(

--- a/src/sync/pull-requests.test.ts
+++ b/src/sync/pull-requests.test.ts
@@ -461,7 +461,7 @@ describe("sync/pull-request", () => {
 
 			mockPullRequestList();
 
-			const gitHubClient = await createInstallationClient(DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, getLogger("test"), undefined);
+			const gitHubClient = await createInstallationClient(DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, { trigger: "test" }, getLogger("test"), undefined);
 			expect(await getPullRequestTask(getLogger("test"),
 				gitHubClient,
 				jiraHost,
@@ -730,7 +730,7 @@ describe("sync/pull-request", () => {
 				.get("/repos/integrations/test-repo-name/pulls?per_page=2&page=1&state=all&sort=created&direction=desc")
 				.reply(200, twoPRs);
 
-			const gitHubClient = await createInstallationClient(DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, getLogger("test"), undefined);
+			const gitHubClient = await createInstallationClient(DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, { trigger: "test" }, getLogger("test"), undefined);
 			const result = await getPullRequestTask(
 				getLogger("test"),
 				gitHubClient,

--- a/src/transforms/transform-code-scanning-alert.ts
+++ b/src/transforms/transform-code-scanning-alert.ts
@@ -53,7 +53,11 @@ const transformStatusToAppearance = (status: string, context: WebhookContext): J
 export const transformCodeScanningAlert = async (context: WebhookContext, githubInstallationId: number, jiraHost: string): Promise<JiraRemoteLinkBulkSubmitData | undefined> => {
 	const { action, alert, ref, repository } = context.payload;
 
-	const gitHubInstallationClient = await createInstallationClient(githubInstallationId, jiraHost, context.log, context.gitHubAppConfig?.gitHubAppId);
+	const metrics = {
+		trigger: "webhook",
+		subTrigger: "code_scanning_alert"
+	};
+	const gitHubInstallationClient = await createInstallationClient(githubInstallationId, jiraHost, metrics, context.log, context.gitHubAppConfig?.gitHubAppId);
 
 	// Grab branch names or PR titles
 	const entityTitles: string[] = [];

--- a/src/transforms/transform-deployment.test.ts
+++ b/src/transforms/transform-deployment.test.ts
@@ -34,6 +34,7 @@ const mockGetRepoConfig = () => {
 		expect.anything(),
 		expect.anything(),
 		expect.anything(),
+		expect.anything(),
 		expect.anything()
 	).mockResolvedValue(mockConfig);
 };
@@ -161,7 +162,7 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 	describe("cloud", () => {
 
 		beforeEach(async () => {
-			gitHubClient = new GitHubInstallationClient(getInstallationId(DatabaseStateCreator.GITHUB_INSTALLATION_ID), gitHubCloudConfig, jiraHost, getLogger("test"));
+			gitHubClient = new GitHubInstallationClient(getInstallationId(DatabaseStateCreator.GITHUB_INSTALLATION_ID), gitHubCloudConfig, jiraHost, { trigger: "test" }, getLogger("test"));
 
 			await new DatabaseStateCreator().create();
 		});
@@ -230,7 +231,7 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 
 			mockGetRepoConfig();
 
-			const jiraPayload = await transformDeployment(gitHubClient, deployment_status_staging.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
+			const jiraPayload = await transformDeployment(gitHubClient, deployment_status_staging.payload as any, jiraHost, { trigger: "test" }, getLogger("deploymentLogger"), undefined);
 
 
 			expect(jiraPayload?.deployments[0].associations).toStrictEqual(
@@ -321,7 +322,7 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 					]
 				});
 
-			const jiraPayload = await transformDeployment(gitHubClient, deployment_status.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
+			const jiraPayload = await transformDeployment(gitHubClient, deployment_status.payload as any, jiraHost, { trigger: "test" }, getLogger("deploymentLogger"), undefined);
 
 			expect(jiraPayload).toMatchObject(buildJiraPayload("Q4ua5dPnvDaW8CQgbnC7IiOQ8emND4bTv6ibK2Vh5LsGukmAF7VFE7MWZBwiPWON2fbqWL9q1jyjilgOMmt79WgMgDbT2opGlh6at5WfTYlYQVV77FXiLtPIOs8szN02ldD4slvScLRRynPQpzShisQpVfYU4PL5vCl2OzIYBIJ3zJJIY9g3EMSxtwe0rGaDBuINFBBgWYS2WOh8UAZxSR0w2wetYgq1Adv11Qy85rffGG3GkRHpFNvQ22n6Jqp",  [
 				{
@@ -406,7 +407,7 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 					]
 				});
 
-			const jiraPayload = await transformDeployment(gitHubClient, deployment_status.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
+			const jiraPayload = await transformDeployment(gitHubClient, deployment_status.payload as any, jiraHost, { trigger: "test" }, getLogger("deploymentLogger"), undefined);
 
 			expect(jiraPayload).toMatchObject(buildJiraPayload("testing",  [
 				{
@@ -493,7 +494,7 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 						]
 					});
 
-				const jiraPayload = await transformDeployment(gitHubClient, deployment_status.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
+				const jiraPayload = await transformDeployment(gitHubClient, deployment_status.payload as any, jiraHost, { trigger: "test" }, getLogger("deploymentLogger"), undefined);
 
 				// make expected issue id array
 				const expectedIssueIds = [...Array(500).keys()].map(number => "ABC-" + (number + 1));
@@ -525,7 +526,7 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 
 				mockGetRepoConfig();
 
-				const jiraPayload = await transformDeployment(gitHubClient, deployment_status.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
+				const jiraPayload = await transformDeployment(gitHubClient, deployment_status.payload as any, jiraHost, { trigger: "test" }, getLogger("deploymentLogger"), undefined);
 
 				// make expected issue id array
 
@@ -569,10 +570,11 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 					expect.anything(),
 					expect.anything(),
 					expect.anything(),
+					expect.anything(),
 					expect.anything()
 				).mockResolvedValue(mockConfig);
 
-				const jiraPayload = await transformDeployment(gitHubClient, deployment_status.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
+				const jiraPayload = await transformDeployment(gitHubClient, deployment_status.payload as any, jiraHost, { trigger: "test" }, getLogger("deploymentLogger"), undefined);
 
 				expect(jiraPayload).toMatchObject(buildJiraPayload("testing", [
 					{
@@ -660,7 +662,7 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 
 			mockGetRepoConfig();
 
-			const jiraPayload = await transformDeployment(gitHubClient, deployment_status_staging.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
+			const jiraPayload = await transformDeployment(gitHubClient, deployment_status_staging.payload as any, jiraHost, { trigger: "test" }, getLogger("deploymentLogger"), undefined);
 			expect(jiraPayload?.deployments[0].environment.type).toBe("development");
 		});
 
@@ -684,6 +686,7 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 					graphqlUrl: gheApiUrl + "/graphql"
 				},
 				jiraHost,
+				{ trigger: "test" },
 				getLogger("test"),
 				builderOutput.gitHubServerApp!.id
 			);
@@ -751,7 +754,7 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 					]
 				});
 
-			const jiraPayload = await transformDeployment(gitHubClient, deployment_status.payload as any, jiraHost, getLogger("deploymentLogger"), undefined);
+			const jiraPayload = await transformDeployment(gitHubClient, deployment_status.payload as any, jiraHost, { trigger: "test" }, getLogger("deploymentLogger"), undefined);
 
 			expect(jiraPayload).toMatchObject(buildJiraPayload("testing", [
 				{

--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -229,7 +229,7 @@ const mapJiraIssueIdsCommitsAndServicesToAssociationArray = (
 	return associations;
 };
 
-export const transformDeployment = async (githubInstallationClient: GitHubInstallationClient, payload: WebhookPayloadDeploymentStatus, jiraHost: string, logger: Logger, gitHubAppId: number | undefined): Promise<JiraDeploymentBulkSubmitData | undefined> => {
+export const transformDeployment = async (githubInstallationClient: GitHubInstallationClient, payload: WebhookPayloadDeploymentStatus, jiraHost: string, metrics: {trigger: string, subTrigger?: string}, logger: Logger, gitHubAppId: number | undefined): Promise<JiraDeploymentBulkSubmitData | undefined> => {
 	const deployment = payload.deployment;
 	const deployment_status = payload.deployment_status;
 	const { data: { commit: { message } } } = await githubInstallationClient.getCommit(payload.repository.owner.login, payload.repository.name, deployment.sha);
@@ -254,7 +254,9 @@ export const transformDeployment = async (githubInstallationClient: GitHubInstal
 			githubInstallationClient.githubInstallationId,
 			payload.repository.id,
 			payload.repository.owner.login,
-			payload.repository.name);
+			payload.repository.name,
+			metrics
+		);
 	} else {
 		logger.warn({
 			jiraHost,

--- a/src/transforms/transform-pull-request.test.ts
+++ b/src/transforms/transform-pull-request.test.ts
@@ -13,7 +13,7 @@ describe("pull_request transform", () => {
 
 	beforeEach(() => {
 		mockSystemTime(12345678);
-		client = new GitHubInstallationClient(getInstallationId(gitHubInstallationId), gitHubCloudConfig, jiraHost, getLogger("test"));
+		client = new GitHubInstallationClient(getInstallationId(gitHubInstallationId), gitHubCloudConfig, jiraHost, { trigger: "test" }, getLogger("test"));
 	});
 
 	it("should not contain branches on the payload if pull request status is closed.", async () => {

--- a/src/transforms/util/github-api-requests.test.ts
+++ b/src/transforms/util/github-api-requests.test.ts
@@ -16,7 +16,7 @@ describe("GitHub API Request Suite", () => {
 
 	const gitHubInstallationId = 123;
 	beforeEach(() => {
-		gitHubInstallationClient = new GitHubInstallationClient(getInstallationId(gitHubInstallationId), gitHubCloudConfig, jiraHost, getLogger("test"));
+		gitHubInstallationClient = new GitHubInstallationClient(getInstallationId(gitHubInstallationId), gitHubCloudConfig, jiraHost, { trigger: "test" }, getLogger("test"));
 	});
 
 	describe("compareCommitsBetweenBaseAndHeadBranches", () => {

--- a/src/transforms/util/github-get-pull-request-reviews.test.ts
+++ b/src/transforms/util/github-get-pull-request-reviews.test.ts
@@ -29,7 +29,7 @@ describe("getPullRequestReviews", () => {
 		githubNock
 			.get(`/repos/batman/gotham-city-bus-pass/pulls/2/reviews`)
 			.reply(200, { stuff: "things" });
-		const client = new GitHubInstallationClient(getInstallationId(GITHUB_INSTALLATION_ID), gitHubCloudConfig, jiraHost, logger);
+		const client = new GitHubInstallationClient(getInstallationId(GITHUB_INSTALLATION_ID), gitHubCloudConfig, jiraHost, { trigger: "test" }, logger);
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		expect(await getPullRequestReviews(client, MOCK_REPOSITORY, MOCK_PR, logger)).toEqual({ stuff: "things" });
@@ -40,7 +40,7 @@ describe("getPullRequestReviews", () => {
 		githubNock
 			.get(`/repos/batman/gotham-city-bus-pass/pulls/2/reviews`)
 			.reply(404);
-		const client = new GitHubInstallationClient(getInstallationId(GITHUB_INSTALLATION_ID), gitHubCloudConfig, jiraHost, logger);
+		const client = new GitHubInstallationClient(getInstallationId(GITHUB_INSTALLATION_ID), gitHubCloudConfig, jiraHost, { trigger: "test" }, logger);
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		expect(await getPullRequestReviews(client, MOCK_REPOSITORY, MOCK_PR, logger)).toEqual([]);
@@ -65,7 +65,7 @@ describe("getPullRequestReviews", () => {
 		githubNock
 			.get(`/repos/batman/gotham-city-bus-pass/pulls/2/reviews`)
 			.replyWithError("something awful happened");
-		const client = new GitHubInstallationClient(getInstallationId(GITHUB_INSTALLATION_ID), gitHubCloudConfig, jiraHost, logger);
+		const client = new GitHubInstallationClient(getInstallationId(GITHUB_INSTALLATION_ID), gitHubCloudConfig, jiraHost, { trigger: "test" }, logger);
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		expect(await getPullRequestReviews(client, MOCK_REPOSITORY, MOCK_PR, logger)).toEqual([]);

--- a/src/util/get-github-client-config.test.ts
+++ b/src/util/get-github-client-config.test.ts
@@ -114,7 +114,7 @@ describe("anonymous client", () => {
 		gheNock.get("/")
 			.matchHeader("ApiKeyHeader", "super-key")
 			.reply(200);
-		const client = await createAnonymousClient(gheUrl, jiraHost, getLogger("test"));
+		const client = await createAnonymousClient(gheUrl, jiraHost, { trigger: "test" }, getLogger("test"));
 		const response = await client.getMainPage(1000);
 		expect(response).toBeDefined();
 	});
@@ -136,7 +136,7 @@ describe("user client", () => {
 		gheApiNock.get("/user")
 			.matchHeader("ApiKeyHeader", "super-key")
 			.reply(200);
-		const client = await createUserClient("MY_TOKEN", jiraHost, getLogger("test"), gitHubServerApp?.id);
+		const client = await createUserClient("MY_TOKEN", jiraHost, { trigger: "test" }, getLogger("test"), gitHubServerApp?.id);
 		const response = await client.getUser();
 		expect(response).toBeDefined();
 	});
@@ -162,7 +162,7 @@ describe("installation client", () => {
 		gheApiNock.get("/rate_limit")
 			.matchHeader("ApiKeyHeader", "super-key")
 			.reply(200);
-		const client = await createInstallationClient(subscription!.gitHubInstallationId, jiraHost, getLogger("test"), gitHubServerApp?.id);
+		const client = await createInstallationClient(subscription!.gitHubInstallationId, jiraHost, { trigger: "test" }, getLogger("test"), gitHubServerApp?.id);
 		const response = await client.getRateLimit();
 		expect(response).toBeDefined();
 	});
@@ -183,7 +183,7 @@ describe("app client", () => {
 		gheAppTokenNock()
 			.matchHeader("ApiKeyHeader", "super-key");
 
-		const client = await createAppClient(getLogger("test"), jiraHost, gitHubServerApp?.id);
+		const client = await createAppClient(getLogger("test"), jiraHost, gitHubServerApp?.id, { trigger: "test" });
 		const response = await client.getApp();
 		expect(response).toBeDefined();
 	});

--- a/src/util/get-github-client-config.ts
+++ b/src/util/get-github-client-config.ts
@@ -7,7 +7,7 @@ import Logger from "bunyan";
 import { GitHubAppClient } from "../github/client/github-app-client";
 import { envVars } from "~/src/config/env";
 import { keyLocator } from "~/src/github/client/key-locator";
-import { GitHubClientApiKeyConfig, GitHubConfig } from "~/src/github/client/github-client";
+import { GitHubClientApiKeyConfig, GitHubConfig, Metrics } from "~/src/github/client/github-client";
 import { GitHubAnonymousClient } from "~/src/github/client/github-anonymous-client";
 import { EncryptionClient } from "utils/encryption-client";
 import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL, GITHUB_CLOUD_HOSTNAME } from "~/src/github/client/github-client-constants";
@@ -141,33 +141,33 @@ export const getGitHubClientConfigFromAppId = async (gitHubAppId: number | undef
  * Factory function to create a GitHub client that authenticates as the installation of our GitHub app to
  * get all installation or get more info for the app
  */
-export const createAppClient = async (logger: Logger, jiraHost: string, gitHubAppId: number | undefined): Promise<GitHubAppClient> => {
+export const createAppClient = async (logger: Logger, jiraHost: string, gitHubAppId: number | undefined, metrics: Metrics): Promise<GitHubAppClient> => {
 	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, logger, jiraHost);
-	return new GitHubAppClient(gitHubClientConfig, logger, gitHubClientConfig.appId.toString(), gitHubClientConfig.privateKey);
+	return new GitHubAppClient(gitHubClientConfig, metrics, logger, gitHubClientConfig.appId.toString(), gitHubClientConfig.privateKey);
 };
 
 /**
  * Factory function to create a GitHub client that authenticates as the installation of our GitHub app to get
  * information specific to an organization.
  */
-export const createInstallationClient = async (gitHubInstallationId: number, jiraHost: string, logger: Logger, gitHubAppId: number | undefined): Promise<GitHubInstallationClient> => {
+export const createInstallationClient = async (gitHubInstallationId: number, jiraHost: string, metrics: Metrics, logger: Logger, gitHubAppId: number | undefined): Promise<GitHubInstallationClient> => {
 	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, logger, jiraHost);
-	return new GitHubInstallationClient(getInstallationId(gitHubInstallationId, gitHubClientConfig.baseUrl, gitHubClientConfig.appId), gitHubClientConfig, jiraHost, logger, gitHubClientConfig.serverId);
+	return new GitHubInstallationClient(getInstallationId(gitHubInstallationId, gitHubClientConfig.baseUrl, gitHubClientConfig.appId), gitHubClientConfig, jiraHost, metrics, logger, gitHubClientConfig.serverId);
 };
 
 /**
  * Factory function to create a GitHub client that authenticates as the user (with a user access token).
  */
-export const createUserClient = async (githubToken: string, jiraHost: string, logger: Logger, gitHubAppId: number | undefined): Promise<GitHubUserClient> => {
+export const createUserClient = async (githubToken: string, jiraHost: string, metrics: Metrics, logger: Logger, gitHubAppId: number | undefined): Promise<GitHubUserClient> => {
 	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, logger, jiraHost);
-	return new GitHubUserClient(githubToken, gitHubClientConfig, logger);
+	return new GitHubUserClient(githubToken, gitHubClientConfig, metrics, logger);
 };
 
-export const createAnonymousClient = async (gitHubBaseUrl: string, jiraHost: string, logger: Logger): Promise<GitHubAnonymousClient> => {
-	return new GitHubAnonymousClient(await buildGitHubServerConfig(gitHubBaseUrl, jiraHost, logger), logger);
+export const createAnonymousClient = async (gitHubBaseUrl: string, jiraHost: string, metrics: Metrics, logger: Logger): Promise<GitHubAnonymousClient> => {
+	return new GitHubAnonymousClient(await buildGitHubServerConfig(gitHubBaseUrl, jiraHost, logger), metrics, logger);
 };
 
-export const createAnonymousClientByGitHubAppId = async (gitHubAppId: number | undefined, jiraHost: string, logger: Logger): Promise<GitHubAnonymousClient> => {
+export const createAnonymousClientByGitHubAppId = async (gitHubAppId: number | undefined, jiraHost: string, metrics: Metrics, logger: Logger): Promise<GitHubAnonymousClient> => {
 	const config = await getGitHubClientConfigFromAppId(gitHubAppId, logger, jiraHost);
-	return new GitHubAnonymousClient(config, logger);
+	return new GitHubAnonymousClient(config, metrics, logger);
 };

--- a/src/util/github-utils.test.ts
+++ b/src/util/github-utils.test.ts
@@ -7,7 +7,7 @@ describe("GitHub Utils", () => {
 	describe("isUserAdminOfOrganization", () => {
 		let githubUserClient: GitHubUserClient;
 		beforeEach(() => {
-			githubUserClient = new GitHubUserClient("token", gitHubCloudConfig, getLogger("test"));
+			githubUserClient = new GitHubUserClient("token", gitHubCloudConfig, { trigger: "test" }, getLogger("test"));
 		});
 
 		it("should return true if user is admin of a given organization", async () => {

--- a/src/util/preemptive-rate-limit.ts
+++ b/src/util/preemptive-rate-limit.ts
@@ -52,7 +52,10 @@ export const preemptiveRateLimitCheck = async <T extends BaseMessagePayload>(con
 const getRateRateLimitStatus = async (context: SQSMessageContext<BaseMessagePayload>) => {
 	const { installationId, jiraHost } = context.payload;
 	const gitHubAppId = context.payload.gitHubAppConfig?.gitHubAppId;
-	const gitHubInstallationClient = await createInstallationClient(installationId, jiraHost, context.log, gitHubAppId);
+	const metrics = {
+		trigger: "ratelimit_check"
+	};
+	const gitHubInstallationClient = await createInstallationClient(installationId, jiraHost, metrics, context.log, gitHubAppId);
 	return await gitHubInstallationClient.getRateLimit();
 };
 


### PR DESCRIPTION
**What's in this PR?**
Add metrics tags whenever we create a github client.

**Why**
So that we can tell which trigger/operation contribute how many github api calls and optimise it.

**Added feature flags**

**Affected issues**  


**How has this been tested?**  


**Whats Next?**
