### PR TITLE
Remove branch comites from date and use main commites from date instead

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -34,7 +34,6 @@ export enum NumberFlags {
 	PERCENTAGE_FLAG_2 = "percentage-flag-2",
 	GITHUB_CLIENT_TIMEOUT = "github-client-timeout",
 	SYNC_MAIN_COMMIT_TIME_LIMIT = "sync-main-commit-time-limit",
-	SYNC_BRANCH_COMMIT_TIME_LIMIT = "sync-branch-commit-time-limit",
 	PREEMPTIVE_RATE_LIMIT_THRESHOLD = "preemptive-rate-limit-threshold",
 	NUMBER_OF_PR_PAGES_TO_FETCH_IN_PARALLEL = "number-of-pr-pages-to-fetch-in-parallel",
 	NUMBER_OF_BUILD_PAGES_TO_FETCH_IN_PARALLEL = "number-of-build-to-fetch-in-parallel",

--- a/src/sqs/sqs.types.ts
+++ b/src/sqs/sqs.types.ts
@@ -139,7 +139,6 @@ export type BackfillMessagePayload = BaseMessagePayload & {
 	syncType?: SyncType,
 	startTime?: string,
 	commitsFromDate?: string, //main commits from date, ISO string
-	branchCommitsFromDate?: string, //branch commits from date, ISO string
 	targetTasks?: TaskType[],
 	metricTags?: Record<string, string> //extra tags for metrics
 }

--- a/src/sync/branch.test.ts
+++ b/src/sync/branch.test.ts
@@ -227,10 +227,10 @@ describe("sync/branches", () => {
 					const time = Date.now();
 					const commitTimeLimitCutoff = 1000 * 60 * 60 * 96;
 					mockSystemTime(time);
-					const branchCommitsFromDate = new Date(time - commitTimeLimitCutoff).toISOString();
-					const data: BackfillMessagePayload = { installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, branchCommitsFromDate };
+					const commitsFromDate = new Date(time - commitTimeLimitCutoff).toISOString();
+					const data: BackfillMessagePayload = { installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, commitsFromDate };
 
-					nockBranchRequest(branchNodesFixture, { commitSince: branchCommitsFromDate });
+					nockBranchRequest(branchNodesFixture, { commitSince: commitsFromDate });
 					jiraNock
 						.post(
 							"/rest/devinfo/0.10/bulk",

--- a/src/sync/branches.ts
+++ b/src/sync/branches.ts
@@ -16,7 +16,7 @@ export const getBranchTask = async (
 
 	logger.info("Syncing branches: started");
 
-	const commitSince = messagePayload.branchCommitsFromDate ? new Date(messagePayload.branchCommitsFromDate) : undefined;
+	const commitSince = messagePayload.commitsFromDate ? new Date(messagePayload.commitsFromDate) : undefined;
 	const result = await gitHubClient.getBranchesPage(repository.owner.login, repository.name, perPage, commitSince, cursor as string);
 	const edges = result?.repository?.refs?.edges || [];
 	const branches = edges.map(edge => edge?.node);

--- a/src/sync/sync-utils.test.ts
+++ b/src/sync/sync-utils.test.ts
@@ -57,15 +57,6 @@ describe("sync utils", () => {
 					expect.objectContaining({ commitsFromDate: undefined }),
 					expect.anything(), expect.anything());
 			});
-			it("should  send undefined commit since date in the msg payload if flag is set to -1 for branch commits from date", async () => {
-				when(jest.mocked(numberFlag))
-					.calledWith(NumberFlags.SYNC_BRANCH_COMMIT_TIME_LIMIT, expect.anything(), jiraHost)
-					.mockResolvedValue(CUTOFF_IN_MSECS__DISABLED);
-				await findOrStartSync(subscription, getLogger("test"), undefined, undefined, undefined);
-				expect(sqsQueues.backfill.sendMessage).toBeCalledWith(
-					expect.objectContaining({ branchCommitsFromDate: undefined }),
-					expect.anything(), expect.anything());
-			});
 		});
 	});
 	describe("GitHubAppConfig", () => {

--- a/src/sync/sync-utils.ts
+++ b/src/sync/sync-utils.ts
@@ -44,8 +44,7 @@ export const findOrStartSync = async (
 
 	const gitHubAppConfig = await getGitHubAppConfig(subscription, logger);
 
-	const mainCommitsFromDate = await getCommitSinceDate(jiraHost, NumberFlags.SYNC_MAIN_COMMIT_TIME_LIMIT, commitsFromDate?.toISOString());
-	const branchCommitsFromDate = await getCommitSinceDate(jiraHost, NumberFlags.SYNC_BRANCH_COMMIT_TIME_LIMIT, commitsFromDate?.toISOString());
+	const mainCommitsFromDate = await getCommitSinceDate(jiraHost, commitsFromDate?.toISOString());
 
 	// Start sync
 	await sqsQueues.backfill.sendMessage({
@@ -54,7 +53,6 @@ export const findOrStartSync = async (
 		syncType,
 		startTime: new Date().toISOString(),
 		commitsFromDate: mainCommitsFromDate?.toISOString(),
-		branchCommitsFromDate: branchCommitsFromDate?.toISOString(),
 		targetTasks,
 		gitHubAppConfig,
 		metricTags: {
@@ -124,11 +122,11 @@ const resetFailedCode = async (subscription: Subscription, syncType?: SyncType, 
 	});
 };
 
-export const getCommitSinceDate = async (jiraHost: string, flagName: NumberFlags.SYNC_MAIN_COMMIT_TIME_LIMIT | NumberFlags.SYNC_BRANCH_COMMIT_TIME_LIMIT, commitsFromDate?: string): Promise<Date | undefined> => {
+export const getCommitSinceDate = async (jiraHost: string, commitsFromDate?: string): Promise<Date | undefined> => {
 	if (commitsFromDate) {
 		return new Date(commitsFromDate);
 	}
-	const timeCutoffMsecs = await numberFlag(flagName, NaN, jiraHost);
+	const timeCutoffMsecs = await numberFlag(NumberFlags.SYNC_MAIN_COMMIT_TIME_LIMIT, NaN, jiraHost);
 	if (!timeCutoffMsecs || timeCutoffMsecs === -1) {
 		return undefined;
 	}


### PR DESCRIPTION
**What's in this PR?**
1. Remove the branch commits from date and use the main commits from date instead

**Why**
1. The branch commits from date in graphql is not reducing the amount of branches to pull. GraphQL still pull same amount of branchces (although amount of commits might be different, but continue to 2)
2. The amount of commits pulled in graphql is also limited by 50, so even if we don't have this from date, it shouldn't be a big problem. In this PR using main commits from date will put a hard limit on it still.

**Added feature flags**

**Affected issues**  


**How has this been tested?**  
Unit test.

**Whats Next?**
