### PR TITLE
HOT-103341 - process app created branches

### DIFF
--- a/src/middleware/github-webhook-middleware.ts
+++ b/src/middleware/github-webhook-middleware.ts
@@ -52,8 +52,8 @@ const isFromIgnoredRepo = (payload) =>
 	// Repository: https://admin.github.com/stafftools/repositories/seequent/lf_github_testing
 	payload.installation?.id === 491520 && payload.repository?.id === 205972230;
 
-const isStateChangeOrDeploymentAction = (action) =>
-	["opened", "closed", "reopened", "deployment", "deployment_status"].includes(
+const isStateChangeBranchCreateOrDeploymentAction = (action) =>
+	["opened", "closed", "reopened", "deployment", "deployment_status", "create"].includes(
 		action
 	);
 
@@ -131,8 +131,8 @@ export const GithubWebhookMiddleware = (
 		// State change actions are allowed because they're one-time actions, therefore they won’t cause a loop.
 		if (
 			context.payload?.sender?.type === "Bot" &&
-			!isStateChangeOrDeploymentAction(context.payload.action) &&
-			!isStateChangeOrDeploymentAction(context.name)
+			!isStateChangeBranchCreateOrDeploymentAction(context.payload.action) &&
+			!isStateChangeBranchCreateOrDeploymentAction(context.name)
 		) {
 			context.log.info(
 				{


### PR DESCRIPTION
**What's in this PR?**
allow app created branchs to be processed by webhook handler

**Why**
App created branches were being treated as a bot doing things, so we skipped it :(

