### PR TITLE
lookup subscription by repo owner

### DIFF
--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -166,6 +166,21 @@ export class Subscription extends Model {
 		return results[0] as Subscription;
 	}
 
+	static async findForRepoOwner(repoOwner: string, jiraHost: string): Promise<Subscription | null> {
+		const results = await this.sequelize!.query(
+			"SELECT * " +
+			"FROM \"Subscriptions\" s " +
+			"LEFT JOIN \"RepoSyncStates\" rss on s.\"id\" = rss.\"subscriptionId\" " +
+			"WHERE s.\"jiraHost\" = :jiraHost " +
+			"AND rss.\"repoOwner\" = :repoOwner",
+			{
+				replacements: { jiraHost, repoOwner },
+				type: QueryTypes.SELECT
+			}
+		);
+		return results[0] as Subscription;
+	}
+
 	// TODO: Change name to 'create' to follow sequelize standards
 	static async install(payload: SubscriptionInstallPayload): Promise<Subscription> {
 		const [subscription] = await this.findOrCreate({

--- a/src/routes/github/create-branch/github-branches-get.test.ts
+++ b/src/routes/github/create-branch/github-branches-get.test.ts
@@ -43,7 +43,7 @@ describe("GitHub Branches Get", () => {
 
 	it("Should fetch branches", async () => {
 		setupNock();
-		mocked(Subscription.findForRepoNameAndOwner).mockResolvedValue({ gitHubInstallationId, id: 1 } as Subscription);
+		mocked(Subscription.findForRepoOwner).mockResolvedValue({ gitHubInstallationId, id: 1 } as Subscription);
 		await GithubBranchesGet(req, res);
 		expect(res.send).toBeCalledWith(response);
 	});
@@ -137,7 +137,7 @@ describe("Getting GitHub Branches securely avoiding XSS attacks", () => {
 	});
 	it("Should fetch branches securely", async () => {
 		setupNockForXSSBranches(gitHubInstallationId);
-		mocked(Subscription.findForRepoNameAndOwner).mockResolvedValue({ gitHubInstallationId, id: 1 } as Subscription);
+		mocked(Subscription.findForRepoOwner).mockResolvedValue({ gitHubInstallationId, id: 1 } as Subscription);
 		await GithubBranchesGet(req, res);
 		expect(res.send).toBeCalledWith(responseForXSSBranches);
 	});

--- a/src/routes/github/create-branch/github-branches-get.ts
+++ b/src/routes/github/create-branch/github-branches-get.ts
@@ -24,7 +24,7 @@ export const GithubBranchesGet = async (req: Request, res: Response): Promise<vo
 	}
 
 	try {
-		const subscription = await Subscription.findForRepoNameAndOwner(repo, owner, jiraHost);
+		const subscription = await Subscription.findForRepoOwner(owner, jiraHost);
 		if (!subscription) {
 			logger.error(Errors.MISSING_SUBSCRIPTION);
 			throw Error(Errors.MISSING_SUBSCRIPTION);


### PR DESCRIPTION
**What's in this PR?**
The reposyncstate isn't always complete so trying to get the sub id from it using repo name and owner can be problamatic, therefore, instead we look up with just the owner since the combination will be unique.

