### PR TITLE
remove stale deployment messages

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -18,7 +18,8 @@ export enum BooleanFlags {
 	USE_BACKFILL_ALGORITHM_INCREMENTAL = "backfill-algorithm-incremental",
 	REPO_CREATED_EVENT = "repo-created-event",
 	USE_SUBTASKS_FOR_BACKFILL = "use-subtasks-for-backfill",
-	JIRA_ADMIN_CHECK = "jira-admin-check"
+	JIRA_ADMIN_CHECK = "jira-admin-check",
+	REMOVE_STALE_MESSAGES = "remove-stale-messages"
 }
 
 export enum StringFlags {

--- a/src/sqs/sqs.test.ts
+++ b/src/sqs/sqs.test.ts
@@ -233,4 +233,104 @@ describe("SQS", () => {
 			}));
 		});
 	});
+
+	describe("deleteStaleMessages", () => {
+
+		// Mock the SQSMessageContext object
+		const context = {
+			log: {
+				warn: jest.fn(),
+				error: jest.fn()
+			}
+		};
+
+		beforeEach(() => {
+			queue = createSqsQueue(1);
+			queue.start();
+		});
+		// Test case for when the message is not from the targeted queue
+		it("should return false when message is not from targeted queue", async () => {
+			const message = {
+				Body: JSON.stringify({}),
+				MessageId: "12345"
+			};
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			const result = await queue.deleteStaleMessages(message, context);
+			expect(result).toBe(false);
+		});
+
+		// Test case for when the message does not have a body
+		it("should return false when message has no body", async () => {
+			const message = {
+				MessageId: "12345"
+			};
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			const result = await queue.deleteStaleMessages(message, context);
+			expect(result).toBe(false);
+		});
+
+		// Test case for when the message is from the targeted queue and is stale
+		it("should delete stale message and return true", async () => {
+			const message = {
+				Body: JSON.stringify({
+					webhookReceived: Date.now() - 2 * 24 * 60 * 60 * 1000 // Two days ago
+				}),
+				MessageId: "12345"
+			};
+			const deleteMessage = jest.fn();
+			const mockThis = {
+				queueName: "deployment",
+				deleteMessage
+			};
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			const result = await queue.deleteStaleMessages.call(mockThis, message, context);
+			expect(result).toBe(true);
+			expect(deleteMessage).toHaveBeenCalledWith(context);
+			expect(context.log.warn).toHaveBeenCalledWith(
+				{ deletedMessageId: "12345" },
+				"Deleted stale message from deployment queue"
+			);
+		});
+
+		// Test case for when the message is from the targeted queue and is not stale
+		it("should return false when message is not stale", async () => {
+			const message = {
+				Body: JSON.stringify({
+					webhookReceived: Date.now() - 12 * 60 * 60 * 1000 // 12 hours ago
+				}),
+				MessageId: "12345"
+			};
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			const result = await queue.deleteStaleMessages(message, context);
+			expect(result).toBe(false);
+		});
+
+		// Test case for when deleting the message fails
+		it("should return false and log an error when deleting the message fails", async () => {
+			const message = {
+				Body: JSON.stringify({
+					webhookReceived: Date.now() - 2 * 24 * 60 * 60 * 1000 // Two days ago
+				}),
+				MessageId: "12345"
+			};
+			const deleteMessage = jest.fn().mockRejectedValue(new Error("Failed to delete message"));
+			const mockThis = {
+				queueName: "deployment",
+				deleteMessage
+			};
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			const result = await queue.deleteStaleMessages.call(mockThis, message, context);
+			expect(result).toBe(false);
+			expect(deleteMessage).toHaveBeenCalledWith(context);
+			expect(context.log.error).toHaveBeenCalledWith(
+				{ error: expect.any(Error), deletedMessageId: "12345" },
+				"Failed to delete stale message from deployment queue"
+			);
+		});
+	});
 });

--- a/src/sqs/sqs.ts
+++ b/src/sqs/sqs.ts
@@ -252,7 +252,7 @@ export class SqsQueue<MessagePayload extends BaseMessagePayload> {
 		const messageBody = JSON.parse(message.Body);
 		const { webhookReceived } = messageBody;
 
-		// Is the webhook too old
+		// If the webhook too old, currently set to greater than one day.
 		if (Date.now() - webhookReceived > ONE_DAY_MILLI) {
 			try {
 				await this.deleteMessage(context);
@@ -304,7 +304,7 @@ export class SqsQueue<MessagePayload extends BaseMessagePayload> {
 			const rateLimitCheckResult = await preemptiveRateLimitCheck(context, this);
 			if (rateLimitCheckResult.isExceedThreshold) {
 
-				// TEMP FIX - this captures stale deployment messages and deleted them instead of trying to consume them later
+				// Remove stale messages
 				if (await this.deleteStaleMessages(message, context)) return;
 				// We have found out that the rate limit quota has been used and exceed the configured threshold.
 				// Next step is to postpone the processing.

--- a/src/sqs/sqs.ts
+++ b/src/sqs/sqs.ts
@@ -7,7 +7,7 @@ import { statsd } from "config/statsd";
 import { Tags } from "hot-shots";
 import { sqsQueueMetrics } from "config/metric-names";
 import { ErrorHandler, ErrorHandlingResult, MessageHandler, QueueSettings, SQSContext, SQSMessageContext, BaseMessagePayload, SqsTimeoutError } from "~/src/sqs/sqs.types";
-import { stringFlag, StringFlags } from "config/feature-flags";
+import { booleanFlag, BooleanFlags, stringFlag, StringFlags } from "config/feature-flags";
 import { preemptiveRateLimitCheck } from "utils/preemptive-rate-limit";
 
 //Maximum SQS Delay according to SQS docs https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-delay-queues.html
@@ -18,7 +18,7 @@ const MAX_MESSAGE_VISIBILITY_TIMEOUT_SEC: number = 12 * 60 * 60 - 1;
 const DEFAULT_LONG_POLLING_INTERVAL = 4;
 const PROCESSING_DURATION_HISTOGRAM_BUCKETS = "10_100_500_1000_2000_3000_5000_10000_30000_60000";
 const EXTRA_VISIBILITY_TIMEOUT_DELAY = 2;
-const ONE_DAY_MILLI = 86400000;
+const ONE_DAY_MILLI = 24 * 60 * 60 * 1000;
 
 const isNotAFailure = (errorHandlingResult: ErrorHandlingResult) => {
 	return !errorHandlingResult.isFailure;
@@ -243,7 +243,10 @@ export class SqsQueue<MessagePayload extends BaseMessagePayload> {
 		}
 	}
 
-	public async deleteStaleMessages(message: Message, context: SQSMessageContext<MessagePayload>): Promise<boolean> {
+	public async deleteStaleMessages(message: Message, context: SQSMessageContext<MessagePayload>, jiraHost: string): Promise<boolean> {
+		if (!await booleanFlag(BooleanFlags.REMOVE_STALE_MESSAGES, jiraHost)) {
+			return false;
+		}
 		const TARGETED_QUEUES = ["deployment"];
 		if (!message?.Body || !TARGETED_QUEUES.includes(this.queueName)) {
 			return false;
@@ -300,7 +303,7 @@ export class SqsQueue<MessagePayload extends BaseMessagePayload> {
 
 		try {
 			const messageProcessingStartTime = Date.now();
-			if (await this.deleteStaleMessages(message, context)) return;
+			if (await this.deleteStaleMessages(message, context, jiraHost)) return;
 
 			const rateLimitCheckResult = await preemptiveRateLimitCheck(context, this);
 			if (rateLimitCheckResult.isExceedThreshold) {

--- a/src/sqs/sqs.ts
+++ b/src/sqs/sqs.ts
@@ -243,7 +243,7 @@ export class SqsQueue<MessagePayload extends BaseMessagePayload> {
 		}
 	}
 
-	public async deleteStaleMessages(message: Message, context: SQSMessageContext<MessagePayload>, jiraHost: string): Promise<boolean> {
+	public async deleteStaleMessages(message: Message, context: SQSMessageContext<MessagePayload>, jiraHost?: string): Promise<boolean> {
 		if (!await booleanFlag(BooleanFlags.REMOVE_STALE_MESSAGES, jiraHost)) {
 			return false;
 		}
@@ -303,7 +303,7 @@ export class SqsQueue<MessagePayload extends BaseMessagePayload> {
 
 		try {
 			const messageProcessingStartTime = Date.now();
-			if (await this.deleteStaleMessages(message, context, jiraHost)) return;
+			if (await this.deleteStaleMessages(message, context, payload?.jiraHost)) return;
 
 			const rateLimitCheckResult = await preemptiveRateLimitCheck(context, this);
 			if (rateLimitCheckResult.isExceedThreshold) {


### PR DESCRIPTION
**What's in this PR?**
created a function to delete preemptively rate limited messages that meet the "stale" criteria, it is isolated to deployments at the moment

**Why**
CUZ THERES SO DAMN MANY