### PR TITLE
ARC-2091 test flags percentage bucket

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -30,6 +30,8 @@ export enum StringFlags {
 }
 
 export enum NumberFlags {
+	PERCENTAGE_FLAG_1 = "percentage-flag-1",
+	PERCENTAGE_FLAG_2 = "percentage-flag-2",
 	GITHUB_CLIENT_TIMEOUT = "github-client-timeout",
 	SYNC_MAIN_COMMIT_TIME_LIMIT = "sync-main-commit-time-limit",
 	SYNC_BRANCH_COMMIT_TIME_LIMIT = "sync-branch-commit-time-limit",

--- a/src/routes/jira/jira-get.ts
+++ b/src/routes/jira/jira-get.ts
@@ -11,7 +11,7 @@ import { GitHubServerApp } from "models/github-server-app";
 import { sendAnalytics } from "utils/analytics-client";
 import { AnalyticsEventTypes, AnalyticsScreenEventsEnum } from "interfaces/common";
 import { getCloudOrServerFromGitHubAppId } from "utils/get-cloud-or-server";
-import { booleanFlag, BooleanFlags } from "config/feature-flags";
+import { booleanFlag, BooleanFlags, numberFlag, NumberFlags } from "config/feature-flags";
 
 interface FailedConnection {
 	id: number;
@@ -121,11 +121,31 @@ const countNumberSkippedRepos = (connections: SuccessfulConnection[]): number =>
 	return connections.reduce((acc, obj) => acc + (obj?.totalNumberOfRepos || 0) - (obj?.numberOfSyncedRepos || 0) , 0);
 };
 
+const trackWhetherDifferentFlagsBindToSamePercentageForSameUserKey = async (jiraHost: string) => {
+	const ffPer1 = await numberFlag(NumberFlags.PERCENTAGE_FLAG_1, NaN, jiraHost);
+	const ffPer2 = await numberFlag(NumberFlags.PERCENTAGE_FLAG_2, NaN, jiraHost);
+	const isSamePercentageBucket =
+		(ffPer1 && ffPer2)
+		||
+		(!ffPer1 && !ffPer2);
+	statsd.increment("github-for-jira.app.server.flags-percentage", {
+		ffMainCommitsFrom: "" + ffPer1,
+		ffBranchCommitsFrom: "" + ffPer2,
+		isSamePercentageBucket: "" + isSamePercentageBucket
+	});
+};
+
 const renderJiraCloudAndEnterpriseServer = async (res: Response, req: Request): Promise<void> => {
 
 	const { jiraHost, nonce } = res.locals;
 
 	const isIncrementalBackfillEnabled = await booleanFlag(BooleanFlags.USE_BACKFILL_ALGORITHM_INCREMENTAL, jiraHost);
+
+	try {
+		await trackWhetherDifferentFlagsBindToSamePercentageForSameUserKey(jiraHost);
+	} catch (e) {
+		req.log.warn({ err: e }, `Error tracking flags percentage experiment`);
+	}
 
 	const subscriptions = await Subscription.getAllForHost(jiraHost);
 	const gheServers: GitHubServerApp[] = await GitHubServerApp.findForInstallationId(res.locals.installation.id) || [];


### PR DESCRIPTION
**What's in this PR?**
Add statsd for tracking flags percentage rollout bucket.

**Why**
I want to know whether different flags put same jiraHost into same percentage bucket, which should be true by this doc https://docs.launchdarkly.com/home/flags/rollouts

**Added feature flags**

![image](https://user-images.githubusercontent.com/105693507/229693840-38a72863-a65d-4ab4-af03-8e25d879ee2e.png)


**Affected issues**  
ARC-2091

**How has this been tested?**  
N/A

**Whats Next?**
Remove and disable the flags
