### PR TITLE
created new jira admin middleware and tests to return 403 when no auth

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -17,7 +17,8 @@ export enum BooleanFlags {
 	SEND_PR_COMMENTS_TO_JIRA = "send-pr-comments-to-jira_zy5ib",
 	USE_BACKFILL_ALGORITHM_INCREMENTAL = "backfill-algorithm-incremental",
 	REPO_CREATED_EVENT = "repo-created-event",
-	USE_SUBTASKS_FOR_BACKFILL = "use-subtasks-for-backfill"
+	USE_SUBTASKS_FOR_BACKFILL = "use-subtasks-for-backfill",
+	JIRA_ADMIN_CHECK = "jira-admin-check"
 }
 
 export enum StringFlags {

--- a/src/interfaces/common.ts
+++ b/src/interfaces/common.ts
@@ -66,7 +66,7 @@ declare global {
 				githubToken?: string;
 				githubRefreshToken?: string;
 				gitHubUuid?: string;
-				isJiraAdmin?: string;
+				isJiraAdmin?: boolean;
 				temp?:  {
 					[key: string]: string;
 				}

--- a/src/middleware/jira-admin-permission-middleware.test.ts
+++ b/src/middleware/jira-admin-permission-middleware.test.ts
@@ -1,0 +1,108 @@
+import { Request } from "express";
+import { DatabaseStateCreator } from "test/utils/database-state-creator";
+import { jiraAdminPermissionsMiddleware, setJiraAdminPrivileges } from "middleware/jira-admin-permission-middleware";
+
+describe("jiraAdminPermissionsMiddleware", () => {
+	let mockRequest;
+	let mockResponse;
+	let mockNext;
+
+	beforeEach(() => {
+		mockRequest = {
+			session: undefined,
+			log: { info: jest.fn() }
+		};
+		mockResponse = {
+			status: jest.fn().mockReturnThis(),
+			send: jest.fn()
+		};
+		mockNext = jest.fn();
+	});
+
+	test("should return 403 Forbidden if session is undefined", async () => {
+		await jiraAdminPermissionsMiddleware(mockRequest, mockResponse, mockNext);
+		expect(mockResponse.status).toHaveBeenCalledWith(403);
+	});
+
+	test("should return 403 Forbidden if hasAdminPermissions is false", async () => {
+		mockRequest.session = "false";
+		await jiraAdminPermissionsMiddleware(mockRequest, mockResponse, mockNext);
+		expect(mockResponse.status).toHaveBeenCalledWith(403);
+	});
+
+	test("should call next() if user has Jira admin permissions", async () => {
+		mockRequest.session = true;
+		await jiraAdminPermissionsMiddleware(mockRequest, mockResponse, mockNext);
+		expect(mockNext).toHaveBeenCalled();
+	});
+});
+
+
+describe("setJiraAdminPrivileges",  () => {
+	const mockRequest = {
+		session: {},
+		log: {
+			info: jest.fn(),
+			debug: jest.fn(),
+			error: jest.fn()
+		}
+	} as unknown as Request;
+	const mockClaims = { sub: "1111" };
+	let installation;
+
+	beforeEach(async () => {
+		installation = (await new DatabaseStateCreator().create()).installation;
+	});
+
+	it("sets session isJiraAdmin to true if user has ADMINISTER permission", async () => {
+		mockRequest.session.isJiraAdmin = undefined;
+		const payload = {
+			accountId: "1111",
+			globalPermissions: [
+				"ADMINISTER"
+			]
+		};
+		jiraNock
+			.post("/rest/api/latest/permissions/check", payload)
+			.reply(200, { globalPermissions: ["ADMINISTER"] });
+
+		await setJiraAdminPrivileges(mockRequest, mockClaims, installation);
+
+		expect(mockRequest.session.isJiraAdmin).toBe(true);
+	});
+
+	it("sets session isJiraAdmin to false if user does not have ADMINISTER permission", async () => {
+		mockClaims.sub = "2222";
+		mockRequest.session.isJiraAdmin = undefined;
+		const payload = {
+			accountId: "2222",
+			globalPermissions: [
+				"ADMINISTER"
+			]
+		};
+		jiraNock
+			.post("/rest/api/latest/permissions/check", payload)
+			.reply(200, { globalPermissions: [] });
+
+		await setJiraAdminPrivileges(mockRequest, mockClaims, installation);
+
+		expect(mockRequest.session.isJiraAdmin).toBe(false);
+	});
+
+	it("should exit early when claim has no sub", async () => {
+		const mockClaimsNoSub = {};
+		mockRequest.session.isJiraAdmin = undefined;
+
+		await setJiraAdminPrivileges(mockRequest, mockClaimsNoSub, installation);
+
+		expect(mockRequest.session.isJiraAdmin).toBe(undefined);
+	});
+
+	it("should return session value without JiraClient request if already exists", async () => {
+		mockRequest.session.isJiraAdmin = "true";
+
+		await setJiraAdminPrivileges(mockRequest, mockClaims, installation);
+
+		expect(mockRequest.session.isJiraAdmin).toBe("true");
+	});
+});

--- a/src/middleware/jira-admin-permission-middleware.test.ts
+++ b/src/middleware/jira-admin-permission-middleware.test.ts
@@ -6,7 +6,7 @@ import { when } from "jest-when";
 
 jest.mock("config/feature-flags");
 
-describe("jiraAdminPermissionsMiddleware", () => {
+describe.skip("jiraAdminPermissionsMiddleware", () => {
 	let mockRequest;
 	let mockResponse;
 	let mockNext;
@@ -33,20 +33,20 @@ describe("jiraAdminPermissionsMiddleware", () => {
 	});
 
 	test("should return 403 Forbidden if hasAdminPermissions is false", async () => {
-		mockRequest.session = "false";
+		mockRequest.session.isJiraAdmin = false;
 		await jiraAdminPermissionsMiddleware(mockRequest, mockResponse, mockNext);
 		expect(mockResponse.status).toHaveBeenCalledWith(403);
 	});
 
 	test("should call next() if user has Jira admin permissions", async () => {
-		mockRequest.session = true;
+		mockRequest.session.isJiraAdmin = true;
 		await jiraAdminPermissionsMiddleware(mockRequest, mockResponse, mockNext);
 		expect(mockNext).toHaveBeenCalled();
 	});
 });
 
 // Delete this describe block during flag clean up
-describe("jiraAdminPermissionsMiddleware - feature flag off", () => {
+describe.skip("jiraAdminPermissionsMiddleware - feature flag off", () => {
 	let mockRequest;
 	let mockResponse;
 	let mockNext;
@@ -73,13 +73,13 @@ describe("jiraAdminPermissionsMiddleware - feature flag off", () => {
 	});
 
 	test("should return 403 Forbidden if hasAdminPermissions is false", async () => {
-		mockRequest.session = "false";
+		mockRequest.session.isJiraAdmin = false;
 		await jiraAdminPermissionsMiddleware(mockRequest, mockResponse, mockNext);
 		expect(mockNext).toHaveBeenCalled();
 	});
 
 	test("should call next() if user has Jira admin permissions", async () => {
-		mockRequest.session = true;
+		mockRequest.session.isJiraAdmin = true;
 		await jiraAdminPermissionsMiddleware(mockRequest, mockResponse, mockNext);
 		expect(mockNext).toHaveBeenCalled();
 	});
@@ -146,10 +146,10 @@ describe("setJiraAdminPrivileges",  () => {
 	});
 
 	it("should return session value without JiraClient request if already exists", async () => {
-		mockRequest.session.isJiraAdmin = "true";
+		mockRequest.session.isJiraAdmin = true;
 
 		await setJiraAdminPrivileges(mockRequest, mockClaims, installation);
 
-		expect(mockRequest.session.isJiraAdmin).toBe("true");
+		expect(mockRequest.session.isJiraAdmin).toBe(true);
 	});
 });

--- a/src/middleware/jira-admin-permission-middleware.test.ts
+++ b/src/middleware/jira-admin-permission-middleware.test.ts
@@ -6,14 +6,14 @@ import { when } from "jest-when";
 
 jest.mock("config/feature-flags");
 
-describe.skip("jiraAdminPermissionsMiddleware", () => {
+describe("jiraAdminPermissionsMiddleware", () => {
 	let mockRequest;
 	let mockResponse;
 	let mockNext;
 
 	beforeEach(() => {
 		mockRequest = {
-			session: undefined,
+			session: {},
 			log: { info: jest.fn() }
 		};
 		mockResponse = {
@@ -46,14 +46,14 @@ describe.skip("jiraAdminPermissionsMiddleware", () => {
 });
 
 // Delete this describe block during flag clean up
-describe.skip("jiraAdminPermissionsMiddleware - feature flag off", () => {
+describe("jiraAdminPermissionsMiddleware - feature flag off", () => {
 	let mockRequest;
 	let mockResponse;
 	let mockNext;
 
 	beforeEach(() => {
 		mockRequest = {
-			session: undefined,
+			session: {},
 			log: { info: jest.fn() }
 		};
 		mockResponse = {
@@ -68,6 +68,7 @@ describe.skip("jiraAdminPermissionsMiddleware - feature flag off", () => {
 	});
 
 	test("should return 403 Forbidden if session is undefined", async () => {
+		delete mockRequest.session.isJiraAdmin;
 		await jiraAdminPermissionsMiddleware(mockRequest, mockResponse, mockNext);
 		expect(mockNext).toHaveBeenCalled();
 	});

--- a/src/middleware/jira-admin-permission-middleware.test.ts
+++ b/src/middleware/jira-admin-permission-middleware.test.ts
@@ -1,6 +1,9 @@
 import { Request } from "express";
 import { DatabaseStateCreator } from "test/utils/database-state-creator";
-import { jiraAdminPermissionsMiddleware, setJiraAdminPrivileges } from "middleware/jira-admin-permission-middleware";
+import {
+	fetchAndSaveUserJiraAdminStatus,
+	jiraAdminPermissionsMiddleware
+} from "middleware/jira-admin-permission-middleware";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
 import { when } from "jest-when";
 
@@ -86,7 +89,7 @@ describe("jiraAdminPermissionsMiddleware - feature flag off", () => {
 	});
 });
 
-describe("setJiraAdminPrivileges",  () => {
+describe("fetchAndSaveUserJiraAdminStatus",  () => {
 	const mockRequest = {
 		session: {},
 		log: {
@@ -114,7 +117,7 @@ describe("setJiraAdminPrivileges",  () => {
 			.post("/rest/api/latest/permissions/check", payload)
 			.reply(200, { globalPermissions: ["ADMINISTER"] });
 
-		await setJiraAdminPrivileges(mockRequest, mockClaims, installation);
+		await fetchAndSaveUserJiraAdminStatus(mockRequest, mockClaims, installation);
 
 		expect(mockRequest.session.isJiraAdmin).toBe(true);
 	});
@@ -132,7 +135,7 @@ describe("setJiraAdminPrivileges",  () => {
 			.post("/rest/api/latest/permissions/check", payload)
 			.reply(200, { globalPermissions: [] });
 
-		await setJiraAdminPrivileges(mockRequest, mockClaims, installation);
+		await fetchAndSaveUserJiraAdminStatus(mockRequest, mockClaims, installation);
 
 		expect(mockRequest.session.isJiraAdmin).toBe(false);
 	});
@@ -141,7 +144,7 @@ describe("setJiraAdminPrivileges",  () => {
 		const mockClaimsNoSub = {};
 		mockRequest.session.isJiraAdmin = undefined;
 
-		await setJiraAdminPrivileges(mockRequest, mockClaimsNoSub, installation);
+		await fetchAndSaveUserJiraAdminStatus(mockRequest, mockClaimsNoSub, installation);
 
 		expect(mockRequest.session.isJiraAdmin).toBe(undefined);
 	});
@@ -149,7 +152,7 @@ describe("setJiraAdminPrivileges",  () => {
 	it("should return session value without JiraClient request if already exists", async () => {
 		mockRequest.session.isJiraAdmin = true;
 
-		await setJiraAdminPrivileges(mockRequest, mockClaims, installation);
+		await fetchAndSaveUserJiraAdminStatus(mockRequest, mockClaims, installation);
 
 		expect(mockRequest.session.isJiraAdmin).toBe(true);
 	});

--- a/src/middleware/jira-admin-permission-middleware.ts
+++ b/src/middleware/jira-admin-permission-middleware.ts
@@ -17,11 +17,9 @@ export const setJiraAdminPrivileges = async (req: Request, claims: Record<any, a
 			return;
 		}
 		const jiraClient = await JiraClient.getNewClient(installation, req.log);
-		// Make jira call to permissions with userAccountId.
 		const permissions = await jiraClient.checkAdminPermissions(userAccountId);
-		const hasAdminPermissions = permissions.data.globalPermissions.includes(ADMIN_PERMISSION);
 
-		req.session.isJiraAdmin = hasAdminPermissions;
+		req.session.isJiraAdmin = permissions.data.globalPermissions.includes(ADMIN_PERMISSION);
 		req.log.info({ isAdmin :req.session.isJiraAdmin }, "Admin permissions set");
 	} catch (err) {
 		req.log.error({ err }, "Failed to fetch Jira Admin rights");
@@ -29,18 +27,18 @@ export const setJiraAdminPrivileges = async (req: Request, claims: Record<any, a
 };
 
 export const jiraAdminPermissionsMiddleware = async (req: Request, res: Response, next: NextFunction): Promise<void | Response>  => {
-	const hasAdminPermissions = req.session;
+	const { isJiraAdmin } = req.session;
 	if (!(await booleanFlag(BooleanFlags.JIRA_ADMIN_CHECK))) {
 		return next();
 	}
 
-	if (hasAdminPermissions === undefined) {
+	if (isJiraAdmin === undefined) {
 		// User permissions could bot be extracted from the Jira JWT, check that the jwt middleware has run
 		req.log.info("No Jira user permissions found");
 		return res.status(403).send("Forbidden - User Jira permissions have not been found.");
 	}
 
-	if (hasAdminPermissions === "false") {
+	if (!isJiraAdmin) {
 		req.log.info("User does not have Jira admin permissions.");
 		return res.status(403).send("Forbidden - User does not have Jira administer permissions.");
 	}

--- a/src/middleware/jira-admin-permission-middleware.ts
+++ b/src/middleware/jira-admin-permission-middleware.ts
@@ -19,7 +19,7 @@ export const fetchAndSaveUserJiraAdminStatus = async (req: Request, claims: Reco
 		const jiraClient = await JiraClient.getNewClient(installation, req.log);
 		const permissions = await jiraClient.checkAdminPermissions(userAccountId);
 
-		req.session.isJiraAdmin = !permissions.data.globalPermissions.includes(ADMIN_PERMISSION);
+		req.session.isJiraAdmin = permissions.data.globalPermissions.includes(ADMIN_PERMISSION);
 		req.log.info({ isAdmin :req.session.isJiraAdmin }, "Admin permissions set");
 	} catch (err) {
 		req.log.error({ err }, "Failed to fetch Jira Admin rights");

--- a/src/middleware/jira-admin-permission-middleware.ts
+++ b/src/middleware/jira-admin-permission-middleware.ts
@@ -3,7 +3,7 @@ import { Installation } from "models/installation";
 import { JiraClient } from "models/jira-client";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
 
-export const setJiraAdminPrivileges = async (req: Request, claims: Record<any, any>, installation: Installation) => {
+export const setJiraAdminPrivileges = async (req: Request, claims: Record<any, any>, installation: Installation): Promise<void> => {
 	const ADMIN_PERMISSION = "ADMINISTER";
 	// We only need to add this to the session if it doesn't exist
 	if (req.session.isJiraAdmin !== undefined) {
@@ -28,7 +28,7 @@ export const setJiraAdminPrivileges = async (req: Request, claims: Record<any, a
 	}
 };
 
-export const jiraAdminPermissionsMiddleware = async (req: Request, res: Response, next: NextFunction) => {
+export const jiraAdminPermissionsMiddleware = async (req: Request, res: Response, next: NextFunction): Promise<void | Response>  => {
 	const hasAdminPermissions = req.session;
 	if (!(await booleanFlag(BooleanFlags.JIRA_ADMIN_CHECK))) {
 		return next();
@@ -44,5 +44,5 @@ export const jiraAdminPermissionsMiddleware = async (req: Request, res: Response
 		req.log.info("User does not have Jira admin permissions.");
 		return res.status(403).send("Forbidden - User does not have Jira administer permissions.");
 	}
-	return next();
+	next();
 };

--- a/src/middleware/jira-admin-permission-middleware.ts
+++ b/src/middleware/jira-admin-permission-middleware.ts
@@ -1,0 +1,44 @@
+import { NextFunction, Request, Response } from "express";
+import { Installation } from "models/installation";
+import { JiraClient } from "models/jira-client";
+
+export const setJiraAdminPrivileges = async (req: Request, claims: Record<any, any>, installation: Installation) => {
+	const ADMIN_PERMISSION = "ADMINISTER";
+	// We only need to add this to the session if it doesn't exist
+	if (req.session.isJiraAdmin !== undefined) {
+		return;
+	}
+
+	try {
+		const userAccountId = claims.sub;
+		// Can't check permissions without userAccountId
+		if (!userAccountId) {
+			return;
+		}
+		const jiraClient = await JiraClient.getNewClient(installation, req.log);
+		// Make jira call to permissions with userAccountId.
+		const permissions = await jiraClient.checkAdminPermissions(userAccountId);
+		const hasAdminPermissions = permissions.data.globalPermissions.includes(ADMIN_PERMISSION);
+
+		req.session.isJiraAdmin = hasAdminPermissions;
+		req.log.info({ isAdmin :req.session.isJiraAdmin }, "Admin permissions set");
+	} catch (err) {
+		req.log.error({ err }, "Failed to fetch Jira Admin rights");
+	}
+};
+
+export const jiraAdminPermissionsMiddleware = async (req: Request, res: Response, next: NextFunction) => {
+	const hasAdminPermissions = req.session;
+
+	if (hasAdminPermissions === undefined) {
+		// User permissions could bot be extracted from the Jira JWT, check that the jwt middleware has run
+		req.log.info("No Jira user permissions found");
+		return res.status(403).send("Forbidden - User Jira permissions have not been found.");
+	}
+
+	if (hasAdminPermissions === "false") {
+		req.log.info("User does not have Jira admin permissions.");
+		return res.status(403).send("Forbidden - User does not have Jira administer permissions.");
+	}
+	return next();
+};

--- a/src/middleware/jira-admin-permission-middleware.ts
+++ b/src/middleware/jira-admin-permission-middleware.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import { Installation } from "models/installation";
 import { JiraClient } from "models/jira-client";
+import { booleanFlag, BooleanFlags } from "config/feature-flags";
 
 export const setJiraAdminPrivileges = async (req: Request, claims: Record<any, any>, installation: Installation) => {
 	const ADMIN_PERMISSION = "ADMINISTER";
@@ -29,6 +30,9 @@ export const setJiraAdminPrivileges = async (req: Request, claims: Record<any, a
 
 export const jiraAdminPermissionsMiddleware = async (req: Request, res: Response, next: NextFunction) => {
 	const hasAdminPermissions = req.session;
+	if (!(await booleanFlag(BooleanFlags.JIRA_ADMIN_CHECK))) {
+		return next();
+	}
 
 	if (hasAdminPermissions === undefined) {
 		// User permissions could bot be extracted from the Jira JWT, check that the jwt middleware has run

--- a/src/middleware/jira-symmetric-jwt-middleware.ts
+++ b/src/middleware/jira-symmetric-jwt-middleware.ts
@@ -5,7 +5,7 @@ import { getJWTRequest, TokenType, validateQsh } from "~/src/jira/util/jwt";
 import { Installation } from "~/src/models/installation";
 import { moduleUrls } from "~/src/routes/jira/atlassian-connect/jira-atlassian-connect-get";
 import { matchRouteWithPattern } from "~/src/util/match-route-with-pattern";
-import { setJiraAdminPrivileges } from "middleware/jira-admin-permission-middleware";
+import { fetchAndSaveUserJiraAdminStatus } from "middleware/jira-admin-permission-middleware";
 
 export const jiraSymmetricJwtMiddleware = async (req: Request, res: Response, next: NextFunction) => {
 
@@ -38,7 +38,7 @@ export const jiraSymmetricJwtMiddleware = async (req: Request, res: Response, ne
 		req.session.jiraHost = installation.jiraHost;
 
 		// Check whether logged in user has Jira Admin permissions and save it to the session
-		await setJiraAdminPrivileges(req, verifiedClaims, installation);
+		await fetchAndSaveUserJiraAdminStatus(req, verifiedClaims, installation);
 
 		if (req.cookies.jwt) {
 			res.clearCookie("jwt");

--- a/src/middleware/jira-symmetric-jwt-middleware.ts
+++ b/src/middleware/jira-symmetric-jwt-middleware.ts
@@ -5,32 +5,7 @@ import { getJWTRequest, TokenType, validateQsh } from "~/src/jira/util/jwt";
 import { Installation } from "~/src/models/installation";
 import { moduleUrls } from "~/src/routes/jira/atlassian-connect/jira-atlassian-connect-get";
 import { matchRouteWithPattern } from "~/src/util/match-route-with-pattern";
-import { JiraClient } from "models/jira-client";
-
-export const setJiraAdminPrivileges = async (req: Request, claims: Record<any, any>, installation: Installation) => {
-	const ADMIN_PERMISSION = "ADMINISTER";
-	// We only need to add this to the session if it doesn't exist
-	if (req.session.isJiraAdmin !== undefined) {
-		return;
-	}
-
-	try {
-		const userAccountId = claims.sub;
-		// Can't check permissions without userAccountId
-		if (!userAccountId) {
-			return;
-		}
-		const jiraClient = await JiraClient.getNewClient(installation, req.log);
-		// Make jira call to permissions with userAccountId.
-		const permissions = await jiraClient.checkAdminPermissions(userAccountId);
-		const hasAdminPermissions = permissions.data.globalPermissions.includes(ADMIN_PERMISSION);
-
-		req.session.isJiraAdmin = hasAdminPermissions;
-		req.log.info({ isAdmin :req.session.isJiraAdmin }, "Admin permissions set");
-	} catch (err) {
-		req.log.error({ err }, "Failed to fetch Jira Admin rights");
-	}
-};
+import { setJiraAdminPrivileges } from "middleware/jira-admin-permission-middleware";
 
 export const jiraSymmetricJwtMiddleware = async (req: Request, res: Response, next: NextFunction) => {
 

--- a/src/routes/github/github-router.ts
+++ b/src/routes/github/github-router.ts
@@ -16,6 +16,7 @@ import { GithubBranchRouter } from "routes/github/branch/github-branch-router";
 import { jiraSymmetricJwtMiddleware } from "~/src/middleware/jira-symmetric-jwt-middleware";
 import { Errors } from "config/errors";
 import { GithubEncryptHeaderPost } from "routes/github/github-encrypt-header-post";
+import { jiraAdminPermissionsMiddleware } from "middleware/jira-admin-permission-middleware";
 
 //  DO NOT USE THIS MIDDLEWARE ELSE WHERE EXCEPT FOR CREATE BRANCH FLOW AS THIS HAS SECURITY HOLE
 // TODO - Once JWT is passed from Jira for create branch this midddleware is obsolete.
@@ -62,6 +63,7 @@ subRouter.use("/branch", JiraHostFromQueryParamMiddleware, GithubServerAppMiddle
 subRouter.use(GithubOAuthRouter);
 
 subRouter.use(jiraSymmetricJwtMiddleware);
+subRouter.use(jiraAdminPermissionsMiddleware); // This must stay after jiraSymmetricJwtMiddleware
 subRouter.use(GithubServerAppMiddleware);
 
 subRouter.post("/encrypt/header", GithubEncryptHeaderPost);

--- a/src/routes/jira/configuration/jira-configuration-router.ts
+++ b/src/routes/jira/configuration/jira-configuration-router.ts
@@ -3,9 +3,10 @@ import { csrfMiddleware } from "middleware/csrf-middleware";
 import { JiraGet } from "routes/jira/jira-get";
 import { JiraDelete } from "routes/jira/jira-delete";
 import { jiraSymmetricJwtMiddleware } from "~/src/middleware/jira-symmetric-jwt-middleware";
+import { jiraAdminPermissionsMiddleware } from "middleware/jira-admin-permission-middleware";
 
 export const JiraConfigurationRouter = Router();
 
 JiraConfigurationRouter.route("/")
-	.get(csrfMiddleware, jiraSymmetricJwtMiddleware, JiraGet)
-	.delete(jiraSymmetricJwtMiddleware, JiraDelete);
+	.get(csrfMiddleware, jiraSymmetricJwtMiddleware, jiraAdminPermissionsMiddleware, JiraGet)
+	.delete(jiraSymmetricJwtMiddleware, jiraAdminPermissionsMiddleware, JiraDelete);

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-router.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-router.ts
@@ -6,10 +6,12 @@ import { JiraConnectEnterpriseAppPut } from "routes/jira/connect/enterprise/app/
 import { JiraConnectEnterpriseAppPost } from "routes/jira/connect/enterprise/app/jira-connect-enterprise-app-post";
 import { JiraConnectEnterpriseAppCreateOrEdit } from "routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit";
 import { jiraSymmetricJwtMiddleware } from "~/src/middleware/jira-symmetric-jwt-middleware";
+import { jiraAdminPermissionsMiddleware } from "middleware/jira-admin-permission-middleware";
 
 export const JiraConnectEnterpriseAppRouter = Router();
 
 JiraConnectEnterpriseAppRouter.use(jiraSymmetricJwtMiddleware);
+JiraConnectEnterpriseAppRouter.use(jiraAdminPermissionsMiddleware);
 
 JiraConnectEnterpriseAppRouter.post("/", JiraConnectEnterpriseAppPost);
 

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-router.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-router.ts
@@ -7,17 +7,18 @@ import { JiraConnectEnterpriseAppRouter } from "routes/jira/connect/enterprise/a
 import { JiraConnectEnterpriseServerAppGet } from "routes/jira/connect/enterprise/server_app/jira-connect-enterprise-server-app-get";
 import { JiraConnectEnterpriseAppCreateOrEdit } from "routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit";
 import { jiraSymmetricJwtMiddleware } from "~/src/middleware/jira-symmetric-jwt-middleware";
+import { jiraAdminPermissionsMiddleware } from "middleware/jira-admin-permission-middleware";
 
 export const JiraConnectEnterpriseRouter = Router();
 
 JiraConnectEnterpriseRouter.route("/")
-	.get(csrfMiddleware, jiraSymmetricJwtMiddleware, JiraConnectEnterpriseGet)
-	.post(jiraSymmetricJwtMiddleware, JiraConnectEnterprisePost)
-	.delete(jiraSymmetricJwtMiddleware, JiraConnectEnterpriseDelete);
+	.get(csrfMiddleware, jiraSymmetricJwtMiddleware, jiraAdminPermissionsMiddleware, JiraConnectEnterpriseGet)
+	.post(jiraSymmetricJwtMiddleware, jiraAdminPermissionsMiddleware, JiraConnectEnterprisePost)
+	.delete(jiraSymmetricJwtMiddleware, jiraAdminPermissionsMiddleware, JiraConnectEnterpriseDelete);
 
 JiraConnectEnterpriseRouter.use("/app", JiraConnectEnterpriseAppRouter);
 
-JiraConnectEnterpriseRouter.get("/:serverUrl/app/new", csrfMiddleware, jiraSymmetricJwtMiddleware, JiraConnectEnterpriseAppCreateOrEdit);
+JiraConnectEnterpriseRouter.get("/:serverUrl/app/new", csrfMiddleware, jiraSymmetricJwtMiddleware, jiraAdminPermissionsMiddleware, JiraConnectEnterpriseAppCreateOrEdit);
 
-JiraConnectEnterpriseRouter.get("/:serverUrl/app", csrfMiddleware, jiraSymmetricJwtMiddleware, JiraConnectEnterpriseServerAppGet);
+JiraConnectEnterpriseRouter.get("/:serverUrl/app", csrfMiddleware, jiraSymmetricJwtMiddleware, jiraAdminPermissionsMiddleware, JiraConnectEnterpriseServerAppGet);
 

--- a/src/routes/jira/connect/jira-connect-router.ts
+++ b/src/routes/jira/connect/jira-connect-router.ts
@@ -3,10 +3,11 @@ import { csrfMiddleware } from "middleware/csrf-middleware";
 import { JiraConnectGet } from "./jira-connect-get";
 import { JiraConnectEnterpriseRouter } from "./enterprise/jira-connect-enterprise-router";
 import { jiraSymmetricJwtMiddleware } from "~/src/middleware/jira-symmetric-jwt-middleware";
+import { jiraAdminPermissionsMiddleware } from "middleware/jira-admin-permission-middleware";
 
 export const JiraConnectRouter = Router();
 
 JiraConnectRouter.route("/")
-	.get(csrfMiddleware, jiraSymmetricJwtMiddleware, JiraConnectGet);
+	.get(csrfMiddleware, jiraSymmetricJwtMiddleware, jiraAdminPermissionsMiddleware, JiraConnectGet);
 
 JiraConnectRouter.use("/enterprise", JiraConnectEnterpriseRouter);

--- a/src/routes/jira/jira-router.ts
+++ b/src/routes/jira/jira-router.ts
@@ -10,11 +10,12 @@ import { JiraConnectRouter } from "routes/jira/connect/jira-connect-router";
 import { body } from "express-validator";
 import { returnOnValidationError } from "routes/api/api-utils";
 import { jiraSymmetricJwtMiddleware } from "~/src/middleware/jira-symmetric-jwt-middleware";
+import { jiraAdminPermissionsMiddleware } from "middleware/jira-admin-permission-middleware";
 
 export const JiraRouter = Router();
 
 // TODO: The params `installationId` needs to be replaced by `subscriptionId`
-JiraRouter.delete("/subscription/:installationId", jiraSymmetricJwtMiddleware, JiraDelete);
+JiraRouter.delete("/subscription/:installationId", jiraSymmetricJwtMiddleware, jiraAdminPermissionsMiddleware, JiraDelete);
 
 JiraRouter.get("/atlassian-connect.json", JiraAtlassianConnectGet);
 
@@ -28,7 +29,7 @@ JiraRouter.post("/sync",
 
 JiraRouter.use("/events", JiraEventsRouter);
 
-JiraRouter.get("/", csrfMiddleware, jiraSymmetricJwtMiddleware, JiraGet);
+JiraRouter.get("/", csrfMiddleware, jiraSymmetricJwtMiddleware, jiraAdminPermissionsMiddleware, JiraGet);
 
 /********************************************************************************************************************
  * TODO: remove this later, keeping this for now cause its out in `Prod`


### PR DESCRIPTION
**What's in this PR?**
Created new middleware to return 403 for endpoints that require Jira Admin privileges

**Why**
So we can be sure that endpoints are being called by allowed folks.
Plus the create branch JWT token can be any user so we dont want any funny business

**Added feature flags**
JIRA_CHECK_ADMIN


**Affected issues**  
_Jira Issues_

**How has this been tested?**  
Complete covereage unit tests, testing on STAGE with on/off flag

**Whats Next?**
Remove the user token from create branch and turn on JWT for create branch