### PR TITLE
NONE use installation client key

### DIFF
--- a/src/routes/github/configuration/github-configuration-post.ts
+++ b/src/routes/github/configuration/github-configuration-post.ts
@@ -57,8 +57,8 @@ export const GithubConfigurationPost = async (req: Request, res: Response): Prom
 		const metrics = {
 			trigger: "github-configuration-post"
 		};
-		const gitHubUserClient = await createUserClient(githubToken, jiraHost, metrics, req.log, gitHubAppId);
-		const gitHubAppClient = await createAppClient(req.log, jiraHost, gitHubAppId, metrics);
+		const gitHubUserClient = await createUserClient(githubToken, installation.jiraHost, metrics, req.log, gitHubAppId);
+		const gitHubAppClient = await createAppClient(req.log, installation.jiraHost, gitHubAppId, metrics);
 
 		// Check if the user that posted this has access to the installation ID they're requesting
 		if (!await hasAdminAccess(gitHubAppClient, gitHubUserClient, gitHubInstallationId, req.log)) {
@@ -78,7 +78,7 @@ export const GithubConfigurationPost = async (req: Request, res: Response): Prom
 
 		await Promise.all(
 			[
-				saveConfiguredAppProperties(jiraHost, req.log, true),
+				saveConfiguredAppProperties(installation.jiraHost, req.log, true),
 				findOrStartSync(subscription, req.log, "full", undefined, undefined, {
 					source: "initial-sync"
 				})
@@ -88,7 +88,7 @@ export const GithubConfigurationPost = async (req: Request, res: Response): Prom
 		sendAnalytics(AnalyticsEventTypes.TrackEvent, {
 			name: AnalyticsTrackEventsEnum.ConnectToOrgTrackEventName,
 			source: !gitHubAppId ? AnalyticsTrackSource.Cloud : AnalyticsTrackSource.GitHubEnterprise,
-			jiraHost,
+			jiraHost: installation.jiraHost,
 			success: true,
 			gitHubProduct
 		});
@@ -99,7 +99,7 @@ export const GithubConfigurationPost = async (req: Request, res: Response): Prom
 		sendAnalytics(AnalyticsEventTypes.TrackEvent, {
 			name: AnalyticsTrackEventsEnum.ConnectToOrgTrackEventName,
 			source: !gitHubAppId ? AnalyticsTrackSource.Cloud : AnalyticsTrackSource.GitHubEnterprise,
-			jiraHost,
+			jiraHost: installation.jiraHost,
 			success: false,
 			gitHubProduct
 		});

--- a/src/routes/github/github-oauth-router.test.ts
+++ b/src/routes/github/github-oauth-router.test.ts
@@ -17,7 +17,8 @@ describe("github-oauth-router", () => {
 		let locals = {};
 		let session = {};
 
-		beforeEach(() => {
+		beforeEach(async () => {
+			await new DatabaseStateCreator().create();
 			locals = {};
 			session = {
 				jiraHost,

--- a/src/routes/github/github-oauth-router.ts
+++ b/src/routes/github/github-oauth-router.ts
@@ -10,7 +10,6 @@ import { GitHubServerApp } from "models/github-server-app";
 import { GithubServerAppMiddleware } from "middleware/github-server-app-middleware";
 import { GitHubAppConfig } from "~/src/sqs/sqs.types";
 import Logger from "bunyan";
-import { jiraSymmetricJwtMiddleware } from "middleware/jira-symmetric-jwt-middleware";
 
 const logger = getLogger("github-oauth");
 const appUrl = envVars.APP_URL;
@@ -193,6 +192,43 @@ const getCloudOrGHESAppClientSecret = async (gitHubAppConfig, jiraHost: string) 
 	return ghesApp.getDecryptedGitHubClientSecret(jiraHost);
 };
 
+const TempGetJiraHostFromStateMiddleware  = async (req: Request, res: Response, next: NextFunction) => {
+
+	const stateKey = req.query.state as string;
+	if (!stateKey) {
+		req.log.warn("State key is empty");
+		res.status(400).send(Errors.MISSING_JIRA_HOST);
+		return;
+	}
+	if (!req.session[stateKey]) {
+		req.log.warn("State is empty in req.session for callback redirect");
+		res.status(400).send(Errors.MISSING_JIRA_HOST);
+		return;
+	}
+
+	let url;
+	try {
+		let redirectUrl = req.session[stateKey];
+		if (!redirectUrl.startsWith("http")) {
+			redirectUrl = "https://dummy.domain" + redirectUrl;
+		}
+		url = new URL(redirectUrl);
+	} catch (e) {
+		req.log.warn("Error passing redirect url in callback", e);
+		res.status(400).send(Errors.MISSING_JIRA_HOST);
+		return;
+	}
+	const jiraHost = url.searchParams.get("jiraHost");
+	if (!jiraHost) {
+		req.log.warn("jiraHost is missing in state redirect uri");
+		res.status(400).send(Errors.MISSING_JIRA_HOST);
+		return;
+	}
+
+	res.locals.jiraHost = jiraHost;
+	next();
+};
+
 const appendJiraHostIfNeeded = (url: string, jiraHost: string): string => {
 	if (!jiraHost) return url;
 	if (url.indexOf("?") === -1) url = url + "?";
@@ -223,4 +259,4 @@ const renewGitHubToken = async (githubRefreshToken: string, gitHubAppConfig: Git
 // in the same file as they reference each other
 export const GithubOAuthRouter = Router({ mergeParams: true });
 GithubOAuthRouter.get("/login", GithubServerAppMiddleware, GithubOAuthLoginGet);
-GithubOAuthRouter.get(callbackSubPath, jiraSymmetricJwtMiddleware, GithubServerAppMiddleware, GithubOAuthCallbackGet);
+GithubOAuthRouter.get(callbackSubPath, TempGetJiraHostFromStateMiddleware, GithubServerAppMiddleware, GithubOAuthCallbackGet);

--- a/static/js/github-configuration.js
+++ b/static/js/github-configuration.js
@@ -6,8 +6,7 @@ $('.install-link').click(function (event) {
 
 	$.post(window.location.href, {
 		installationId: $(event.target).data('installation-id'),
-		_csrf: document.getElementById('_csrf').value,
-		clientKey: document.getElementById('clientKey').value
+		_csrf: document.getElementById('_csrf').value
 	}, function (data) {
 		event.currentTarget.removeAttribute("disabled");
 		if (data.err) {

--- a/views/github-configuration.hbs
+++ b/views/github-configuration.hbs
@@ -24,13 +24,6 @@
 
 <body>
 <input type="hidden" id="_csrf" name="_csrf" value="{{csrfToken}}" />
-<input type="hidden" id="jiraHost" name="jiraHost" value="{{jiraHost}}" />
-<input
-  type="hidden"
-  id="clientKey"
-  name="clientKey"
-  value="{{clientKey}}"
-/>
 
 {{> navigation hideBackButton=true }}
 


### PR DESCRIPTION
**What's in this PR?**
- Do not pass clientKey in payload, use one from installation instead

**Why**
- Because that might cause data inconsistency, as we had with one of our client. All the pages are JWT-protected and installation is guaranteed to be there, there's only one possible value.

**How has this been tested?**  
Locally.
