### PR TITLE
ARC 2092 - Adding Sonarqube Scan in GitHub

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -9,6 +9,20 @@ on:
   pull_request:
 
 jobs:
+  sonarqube:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Disabling shallow clone is recommended for improving relevancy of reporting
+          fetch-depth: 0
+      - name: SonarQube Scan
+        uses: sonarsource/sonarqube-scan-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+
+
   build:
     runs-on: ubuntu-22.04
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ test/e2e/test-results/
 
 *.drawio.bkp
 *.drawio.dtmp
+
+./.scannerwork/*

--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,4 @@ test/e2e/test-results/
 *.drawio.bkp
 *.drawio.dtmp
 
-./.scannerwork/*
+/.scannerwork/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,16 @@
+# See https://docs.sonarqube.org/latest/analysis/analysis-parameters/
+# Sonar server to publish results to
+sonar.host.url=https://sonar-enterprise.internal.atlassian.com/
+
+# Sonar project setup
+sonar.language=javaScript/typeScript
+sonar.projectKey=github-for-jira
+sonar.projectName=github-for-jira
+
+# Find sources to analyze here
+sonar.sources=src
+sonar.tests=test
+
+# These parameters are custom key/values to pass to the analysis context
+sonar.analysis.repo=git@github.com:atlassian/github-for-jira.git
+sonar.analysis.inline_comments=true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,3 +14,4 @@ sonar.tests=test
 # These parameters are custom key/values to pass to the analysis context
 sonar.analysis.repo=git@github.com:atlassian/github-for-jira.git
 sonar.analysis.inline_comments=true
+sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,13 +3,14 @@
 sonar.host.url=https://sonar-enterprise.internal.atlassian.com/
 
 # Sonar project setup
-sonar.language=javaScript/typeScript
+sonar.language=JavaScript/TypeScript
 sonar.projectKey=github-for-jira
 sonar.projectName=github-for-jira
 
 # Find sources to analyze here
 sonar.sources=src
 sonar.tests=test
+sonar.test.inclusions=**/*.test.ts
 
 # These parameters are custom key/values to pass to the analysis context
 sonar.analysis.repo=git@github.com:atlassian/github-for-jira.git


### PR DESCRIPTION
**What's in this PR?**
- Adding SonarQube scan in GitHub

**Why**
- Earlier this was done in the Bitbucket pipelines, during CD process. Doing it in CD process was incorrect, so doing it here in GitHub when PR is build, so that we can catch any code issues during build and not after pushing it.
