### PR TITLE
NONE - update missing jiraHost warnings for consistency

### DIFF
--- a/src/routes/github/github-oauth-router.ts
+++ b/src/routes/github/github-oauth-router.ts
@@ -237,7 +237,7 @@ const TempGetJiraHostFromStateMiddleware  = async (req: Request, res: Response, 
 	}
 	const jiraHost = url.searchParams.get("jiraHost");
 	if (!jiraHost) {
-		req.log.warn("jiraHost is missing in state redirect uri");
+		req.log.warn(Errors.MISSING_JIRA_HOST);
 		res.status(400).send(Errors.MISSING_JIRA_HOST);
 		return;
 	}

--- a/src/routes/github/repository/github-repository-get.ts
+++ b/src/routes/github/repository/github-repository-get.ts
@@ -16,7 +16,7 @@ export const GitHubRepositoryGet = async (req: Request, res: Response): Promise<
 	const log = req.log.child({ jiraHost });
 
 	if (!jiraHost) {
-		log.error(Errors.MISSING_JIRA_HOST);
+		log.warn(Errors.MISSING_JIRA_HOST);
 		sendError(res, 400, Errors.MISSING_JIRA_HOST);
 		return;
 	}

--- a/src/routes/github/repository/github-repository-get.ts
+++ b/src/routes/github/repository/github-repository-get.ts
@@ -4,6 +4,7 @@ import { createAppClient, createInstallationClient } from "utils/get-github-clie
 import { RepositoryNode } from "~/src/github/client/github-queries";
 import { Subscription } from "~/src/models/subscription";
 import { sendError } from "~/src/jira/util/jwt";
+import { Errors } from "config/errors";
 const MAX_REPOS_RETURNED = 20;
 
 export const GitHubRepositoryGet = async (req: Request, res: Response): Promise<void> => {
@@ -15,8 +16,8 @@ export const GitHubRepositoryGet = async (req: Request, res: Response): Promise<
 	const log = req.log.child({ jiraHost });
 
 	if (!jiraHost) {
-		log.error("Unauthorised - No JiraHost found");
-		sendError(res, 401, "Unauthorised");
+		log.error(Errors.MISSING_JIRA_HOST);
+		sendError(res, 400, Errors.MISSING_JIRA_HOST);
 		return;
 	}
 

--- a/src/routes/jira/jira-delete.ts
+++ b/src/routes/jira/jira-delete.ts
@@ -4,6 +4,7 @@ import { Request, Response } from "express";
 import { sendAnalytics } from "utils/analytics-client";
 import { AnalyticsEventTypes, AnalyticsTrackEventsEnum, AnalyticsTrackSource } from "interfaces/common";
 import { getCloudOrServerFromGitHubAppId } from "utils/get-cloud-or-server";
+import { Errors } from "config/errors";
 
 /**
  * Handle the when a user deletes an entry in the UI
@@ -18,8 +19,8 @@ export const JiraDelete = async (req: Request, res: Response): Promise<void> => 
 	req.log.info({ gitHubInstallationId, gitHubAppId }, "Received Jira DELETE subscription request");
 
 	if (!jiraHost) {
-		req.log.error("Missing Jira Host");
-		res.status(401).send("Missing jiraHost");
+		req.log.warn(Errors.MISSING_JIRA_HOST);
+		res.status(400).send(Errors.MISSING_JIRA_HOST);
 		return;
 	}
 

--- a/src/routes/jira/jira-get.ts
+++ b/src/routes/jira/jira-get.ts
@@ -12,6 +12,7 @@ import { sendAnalytics } from "utils/analytics-client";
 import { AnalyticsEventTypes, AnalyticsScreenEventsEnum } from "interfaces/common";
 import { getCloudOrServerFromGitHubAppId } from "utils/get-cloud-or-server";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
+import { Errors } from "config/errors";
 
 interface FailedConnection {
 	id: number;
@@ -218,8 +219,8 @@ export const JiraGet = async (
 	try {
 		const { jiraHost } = res.locals;
 		if (!jiraHost) {
-			req.log.warn({ jiraHost, req, res }, "Missing jiraHost");
-			res.status(404).send(`Missing Jira Host '${jiraHost}'`);
+			req.log.warn({ jiraHost, req, res }, Errors.MISSING_JIRA_HOST);
+			res.status(400).send(Errors.MISSING_JIRA_HOST);
 			return;
 		}
 


### PR DESCRIPTION
**What's in this PR?**
Updated missing jiraHost warnings to use the Errors enum

**Why**
To clean up the errors/warnings that were doing their own thing / for consistency.

**Whats Next?**
Probs do the same with the other Errors messages.