### PR TITLE
ARC-2122: making manual app creation flow to use config object

### DIFF
--- a/src/routes/api/db-migrations/db-migration-down.test.ts
+++ b/src/routes/api/db-migrations/db-migration-down.test.ts
@@ -1,4 +1,3 @@
-import express from "express";
 import { getFrontendApp } from "~/src/app";
 import supertest, { Test } from "supertest";
 import { runDbMigration, DBMigrationType, validateScriptLocally } from "./db-migration-utils";
@@ -21,8 +20,7 @@ const MIGRATION_SCRIPT_LAST = "20220101000001-second-script.js";
 describe("DB migration down", ()=>{
 	let frontendApp;
 	beforeEach(async ()=>{
-		frontendApp = express();
-		frontendApp.use(getFrontendApp());
+		frontendApp = getFrontendApp();
 	});
 	describe("Param validation", ()=>{
 		it("should fail when targetScript is missing in body", async ()=>{

--- a/src/routes/api/db-migrations/db-migration-up.test.ts
+++ b/src/routes/api/db-migrations/db-migration-up.test.ts
@@ -1,4 +1,3 @@
-import express from "express";
 import { getFrontendApp } from "~/src/app";
 import supertest, { Test } from "supertest";
 import { runDbMigration, DBMigrationType, validateScriptLocally } from "./db-migration-utils";
@@ -21,8 +20,7 @@ const MIGRATION_SCRIPT_LAST = "20220101000001-second-script.js";
 describe("DB migration up", ()=>{
 	let frontendApp;
 	beforeEach(async ()=>{
-		frontendApp = express();
-		frontendApp.use(getFrontendApp());
+		frontendApp = getFrontendApp();
 	});
 	describe("Param validation", ()=>{
 		it("should fail when targetScript is missing in body", async ()=>{

--- a/src/routes/api/installation/api-installation-router.test.ts
+++ b/src/routes/api/installation/api-installation-router.test.ts
@@ -9,10 +9,6 @@ jest.mock("config/feature-flags");
 jest.mock("./api-installation-get");
 jest.mock("./api-installation-syncstate-get");
 
-const setupAppAndRouter = () => {
-	return getFrontendApp();
-};
-
 const mockApiGetReturn200OK = () => {
 	when(jest.mocked(ApiInstallationGet))
 		.mockImplementation(async (_req, res)=>{
@@ -28,7 +24,7 @@ describe("Api Installation Routes", () => {
 	describe("Supporting GHES", () => {
 		let app: Application;
 		beforeEach(() => {
-			app = setupAppAndRouter();
+			app = getFrontendApp();
 		});
 		describe("Backward compatible with cloud", () => {
 			const CLOUD_GITHUB_INSTALLATION_ID = 1234;

--- a/src/routes/github/configuration/github-configuration-router.test.ts
+++ b/src/routes/github/configuration/github-configuration-router.test.ts
@@ -3,8 +3,7 @@ import supertest from "supertest";
 import { Installation } from "models/installation";
 import { Subscription } from "models/subscription";
 import { getFrontendApp } from "~/src/app";
-import { getLogger } from "config/logger";
-import express, { Application } from "express";
+import { Application } from "express";
 import { getSignedCookieHeader } from "test/utils/cookies";
 import { ViewerRepositoryCountQuery } from "~/src/github/client/github-queries";
 import installationResponse from "fixtures/jira-configuration/single-installation.json";
@@ -40,12 +39,7 @@ describe("Github Configuration", () => {
 			encryptedSharedSecret: "ghi345"
 		});
 
-		frontendApp = express();
-		frontendApp.use((request, _, next) => {
-			request.log = getLogger("test");
-			next();
-		});
-		frontendApp.use(getFrontendApp());
+		frontendApp = getFrontendApp();
 	});
 
 	describe("Github Token Validation", () => {

--- a/src/routes/github/create-branch/github-create-branch-get.test.ts
+++ b/src/routes/github/create-branch/github-create-branch-get.test.ts
@@ -1,6 +1,5 @@
 import express, { Application } from "express";
 import supertest from "supertest";
-import { getLogger } from "config/logger";
 import { getFrontendApp } from "~/src/app";
 import { getSignedCookieHeader } from "test/utils/cookies";
 import { Subscription } from "models/subscription";
@@ -13,9 +12,7 @@ describe("GitHub Create Branch Get", () => {
 	beforeEach(() => {
 		app = express();
 		app.use((req, _, next) => {
-			req.log = getLogger("test");
 			req.query = { issueKey: "1", issueSummary: "random-string", jiraHost };
-			req.csrfToken = jest.fn();
 			next();
 		});
 		app.use(getFrontendApp());

--- a/src/routes/github/github-encrypt-header-post.test.ts
+++ b/src/routes/github/github-encrypt-header-post.test.ts
@@ -1,7 +1,5 @@
 import supertest from "supertest";
 import { getSignedCookieHeader } from "test/utils/cookies";
-import express from "express";
-import { getLogger } from "config/logger";
 import { getFrontendApp } from "~/src/app";
 import { when } from "jest-when";
 import { stringFlag, StringFlags } from "config/feature-flags";
@@ -10,12 +8,7 @@ import { Installation } from "~/src/models/installation";
 jest.mock("config/feature-flags");
 
 describe("Github Encrypt Header post endpoint", () => {
-	const frontendApp = express();
-	frontendApp.use((request, _, next) => {
-		request.log = getLogger("test");
-		next();
-	});
-	frontendApp.use(getFrontendApp());
+	const frontendApp = getFrontendApp();
 
 	beforeEach(async() => {
 		await Installation.create({

--- a/src/routes/github/github-router.test.ts
+++ b/src/routes/github/github-router.test.ts
@@ -19,9 +19,6 @@ const GITHUB_SERVER_APP_ID = Math.floor(Math.random() * 10000);
 const GITHUB_SERVER_CLIENT_ID = "client-id";
 const DEFAULT_SCOPES = "user,repo";
 const TESTING_SCOPES = "scope1,scope2";
-const setupAppAndRouter = () => {
-	return getFrontendApp();
-};
 
 const prepareGitHubServerAppInDB = async (jiraInstallaionId: number) => {
 	const existed = await GitHubServerApp.findForUuid(GITHUB_SERVER_APP_UUID);
@@ -67,7 +64,7 @@ describe("GitHub router", () => {
 		describe("Cloud scenario", () => {
 			let app: Application;
 			beforeEach(async() => {
-				app = setupAppAndRouter();
+				app = getFrontendApp();
 				mockConfigurationGetProceed();
 				await Installation.create({
 					jiraHost,
@@ -162,7 +159,7 @@ describe("GitHub router", () => {
 			let jiraInstallaionId: number;
 			let gitHubAppId: number;
 			beforeEach(async () => {
-				app = setupAppAndRouter();
+				app = getFrontendApp();
 				const installation = await prepareNewInstallationInDB();
 				jiraInstallaionId = installation.id;
 				const gitHubApp = await prepareGitHubServerAppInDB(jiraInstallaionId);

--- a/src/routes/github/manifest/github-manifest-complete-get.test.ts
+++ b/src/routes/github/manifest/github-manifest-complete-get.test.ts
@@ -1,15 +1,12 @@
 import { Installation } from "~/src/models/installation";
 import { getLogger } from "config/logger";
-import express, { Express } from "express";
+import { Express } from "express";
 import { DatabaseStateCreator } from "test/utils/database-state-creator";
 import { encodeSymmetric } from "atlassian-jwt";
 import supertest from "supertest";
-import path from "path";
-import { registerHandlebarsPartials } from "utils/handlebars/handlebar-partials";
-import { registerHandlebarsHelpers } from "utils/handlebars/handlebar-helpers";
-import { RootRouter } from "routes/router";
 import { GitHubServerApp } from "models/github-server-app";
 import { GheConnectConfigTempStorage } from "utils/ghe-connect-config-temp-storage";
+import { getFrontendApp } from "~/src/app";
 
 describe("github-manifest-complete-get", () => {
 	let app: Express;
@@ -22,13 +19,7 @@ describe("github-manifest-complete-get", () => {
 		installation = result.installation;
 		gheServerApp = result.gitHubServerApp!;
 
-		app = express();
-		app.set("view engine", "hbs");
-		const viewPath = path.resolve(process.cwd(), "views");
-		app.set("views", viewPath);
-		registerHandlebarsPartials(path.resolve(viewPath, "partials"));
-		registerHandlebarsHelpers();
-		app.use(RootRouter);
+		app = getFrontendApp();
 
 		jwt = encodeSymmetric({
 			qsh: "context-qsh",

--- a/src/routes/github/manifest/github-manifest-complete-get.ts
+++ b/src/routes/github/manifest/github-manifest-complete-get.ts
@@ -41,6 +41,7 @@ export const GithubManifestCompleteGet = async (req: Request, res: Response) => 
 			appId: gitHubAppConfig.id,
 			gitHubAppName: gitHubAppConfig.name,
 			gitHubBaseUrl: gheHost,
+			// TODO: copy other values from the connectConfig
 			gitHubClientId: gitHubAppConfig.client_id,
 			gitHubClientSecret: gitHubAppConfig.client_secret,
 			webhookSecret: gitHubAppConfig.webhook_secret,

--- a/src/routes/github/manifest/github-manifest-get.test.ts
+++ b/src/routes/github/manifest/github-manifest-get.test.ts
@@ -1,27 +1,18 @@
-import express, { Express } from "express";
+import { Express } from "express";
 import { Installation } from "models/installation";
-import path from "path";
-import { registerHandlebarsPartials }  from "utils/handlebars/handlebar-partials";
-import { registerHandlebarsHelpers } from "utils/handlebars/handlebar-helpers";
-import { RootRouter } from "routes/router";
 import { getLogger } from "config/logger";
 import { encodeSymmetric } from "atlassian-jwt";
 import { DatabaseStateCreator } from "test/utils/database-state-creator";
 import supertest from "supertest";
 import { GheConnectConfigTempStorage } from "utils/ghe-connect-config-temp-storage";
+import { getFrontendApp } from "~/src/app";
 
 describe("github-manifest-get", () => {
 	let app: Express;
 	let installation: Installation;
 
 	beforeEach(() => {
-		app = express();
-		app.set("view engine", "hbs");
-		const viewPath = path.resolve(process.cwd(), "views");
-		app.set("views", viewPath);
-		registerHandlebarsPartials(path.resolve(viewPath, "partials"));
-		registerHandlebarsHelpers();
-		app.use(RootRouter);
+		app = getFrontendApp();
 	});
 
 	const generateJwt = async () => {

--- a/src/routes/github/repository/github-repository-get.test.ts
+++ b/src/routes/github/repository/github-repository-get.test.ts
@@ -1,6 +1,5 @@
 import express, { Application } from "express";
 import supertest from "supertest";
-import { getLogger } from "config/logger";
 import { getFrontendApp } from "~/src/app";
 import { getSignedCookieHeader } from "test/utils/cookies";
 import { Subscription } from "~/src/models/subscription";
@@ -11,9 +10,7 @@ describe("GitHub Repository Search", () => {
 	beforeEach(() => {
 		app = express();
 		app.use((req, _, next) => {
-			req.log = getLogger("test");
 			req.query = { repoName: randomString, jiraHost };
-			req.csrfToken = jest.fn();
 			next();
 		});
 		app.use(getFrontendApp());

--- a/src/routes/github/setup/github-setup-router.test.ts
+++ b/src/routes/github/setup/github-setup-router.test.ts
@@ -2,8 +2,7 @@
 import supertest from "supertest";
 import { Installation } from "models/installation";
 import { getFrontendApp } from "~/src/app";
-import { getLogger } from "config/logger";
-import express, { Application } from "express";
+import { Application } from "express";
 import { getSignedCookieHeader } from "test/utils/cookies";
 import { envVars }  from "config/env";
 
@@ -13,12 +12,7 @@ describe("Github Setup", () => {
 	let frontendApp: Application;
 
 	beforeEach(async () => {
-		frontendApp = express();
-		frontendApp.use((request, _, next) => {
-			request.log = getLogger("test");
-			next();
-		});
-		frontendApp.use(getFrontendApp());
+		frontendApp = getFrontendApp();
 	});
 
 	describe("#GET", () => {

--- a/src/routes/jira/atlassian-connect/jira-atlassian-connect-get.test.ts
+++ b/src/routes/jira/atlassian-connect/jira-atlassian-connect-get.test.ts
@@ -1,24 +1,15 @@
 import supertest from "supertest";
-import express, { Express } from "express";
+import { Express } from "express";
 import { getFrontendApp } from "~/src/app";
-import { getLogger } from "config/logger";
 
 describe("Atlassian Connect", () => {
 	let app: Express;
 
 	beforeEach(() => {
-
-		app = express();
-		app.use((request, _, next) => {
-			request.log = getLogger("test");
-			next();
-		});
+		app = getFrontendApp();
 	});
 
 	describe("Frontend", () => {
-		beforeEach(() => {
-			app.use(getFrontendApp());
-		});
 
 		describe("Atlassian Connect", () => {
 

--- a/src/routes/jira/atlassian-connect/jira-atlassian-connect-get.ts
+++ b/src/routes/jira/atlassian-connect/jira-atlassian-connect-get.ts
@@ -126,7 +126,9 @@ const modules = {
 			name: {
 				value: "GitHub Manual App"
 			},
-			url: "/jira/connect/enterprise/{ac.serverUrl}/app/new",
+			// connectConfigUuid might be either an existing app uuid or a key of one stored in Redis (see GheConnectConfigTempStorage)
+			// Let's keep it vague and not differentiate to avoid brain melting
+			url: "/jira/connect/enterprise/{ac.connectConfigUuid}/app/new",
 			location: "none",
 			conditions: adminCondition
 		},

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.test.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.test.ts
@@ -102,12 +102,20 @@ describe("jira-connect-enterprise-app-create-or-edit-get", () => {
 					});
 				expect(response.status).toStrictEqual(404);
 			});
+
+			it("returns 404 when UUID from a different installation", async () => {
+				const anotherOne = await new DatabaseStateCreator().forServer().create();
+				const response = await supertest(app)
+					.get(`/jira/connect/enterprise/${anotherOne.gitHubServerApp!.uuid}/app/new`)
+					.query({
+						jwt: await generateJwt(anotherOne.gitHubServerApp!.uuid)
+					});
+				expect(response.status).toStrictEqual(404);
+			});
 		});
 	});
 
 	describe("edit form", () => {
-
-		// /jira/connect/enterprise/app/{ac.uuid}
 
 		describe("unauthorized", () => {
 			describe("unauthorized", () => {
@@ -171,6 +179,16 @@ describe("jira-connect-enterprise-app-create-or-edit-get", () => {
 					.get(`/jira/connect/enterprise/app/${TEST_UUID}`)
 					.query({
 						jwt: await generateJwt(TEST_UUID)
+					});
+				expect(response.status).toStrictEqual(404);
+			});
+
+			it("returns 404 when UUID from a different installation", async () => {
+				const anotherOne = await new DatabaseStateCreator().forServer().create();
+				const response = await supertest(app)
+					.get(`/jira/connect/enterprise/app/${anotherOne.gitHubServerApp!.uuid}`)
+					.query({
+						jwt: await generateJwt(anotherOne.gitHubServerApp!.uuid)
 					});
 				expect(response.status).toStrictEqual(404);
 			});

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.test.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.test.ts
@@ -1,0 +1,180 @@
+import { getFrontendApp } from "~/src/app";
+import { Express } from "express";
+import { createQueryStringHash, encodeSymmetric } from "atlassian-jwt";
+import { getLogger } from "config/logger";
+import { DatabaseStateCreator } from "test/utils/database-state-creator";
+import { Installation } from "models/installation";
+import supertest from "supertest";
+import { GheConnectConfigTempStorage } from "utils/ghe-connect-config-temp-storage";
+import { GitHubServerApp } from "models/github-server-app";
+
+describe("jira-connect-enterprise-app-create-or-edit-get", () => {
+
+	let app: Express;
+	let installation: Installation;
+	let gheServerApp: GitHubServerApp;
+
+	beforeEach(async () => {
+		app = getFrontendApp();
+
+		const result = await new DatabaseStateCreator().forServer().create();
+		installation = result.installation;
+		gheServerApp = result.gitHubServerApp!;
+	});
+
+	describe("new", () => {
+
+		describe("unauthorized", () => {
+			it("returns 401 when JWT is invalid", async () => {
+				const response = await supertest(app)
+					.get("/jira/connect/enterprise/123/app/new")
+					.query({
+						jwt: "bar"
+					});
+				expect(response.status).toStrictEqual(401);
+			});
+
+			it("returns 401 JWT is missing", async () => {
+				const response = await supertest(app)
+					.get("/jira/connect/enterprise/123/app/new")
+					.query({
+						jiraHost: installation.jiraHost
+					})
+					.set("Cookie", [`jiraHost=${installation.jiraHost}`]);
+				expect(response.status).toStrictEqual(401);
+			});
+		});
+
+		describe("authorized", () => {
+
+			const generateJwt = async (uuid: string, query: any = {}) => {
+				return encodeSymmetric({
+					qsh: createQueryStringHash({
+						method: "GET",
+						pathname: `/jira/connect/enterprise/${uuid}/app/new`,
+						query
+					}, false),
+					iss: installation.plainClientKey
+				}, await installation.decrypt("encryptedSharedSecret", getLogger("test")));
+			};
+
+			it("renders creation form and puts connect config onto page from temp storage", async () => {
+				const uuid = await new GheConnectConfigTempStorage().store({
+					serverUrl: "http://foobar.com"
+				}, installation.id);
+
+				const response = await supertest(app)
+					.get(`/jira/connect/enterprise/${uuid}/app/new`)
+					.query({
+						jwt: await generateJwt(uuid)
+					});
+				expect(response.status).toStrictEqual(200);
+				expect(response.text).toContain(`<input type="hidden" name="uuid" value="${uuid}">`);
+				expect(response.text).toContain(`<input type="hidden" id="gitHubBaseUrl" name="gitHubBaseUrl" value="http://foobar.com">`);
+			});
+
+			it("renders creation form and puts connect config onto page from existing ghe", async () => {
+				const response = await supertest(app)
+					.get(`/jira/connect/enterprise/${gheServerApp.uuid}/app/new`)
+					.query({
+						jwt: await generateJwt(gheServerApp.uuid)
+					});
+				expect(response.status).toStrictEqual(200);
+				expect(response.text).toContain(`<input type="hidden" id="gitHubBaseUrl" name="gitHubBaseUrl" value="${gheServerApp.gitHubBaseUrl}">`);
+			});
+
+			it("does not reuse GHE uuid", async () => {
+				const response = await supertest(app)
+					.get(`/jira/connect/enterprise/${gheServerApp.uuid}/app/new`)
+					.query({
+						jwt: await generateJwt(gheServerApp.uuid)
+					});
+				expect(response.text).not.toContain(`<input type="hidden" name="uuid" value="${gheServerApp.uuid}">`);
+				expect(response.text).toMatch(/<input type="hidden" name="uuid" value="[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}">/);
+			});
+
+			it("returns 404 when unknown UUID", async () => {
+				const TEST_UUID = "c7a17b54-2e37-415b-bba1-7d62fa2d2a7f";
+				const response = await supertest(app)
+					.get(`/jira/connect/enterprise/${TEST_UUID}/app/new`)
+					.query({
+						jwt: await generateJwt(TEST_UUID)
+					});
+				expect(response.status).toStrictEqual(404);
+			});
+		});
+	});
+
+	describe("edit form", () => {
+
+		// /jira/connect/enterprise/app/{ac.uuid}
+
+		describe("unauthorized", () => {
+			describe("unauthorized", () => {
+				it("returns 401 when JWT is invalid", async () => {
+					const response = await supertest(app)
+						.get("/jira/connect/enterprise/app/123")
+						.query({
+							jwt: "bar"
+						});
+					expect(response.status).toStrictEqual(401);
+				});
+
+				it("returns 401 JWT is missing", async () => {
+					const response = await supertest(app)
+						.get("/jira/connect/enterprise/app/123")
+						.query({
+							jiraHost: installation.jiraHost
+						})
+						.set("Cookie", [`jiraHost=${installation.jiraHost}`]);
+					expect(response.status).toStrictEqual(401);
+				});
+			});
+		});
+
+		describe("authorized", () => {
+			const generateJwt = async (uuid: string, query: any = {}) => {
+				return encodeSymmetric({
+					qsh: createQueryStringHash({
+						method: "GET",
+						pathname: `/jira/connect/enterprise/app/${uuid}`,
+						query
+					}, false),
+					iss: installation.plainClientKey
+				}, await installation.decrypt("encryptedSharedSecret", getLogger("test")));
+			};
+
+			it("renders edit form and fills up data from database config", async () => {
+				const response = await supertest(app)
+					.get(`/jira/connect/enterprise/app/${gheServerApp.uuid}`)
+					.query({
+						jwt: await generateJwt(gheServerApp.uuid)
+					});
+				expect(response.status).toStrictEqual(200);
+				expect(response.text).toContain(`value="${gheServerApp.gitHubAppName}"`);
+				expect(response.text).toContain(`value="https://test-github-app-instance.com/github/${gheServerApp.uuid}/callback"`);
+				expect(response.text).toContain(`value="https://test-github-app-instance.com/github/${gheServerApp.uuid}/setup"`);
+				expect(response.text).toContain(`value="https://test-github-app-instance.com/github/${gheServerApp.uuid}/webhooks"`);
+				expect(response.text).toContain(`value="${await gheServerApp.getDecryptedWebhookSecret(installation.jiraHost)}"`);
+				expect(response.text).toContain(`value="${gheServerApp.appId}"`);
+				expect(response.text).toContain(`value="${gheServerApp.gitHubClientId}"`);
+				expect(response.text).toContain(`value="${await gheServerApp.getDecryptedGitHubClientSecret(installation.jiraHost)}"`);
+				expect(response.text).toContain(`<input type="hidden" name="uuid" value="${gheServerApp.uuid}">`);
+				expect(response.text).toContain(`data-app-uuid="${gheServerApp.uuid}"`);
+				expect(response.text).toContain(`data-app-appname="${gheServerApp.gitHubAppName}"`);
+				expect(response.text).toContain(`<input type="hidden" id="gitHubBaseUrl" name="gitHubBaseUrl" value="${gheServerApp.gitHubBaseUrl}">`);
+			});
+
+			it("returns 404 when unknown UUID", async () => {
+				const TEST_UUID = "c7a17b54-2e37-415b-bba1-7d62fa2d2a7f";
+				const response = await supertest(app)
+					.get(`/jira/connect/enterprise/app/${TEST_UUID}`)
+					.query({
+						jwt: await generateJwt(TEST_UUID)
+					});
+				expect(response.status).toStrictEqual(404);
+			});
+		});
+	});
+
+});

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.ts
@@ -20,7 +20,6 @@ export const JiraConnectEnterpriseAppCreateOrEditGet = async (
 		const { jiraHost } = res.locals;
 
 		if (!isNew) {
-			// TODO: add tests!!!
 			const app = await GitHubServerApp.getForUuidAndInstallationId(uuidOfServerAppToEdit, res.locals.installation.id);
 			if (!app) {
 				req.log.warn("Cannot find the app");

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.ts
@@ -4,6 +4,7 @@ import { v4 as newUUID } from "uuid";
 import { envVars } from "config/env";
 import { sendAnalytics } from "utils/analytics-client";
 import { AnalyticsEventTypes, AnalyticsScreenEventsEnum } from "interfaces/common";
+import { resolveIntoConnectConfig } from "utils/ghe-connect-config-temp-storage";
 
 export const JiraConnectEnterpriseAppCreateOrEditGet = async (
 	req: Request,
@@ -13,13 +14,14 @@ export const JiraConnectEnterpriseAppCreateOrEditGet = async (
 	try {
 		req.log.debug("Received Jira create or edit app page request");
 		let config;
-		const uuid = req.params.uuid;
+		const uuidOfServerAppForEdit = req.params.uuid;
+		const isNew = !!uuidOfServerAppForEdit;
 
 		const { jiraHost } = res.locals;
 
-		if (uuid) {
+		if (!isNew) {
 			// TODO: add tests!!!
-			const app = await GitHubServerApp.getForUuidAndInstallationId(uuid, res.locals.installation.id);
+			const app = await GitHubServerApp.getForUuidAndInstallationId(uuidOfServerAppForEdit, res.locals.installation.id);
 			if (!app) {
 				req.log.warn("Cannot find the app");
 				res.status(404).send({
@@ -33,21 +35,35 @@ export const JiraConnectEnterpriseAppCreateOrEditGet = async (
 				decryptedGheSecret: await app.getDecryptedGitHubClientSecret(jiraHost),
 				serverUrl: app.gitHubBaseUrl,
 				appUrl: envVars.APP_URL,
-				uuid,
+				uuid: uuidOfServerAppForEdit,
 				csrfToken: req.csrfToken()
 			};
 		} else {
+
+			const newServerAppConnectConfig = await resolveIntoConnectConfig(req.params.tempConnectConfigUuidOrServerUuid, res.locals.installation.id);
+			if (!newServerAppConnectConfig) {
+				req.log.warn({ connectConfigUuid: req.params.tempConnectConfigUuidOrServerUuid }, "No connect config was found");
+				res.sendStatus(404);
+				return;
+			}
+
+			// We don't want to re-use existing UUID to avoid grief
+			const newUuid = (await GitHubServerApp.findForUuid(req.params.tempConnectConfigUuidOrServerUuid))
+				? newUUID()
+				: req.params.tempConnectConfigUuidOrServerUuid;
+
 			config = {
-				serverUrl: req.params.serverUrl,
+				serverUrl: newServerAppConnectConfig.serverUrl,
+				// TODO: copy other values from the newServerAppConnectConfig
 				appUrl: envVars.APP_URL,
-				uuid: newUUID(),
+				uuid: newUuid,
 				csrfToken: req.csrfToken()
 			};
 		}
 
 		sendAnalytics(AnalyticsEventTypes.ScreenEvent, {
 			name: AnalyticsScreenEventsEnum.CreateOrEditGitHubServerAppScreenEventName,
-			isNew: !!uuid
+			isNew
 		});
 
 		res.render("jira-manual-app-creation.hbs", config);

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.ts
@@ -15,7 +15,7 @@ export const JiraConnectEnterpriseAppCreateOrEditGet = async (
 		req.log.debug("Received Jira create or edit app page request");
 		let config;
 		const uuidOfServerAppForEdit = req.params.uuid;
-		const isNew = !!uuidOfServerAppForEdit;
+		const isNew = !uuidOfServerAppForEdit;
 
 		const { jiraHost } = res.locals;
 

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.ts
@@ -14,14 +14,14 @@ export const JiraConnectEnterpriseAppCreateOrEditGet = async (
 	try {
 		req.log.debug("Received Jira create or edit app page request");
 		let config;
-		const uuidOfServerAppForEdit = req.params.uuid;
-		const isNew = !uuidOfServerAppForEdit;
+		const uuidOfServerAppToEdit = req.params.uuid;
+		const isNew = !uuidOfServerAppToEdit;
 
 		const { jiraHost } = res.locals;
 
 		if (!isNew) {
 			// TODO: add tests!!!
-			const app = await GitHubServerApp.getForUuidAndInstallationId(uuidOfServerAppForEdit, res.locals.installation.id);
+			const app = await GitHubServerApp.getForUuidAndInstallationId(uuidOfServerAppToEdit, res.locals.installation.id);
 			if (!app) {
 				req.log.warn("Cannot find the app");
 				res.status(404).send({
@@ -35,7 +35,7 @@ export const JiraConnectEnterpriseAppCreateOrEditGet = async (
 				decryptedGheSecret: await app.getDecryptedGitHubClientSecret(jiraHost),
 				serverUrl: app.gitHubBaseUrl,
 				appUrl: envVars.APP_URL,
-				uuid: uuidOfServerAppForEdit,
+				uuid: uuidOfServerAppToEdit,
 				csrfToken: req.csrfToken()
 			};
 		} else {

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-apps-get.test.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-apps-get.test.ts
@@ -89,7 +89,6 @@ describe("JiraConnectEnterpriseAppsGet", () => {
 				.query({
 					jwt: await generateJwt(testUuid)
 				});
-			expect(response.text).toContain(`<input type="hidden" id="baseUrl" value="https://ghe.com">`);
 			expect(response.text).toContain(`<input type="hidden" id="connectConfigUuid" value="${testUuid}">`);
 			expect(response.text).toContain(`class="jiraSelectAppCreation__options__card optionsCard automatic selected"`);
 			expect(response.text).toContain(`class="jiraSelectAppCreation__options__card optionsCard manual "`);
@@ -135,7 +134,6 @@ describe("JiraConnectEnterpriseAppsGet", () => {
 					jwt: await generateJwt(gheApp.uuid, { new: "true" }),
 					new: "true"
 				});
-			expect(response.text).toContain(`<input type="hidden" id="baseUrl" value="${gheApp.gitHubBaseUrl}">`);
 			expect(response.text).toContain(`<input type="hidden" id="connectConfigUuid" value="${gheApp.uuid}">`);
 			expect(response.text).toContain(`class="jiraSelectAppCreation__options__card optionsCard automatic selected"`);
 			expect(response.text).toContain(`class="jiraSelectAppCreation__options__card optionsCard manual "`);

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-apps-get.test.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-apps-get.test.ts
@@ -1,28 +1,19 @@
-import express, { Express } from "express";
+import { Express } from "express";
 import { Installation } from "models/installation";
-import path from "path";
-import { registerHandlebarsPartials } from "utils/handlebars/handlebar-partials";
-import { RootRouter } from "routes/router";
 import { getLogger } from "config/logger";
 import { createQueryStringHash, encodeSymmetric } from "atlassian-jwt";
 import supertest from "supertest";
 import { DatabaseStateCreator } from "test/utils/database-state-creator";
 import { GheConnectConfigTempStorage } from "utils/ghe-connect-config-temp-storage";
 import { GitHubServerApp } from "models/github-server-app";
-import { registerHandlebarsHelpers } from "utils/handlebars/handlebar-helpers";
+import { getFrontendApp } from "~/src/app";
 
 describe("JiraConnectEnterpriseAppsGet", () => {
 	let app: Express;
 	let installation: Installation;
 
 	beforeEach(() => {
-		app = express();
-		app.set("view engine", "hbs");
-		const viewPath = path.resolve(process.cwd(), "views");
-		app.set("views", viewPath);
-		registerHandlebarsPartials(path.resolve(viewPath, "partials"));
-		registerHandlebarsHelpers();
-		app.use(RootRouter);
+		app = getFrontendApp();
 	});
 
 	const generateJwt = async (uuid: string, query: any = {}) => {

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-apps-get.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-apps-get.ts
@@ -46,7 +46,6 @@ export const JiraConnectEnterpriseAppsGet = async (
 		} else {
 			sendScreenAnalytics({ isNew, gheServers, name: AnalyticsScreenEventsEnum.SelectGitHubAppsCreationScreenEventName });
 			res.render("jira-select-app-creation.hbs", {
-				baseUrl,
 				connectConfigUuid: tempConnectConfigUuidOrServerUuid
 			});
 		}

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-get.test.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-get.test.ts
@@ -1,14 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { DatabaseStateCreator } from "test/utils/database-state-creator";
-import express, { Express } from "express";
+import { Express } from "express";
 import { getLogger } from "config/logger";
-import { RootRouter } from "routes/router";
 import { createQueryStringHash, encodeSymmetric } from "atlassian-jwt";
 import { Installation } from "models/installation";
 import supertest from "supertest";
-import path from "path";
-import { registerHandlebarsPartials } from "utils/handlebars/handlebar-partials";
 import { GitHubServerApp } from "models/github-server-app";
+import { getFrontendApp } from "~/src/app";
 
 describe("GET /jira/connect/enterprise", () => {
 
@@ -16,12 +14,7 @@ describe("GET /jira/connect/enterprise", () => {
 	let installation: Installation;
 
 	beforeEach(() => {
-		app = express();
-		app.set("view engine", "hbs");
-		const viewPath = path.resolve(process.cwd(), "views");
-		app.set("views", viewPath);
-		registerHandlebarsPartials(path.resolve(viewPath, "partials"));
-		app.use(RootRouter);
+		app = getFrontendApp();
 	});
 
 	const generateJwt = async (query: any = {}) => {

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-router.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-router.ts
@@ -18,7 +18,7 @@ JiraConnectEnterpriseRouter.route("/")
 
 JiraConnectEnterpriseRouter.use("/app", JiraConnectEnterpriseAppRouter);
 
-JiraConnectEnterpriseRouter.get("/:serverUrl/app/new", csrfMiddleware, jiraSymmetricJwtMiddleware, jiraAdminPermissionsMiddleware, JiraConnectEnterpriseAppCreateOrEditGet);
+JiraConnectEnterpriseRouter.get("/:tempConnectConfigUuidOrServerUuid/app/new", csrfMiddleware, jiraSymmetricJwtMiddleware, jiraAdminPermissionsMiddleware, JiraConnectEnterpriseAppCreateOrEditGet);
 
 JiraConnectEnterpriseRouter.get("/:tempConnectConfigUuidOrServerUuid/app", csrfMiddleware, jiraSymmetricJwtMiddleware, jiraAdminPermissionsMiddleware, JiraConnectEnterpriseAppsGet);
 

--- a/src/routes/jira/jira-get.test.ts
+++ b/src/routes/jira/jira-get.test.ts
@@ -6,7 +6,7 @@ import { RepoSyncState } from "models/reposyncstate";
 import singleInstallation from "fixtures/jira-configuration/single-installation.json";
 import failedInstallation from "fixtures/jira-configuration/failed-installation.json";
 import { getLogger } from "config/logger";
-import express, { Application } from "express";
+import express from "express";
 import supertest from "supertest";
 import { encodeSymmetric } from "atlassian-jwt";
 import { getFrontendApp } from "~/src/app";
@@ -15,7 +15,6 @@ jest.mock("config/feature-flags");
 jest.mock("utils/app-properties-utils");
 
 describe("Jira Configuration Suite", () => {
-	let frontendApp: Application;
 	let subscription: Subscription;
 	let installation: Installation;
 
@@ -48,17 +47,10 @@ describe("Jira Configuration Suite", () => {
 			//secrets: "def234",
 			encryptedSharedSecret: "ghi345"
 		});
-
-		frontendApp = express();
-		frontendApp.use((request, _, next) => {
-			request.log = getLogger("test");
-			next();
-		});
-		frontendApp.use(getFrontendApp());
 	});
 
 	const mockRequest = (): any => ({
-		query: { xdm_e: jiraHost },
+		query: { },
 		csrfToken: jest.fn().mockReturnValue({}),
 		log: {
 			info: jest.fn(),
@@ -295,7 +287,6 @@ describe.each([
 		frontendApp = express();
 		frontendApp.use((request, _, next) => {
 			request.query = {
-				xdm_e: jiraHost,
 				jwt: encodeSymmetric({
 					qsh: testQsh,
 					iss: "jira-client-key"

--- a/src/routes/maintenance/maintenance-router.test.ts
+++ b/src/routes/maintenance/maintenance-router.test.ts
@@ -1,10 +1,9 @@
 import supertest from "supertest";
-import express, { Express } from "express";
+import { Express } from "express";
 import { HealthcheckRouter } from "../healthcheck/healthcheck-router";
 import { getFrontendApp } from "../../app";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
 import { when } from "jest-when";
-import { getLogger } from "config/logger";
 
 jest.mock("config/feature-flags");
 
@@ -20,11 +19,7 @@ describe("Maintenance", () => {
 	beforeEach(() => {
 		// Defaults maintenance mode to true
 		whenMaintenanceMode(true);
-		app = express();
-		app.use((request, _, next) => {
-			request.log = getLogger("test");
-			next();
-		});
+		app = getFrontendApp();
 	});
 
 	describe("Healthcheck", () => {
@@ -43,9 +38,6 @@ describe("Maintenance", () => {
 	});
 
 	describe("Frontend", () => {
-		beforeEach(() => {
-			app.use(getFrontendApp());
-		});
 
 		describe("Atlassian Connect", () => {
 			it("should return Atlassian Connect JSON in maintenance mode", () =>

--- a/src/routes/session/session-get.test.ts
+++ b/src/routes/session/session-get.test.ts
@@ -1,24 +1,15 @@
 import supertest from "supertest";
-import express, { Express } from "express";
+import { Express } from "express";
 import { getFrontendApp } from "../../app";
-import { getLogger } from "config/logger";
 
 describe("Session GET", () => {
 	let app: Express;
 
 	beforeEach(() => {
-		app = express();
-		app.use((request, _, next) => {
-			request.log = getLogger("test");
-			next();
-		});
+		app = getFrontendApp();
 	});
 
 	describe("Frontend", () => {
-		beforeEach(() => {
-			app.use(getFrontendApp());
-		});
-
 		it("Testing loading when redirecting to GitHub", () =>
 			supertest(app)
 				.get("/session/jira/atlassian-connect.json?ghRedirect=to&foo=bar&ice=berg")

--- a/static/js/jira-select-card-option.js
+++ b/static/js/jira-select-card-option.js
@@ -60,7 +60,8 @@ $(document).ready(function() {
 				{
 					moduleKey: "github-manual-app-page",
 					customData: {
-						serverUrl: $("#baseUrl").val()
+						connectConfigUuid: $("#connectConfigUuid").val(),
+						serverUrl: $("#connectConfigUuid").val() // TODO: remove when the descriptor changes are propagated everywhere, in 1 month maybe?
 					}
 				}
 			);

--- a/test/snapshots/routes/jira/atlassian-connect/jira-atlassian-connect-get.test.ts.snap
+++ b/test/snapshots/routes/jira/atlassian-connect/jira-atlassian-connect-get.test.ts.snap
@@ -123,7 +123,7 @@ Object {
         "name": Object {
           "value": "GitHub Manual App",
         },
-        "url": "/jira/connect/enterprise/{ac.serverUrl}/app/new",
+        "url": "/jira/connect/enterprise/{ac.connectConfigUuid}/app/new",
       },
       Object {
         "conditions": Array [

--- a/test/snapshots/routes/maintenance/maintenance-router.test.ts.snap
+++ b/test/snapshots/routes/maintenance/maintenance-router.test.ts.snap
@@ -123,7 +123,7 @@ Object {
         "name": Object {
           "value": "GitHub Manual App",
         },
-        "url": "/jira/connect/enterprise/{ac.serverUrl}/app/new",
+        "url": "/jira/connect/enterprise/{ac.connectConfigUuid}/app/new",
       },
       Object {
         "conditions": Array [

--- a/test/utils/database-state-creator.ts
+++ b/test/utils/database-state-creator.ts
@@ -5,6 +5,7 @@ import { GitHubServerApp } from "models/github-server-app";
 import fs from "fs";
 import path from "path";
 import { getHashedKey } from "models/sequelize";
+import { v4 } from "uuid";
 
 interface CreatorResult {
 	installation: Installation;
@@ -93,10 +94,10 @@ export class DatabaseStateCreator {
 		});
 
 		const gitHubServerApp = this.forServerFlag ? await GitHubServerApp.install({
-			uuid: "329f2718-76c0-4ef8-83c6-66d7f1767e0d",
+			uuid: v4(),
 			appId: 12321,
 			gitHubBaseUrl: gheUrl,
-			gitHubClientId: "client-id",
+			gitHubClientId: "client-id" + Math.random(),
 			gitHubClientSecret: "client-secret",
 			webhookSecret: "webhook-secret",
 			privateKey: fs.readFileSync(path.resolve(__dirname, "../../test/setup/test-key.pem"), { encoding: "utf8" }),

--- a/views/jira-select-app-creation.hbs
+++ b/views/jira-select-app-creation.hbs
@@ -76,7 +76,6 @@
             </p>
         </div>
 
-        <input type="hidden" id="baseUrl" value="{{baseUrl}}">
         <input type="hidden" id="connectConfigUuid" value="{{connectConfigUuid}}">
 
         <div class="jiraAppCreation__actionBtn__container">


### PR DESCRIPTION
**What's in this PR?**
Moving manual flow off serverUrl to connect config object.

**Why**
In the future we will need to pass more fields (e.g. API key)

**How has this been tested?**  
manually