### PR TITLE
ARC-2119: force deployments status to go to complete on error during backfill

### DIFF
--- a/src/sync/installation.test.ts
+++ b/src/sync/installation.test.ts
@@ -361,7 +361,21 @@ describe("sync/installation", () => {
 			expect(refreshedSubscription?.get({ plain: true })).toStrictEqual(subscription?.get({ plain: true }));
 		});
 
-		// TODO: bgvozdev to finish off before enabling the FF for everyone
+		it("maps failed deployment to complete (until we fix it :allethings: in ARC-2119)", async () => {
+			repoSyncState.deploymentStatus = "pending";
+			await repoSyncState.save();
+
+			await markCurrentTaskAsFailedAndContinue(MESSAGE_PAYLOAD, {
+				...TASK,
+				task: "deployment"
+			}, false, jest.fn(), getLogger("test"), mockError);
+
+			const refreshedRepoSyncState = await RepoSyncState.findByPk(repoSyncState.id);
+			const refreshedSubscription = await Subscription.findByPk(subscription?.id);
+			expect(refreshedRepoSyncState?.deploymentStatus).toEqual("complete");
+			expect(refreshedSubscription?.get({ plain: true })).toStrictEqual(subscription?.get({ plain: true }));
+		});
+
 		describe("parallel sync", () => {
 			let MESSAGE_PAYLOAD_BRANCHES_ONLY;
 

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -337,8 +337,14 @@ export const markCurrentTaskAsFailedAndContinue = async (data: BackfillMessagePa
 	// marking the current task as failed, this value will override any preexisting failedCodes and only keep the last known failed issue.
 	const failedCode = getFailedCode(err);
 
+	const isDeployment = mainNextTask.task === "deployment";
+	const newStatus = isDeployment ? "complete" : "failed";
+	if (isDeployment) {
+		log.warn("Mapping failed status to complete until we fix deployment backfilling in ARC-2119");
+	}
+
 	// marking the current task as failed
-	await updateRepo(subscription, mainNextTask.repositoryId, { [getStatusKey(mainNextTask.task)]: "failed", failedCode });
+	await updateRepo(subscription, mainNextTask.repositoryId, { [getStatusKey(mainNextTask.task)]: newStatus, failedCode });
 	const gitHubProduct = getCloudOrServerFromGitHubAppId(subscription.gitHubAppId);
 
 	if (isPermissionError) {


### PR DESCRIPTION
**What's in this PR?**
Foring deployments task to be marked as complete

**Why**
Because deployments backfilling is broken and we only mislead the customers

