### PR TITLE
Fixing help icon alignment issue

### DIFF
--- a/static/css/jira-configuration-new.css
+++ b/static/css/jira-configuration-new.css
@@ -399,6 +399,13 @@
 .jiraConfiguration__info__backfillDate {
   color: #42526e;
   padding: 0.2em 0.3em;
+  display: flex;
+  white-space: nowrap;
+  align-items: center;
+}
+
+.jiraConfiguration__info__backfillDate-label, .jiraConfiguration__table__backfillInfoIcon {
+    margin-left: 5px;;
 }
 
 .jiraConfiguration__table__pending,

--- a/static/css/jira-configuration-new.css
+++ b/static/css/jira-configuration-new.css
@@ -405,7 +405,7 @@
 }
 
 .jiraConfiguration__info__backfillDate-label, .jiraConfiguration__table__backfillInfoIcon {
-    margin-left: 5px;;
+    margin-left: 5px;
 }
 
 .jiraConfiguration__table__pending,

--- a/views/partials/jira-configuration-table.hbs
+++ b/views/partials/jira-configuration-table.hbs
@@ -93,7 +93,7 @@
                       {{else}}
                         All commits backfilled
                       {{/if}}
-                  </span>
+                  </div>
                 {{/if}}
               {{/if}}
               {{!-- Display any sync warnings --}}

--- a/views/partials/jira-configuration-table.hbs
+++ b/views/partials/jira-configuration-table.hbs
@@ -85,9 +85,10 @@
               {{/if}}
               {{#if ../isIncrementalBackfillEnabled}}
                 {{#if (isAllSyncSuccess connection)}}
-                  <span class="jiraConfiguration__info__backfillDate">
+                  <div class="jiraConfiguration__info__backfillDate">
                       {{#if connection.backfillSince}}
-                        Backfilled from: <span class="jiraConfiguration__info__backfillDate-label" data-backfill-since="{{ toISOString connection.backfillSince }}">{{ connection.backfillSince }}</span>
+                        <span>Backfilled from:</span>
+                        <span class="jiraConfiguration__info__backfillDate-label" data-backfill-since="{{ toISOString connection.backfillSince }}">{{ connection.backfillSince }}</span>
                         <span class="jiraConfiguration__table__backfillInfoIcon aui-icon aui-iconfont-info-filled" title="If you want to backfill more data, choose &quot;Continue backfill&quot; in the settings menu on the right">Information</span>
                       {{else}}
                         All commits backfilled


### PR DESCRIPTION
**What's in this PR?**
Fixing help icon alignment issue which is next to `Backfilled from <date>`. It is moved to next line on small screens. 

**Added feature flags**
Incremental Backfill
