### PR TITLE
ARC-2080 Reset sync information on removing data from Jira

### DIFF
--- a/src/routes/api/installation/api-installation-delete.test.ts
+++ b/src/routes/api/installation/api-installation-delete.test.ts
@@ -4,9 +4,11 @@ import { getLogger } from "config/logger";
 import { Subscription } from "models/subscription";
 import { getJiraClient } from "~/src/jira/client/jira-client";
 import { RepoSyncState } from "~/src/models/reposyncstate";
+import { booleanFlag, BooleanFlags } from "~/src/config/feature-flags";
 
 
 jest.mock("~/src/jira/client/jira-client");
+jest.mock("config/feature-flags");
 
 describe("ApiInstallationDelete", ()=>{
 	describe("GHES support", ()=>{
@@ -48,6 +50,11 @@ describe("ApiInstallationDelete", ()=>{
 					}
 				}
 			};
+
+			when(booleanFlag).calledWith(
+				BooleanFlags.USE_BACKFILL_ALGORITHM_INCREMENTAL,
+				expect.anything()
+			).mockResolvedValue(true);
 		});
 		it("should get subcription with gitHubAppid", async ()=>{
 			when(jest.mocked(getJiraClient))

--- a/src/routes/api/installation/api-installation-delete.ts
+++ b/src/routes/api/installation/api-installation-delete.ts
@@ -1,6 +1,8 @@
 import { Request, Response } from "express";
 import { Subscription } from "models/subscription";
+import { booleanFlag, BooleanFlags } from "~/src/config/feature-flags";
 import { getJiraClient } from "~/src/jira/client/jira-client";
+import { RepoSyncState } from "~/src/models/reposyncstate";
 
 export const ApiInstallationDelete = async (req: Request, res: Response): Promise<void> => {
 	const gitHubInstallationId = req.params.installationId;
@@ -30,6 +32,10 @@ export const ApiInstallationDelete = async (req: Request, res: Response): Promis
 		const jiraClient = await getJiraClient(jiraHost, Number(gitHubInstallationId), gitHubAppId, req.log);
 		req.log.info({ jiraHost, gitHubInstallationId }, `Deleting DevInfo`);
 		await jiraClient.devinfo.installation.delete(gitHubInstallationId);
+		const shouldUseBackfillAlgoIncremental = await booleanFlag(BooleanFlags.USE_BACKFILL_ALGORITHM_INCREMENTAL, jiraHost);
+		if (shouldUseBackfillAlgoIncremental) {
+			await RepoSyncState.resetSyncFromSubscription(subscription);
+		}
 		res.status(200).send(`DevInfo deleted for jiraHost: ${jiraHost} gitHubInstallationId: ${gitHubInstallationId}`);
 	} catch (err) {
 		res.status(500).json(err);


### PR DESCRIPTION
**What's in this PR?**
Updated Admin API to reset the sync data on removing dev Info data from Jira

**Why**
Pollinator check should able to execute same check again and again

**Added feature flags**
Incremental Backfilling

**Affected issues**  
[ARC-2080]


[ARC-2065]: https://softwareteams.atlassian.net/browse/ARC-2065

[ARC-2080]: https://softwareteams.atlassian.net/browse/ARC-2080