### PR TITLE
ARC-1424 and ARC-1425 update api resync post

### DIFF
--- a/src/models/installation.ts
+++ b/src/models/installation.ts
@@ -63,16 +63,6 @@ export class Installation extends EncryptedModel {
 		});
 	}
 
-	static async getForId(id: number): Promise<Installation | null> {
-		if (!id) {
-			return null;
-		}
-
-		return await this.findOne({
-			where: { id }
-		});
-	}
-
 	/**
 	 * Create a new Installation object from a Jira Webhook
 	 *

--- a/src/models/installation.ts
+++ b/src/models/installation.ts
@@ -63,6 +63,16 @@ export class Installation extends EncryptedModel {
 		});
 	}
 
+	static async getForId(id: number): Promise<Installation | null> {
+		if (!id) {
+			return null;
+		}
+
+		return await this.findOne({
+			where: { id }
+		});
+	}
+
 	/**
 	 * Create a new Installation object from a Jira Webhook
 	 *

--- a/src/routes/api/api-resync-post.test.ts
+++ b/src/routes/api/api-resync-post.test.ts
@@ -70,6 +70,22 @@ describe("API Resync POST", () => {
 			});
 	});
 
+	it("should return a 400 when wrong data type is passed as installationIds", async () => {
+		app = createApp();
+
+		await supertest(app)
+			.post(`/api/${gitHubServerApp.uuid}/resync`)
+			.send({
+				statusTypes: ["PENDING", "COMPLETE"],
+				installationIds: installation.id
+			})
+			.set("X-Slauth-Mechanism", "asap")
+			.then((res) => {
+				expect(res.status).toBe(400);
+				expect(res.text).toContain("Installation IDs missing or invalid format");
+			});
+	});
+
 	it("should return 400 if no installations exist for provided IDs", async () => {
 		app = createApp();
 

--- a/src/routes/api/api-resync-post.test.ts
+++ b/src/routes/api/api-resync-post.test.ts
@@ -1,0 +1,121 @@
+import supertest from "supertest";
+import express, { Application, NextFunction, Request, Response } from "express";
+import { Installation } from "models/installation";
+import { Subscription, SyncStatus } from "models/subscription";
+import { GitHubServerApp } from "models/github-server-app";
+import { getLogger } from "config/logger";
+import { v4 as uuid } from "uuid";
+import { ApiRouter } from "routes/api/api-router";
+
+describe("API Resync POST", () => {
+	const gitHubInstallationId = 1234;
+	let installation: Installation;
+	let gitHubServerApp: GitHubServerApp;
+	let app: Application;
+
+	const createApp = () => {
+		const app = express();
+		app.use((req: Request, _: Response, next: NextFunction) => {
+			req.log = getLogger("test");
+			next();
+		});
+		app.use("/api", ApiRouter);
+		return app;
+	};
+
+	beforeEach(async () => {
+		installation = await Installation.create({
+			gitHubInstallationId,
+			jiraHost,
+			encryptedSharedSecret: "secret",
+			clientKey: "client-key"
+		});
+
+		await Subscription.create({
+			gitHubInstallationId,
+			jiraHost,
+			jiraClientKey: "client-key",
+			syncStatus: SyncStatus.PENDING
+		});
+
+		gitHubServerApp = await GitHubServerApp.install({
+			uuid: uuid(),
+			appId: 123,
+			installationId: installation.id,
+			gitHubAppName: "test-github-server-app",
+			gitHubBaseUrl: gheUrl,
+			gitHubClientId: "client-id",
+			gitHubClientSecret: "client-secret",
+			privateKey: "private-key",
+			webhookSecret: "webhook-secret"
+		}, jiraHost);
+
+		await Subscription.create({
+			gitHubInstallationId,
+			jiraHost,
+			jiraClientKey: "client-key",
+			gitHubAppId: gitHubServerApp.id
+		});
+	});
+
+	it("should return 400 if no parameters are provided", async () => {
+		app = createApp();
+
+		await supertest(app)
+			.post(`/api/${gitHubServerApp.uuid}/resync`)
+			.set("X-Slauth-Mechanism", "asap")
+			.then((res) => {
+				expect(res.status).toBe(400);
+				expect(res.text).toContain("Please provide at least one of the filter parameters!");
+			});
+	});
+
+	it("should return 400 if no installations exist for provided IDs", async () => {
+		app = createApp();
+
+		await supertest(app)
+			.post(`/api/${gitHubServerApp.uuid}/resync`)
+			.send({
+				statusTypes: ["PENDING", "COMPLETE"],
+				installationIds: [installation.id + 1, installation.id + 2]
+			})
+			.set("X-Slauth-Mechanism", "asap")
+			.then((res) => {
+				expect(res.status).toBe(400);
+				expect(res.text).toContain("No installations exist for provided IDs");
+			});
+	});
+
+	it("should return 400 if commitsFromDate are present and are ahead of current date", async () => {
+		app = createApp();
+		const timeOneSecondFromNow = () => new Date(Date.now() + 1000);
+
+		await supertest(app)
+			.post(`/api/${gitHubServerApp.uuid}/resync`)
+			.send({
+				statusTypes: ["PENDING", "COMPLETE"],
+				installationIds: [installation.id],
+				commitsFromDate: timeOneSecondFromNow()
+			})
+			.set("X-Slauth-Mechanism", "asap")
+			.then((res) => {
+				expect(res.status).toBe(400);
+				expect(res.text).toContain("Invalid date value, cannot select a future date!");
+			});
+	});
+
+	it("should return 200 if all checks are met", async () => {
+		app = createApp();
+
+		await supertest(app)
+			.post(`/api/${gitHubServerApp.uuid}/resync`)
+			.send({
+				statusTypes: ["PENDING", "COMPLETE"],
+				installationIds: [installation.id]
+			})
+			.set("X-Slauth-Mechanism", "asap")
+			.then((res) => {
+				expect(res.statusCode).toBe(200);
+			});
+	});
+});

--- a/src/routes/api/api-resync-post.ts
+++ b/src/routes/api/api-resync-post.ts
@@ -44,6 +44,11 @@ export const ApiResyncPost = async (req: Request, res: Response): Promise<void> 
 		return;
 	}
 
+	if (!installationIds.length) {
+		res.status(400).send("Installation IDs missing or invalid format");
+		return;
+	}
+
 	const existingInstallationIds = await getIdsForExistingInstallations(installationIds, req.log);
 
 	if (!existingInstallationIds.length) {

--- a/src/routes/api/api-router.ts
+++ b/src/routes/api/api-router.ts
@@ -77,7 +77,6 @@ ApiRouter.get("/", (_: Request, res: Response): void => {
 
 ApiRouter.use("/configuration", ApiConfigurationRouter);
 
-
 ApiRouter.post(
 	`/:uuid(${UUID_REGEX})?/resync`,
 	body("commitsFromDate").optional().isISO8601(),


### PR DESCRIPTION
**What's in this PR?**
Added additional checks to send 400 if no installations are found for passed IDs or wrong data type is passed (the latter now fails on an error but still good to be more explicit).

**Why**
To address 2 tickets that has been open in the disturbed/ops backlog for almost a year (2nd one didn't require much additional effort so it piggy backed off the first).

**Affected issues**  
ARC-1424 and ARC-1425

**How has this been tested?**  
Wrote tests for these additions (plus wrote tests for the existing code because there was none!) and tested in stg

**Whats Next?**
Grab another ticket from the backlog
