### PR TITLE
ARC-2144 try to compare to future deployments only

### DIFF
--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -24,19 +24,30 @@ const getLastSuccessfulDeployCommitSha = async (
 	owner: string,
 	repoName: string,
 	githubInstallationClient: GitHubInstallationClient,
+	currentDeployDate: string,
 	deployments: Octokit.ReposListDeploymentsResponseItem[],
 	logger?: Logger
-): Promise<string> => {
+): Promise<string | undefined> => {
 
 	try {
-		for (const deployment of deployments) {
+
+		const currentDate = new Date(currentDeployDate);
+
+		let filteredDeployments = deployments;
+		if (currentDate) {
+			filteredDeployments = deployments.filter((deployment) => !deployment.updated_at || new Date(deployment.updated_at).getTime() < currentDate.getTime());
+			if (filteredDeployments.length === 0) {
+				return undefined;
+			}
+		}
+
+		for (const deployment of filteredDeployments) {
 			// Get each deployment status for this environment so we can have their statuses' ids
 			const listDeploymentStatusResponse: AxiosResponse<Octokit.ReposListDeploymentStatusesResponse> =
 				await githubInstallationClient.listDeploymentStatuses(owner, repoName, deployment.id, 100);
 			// Find the first successful one
 			const lastSuccessful = listDeploymentStatusResponse.data.find(deployment => deployment.state === "success");
 			if (lastSuccessful) {
-
 				return deployment.sha;
 			}
 		}
@@ -54,6 +65,7 @@ const getCommitsSinceLastSuccessfulDeployment = async (
 	currentDeploySha: string,
 	currentDeployId: number,
 	currentDeployEnv: string,
+	currentDeployDate: string,
 	githubInstallationClient: GitHubInstallationClient,
 	logger: Logger
 ): Promise<CommitSummary[] | undefined> => {
@@ -71,7 +83,11 @@ const getCommitsSinceLastSuccessfulDeployment = async (
 		return undefined;
 	}
 
-	const lastSuccessfullyDeployedCommit = await getLastSuccessfulDeployCommitSha(owner, repoName, githubInstallationClient, filteredDeployments, logger);
+	const lastSuccessfullyDeployedCommit = await getLastSuccessfulDeployCommitSha(owner, repoName, githubInstallationClient, currentDeployDate, filteredDeployments, logger);
+	if (!lastSuccessfullyDeployedCommit) {
+		logger?.info(`Skipped comparing commit base for deployment_status event as there's no past deployments`);
+		return undefined;
+	}
 
 	const compareCommitsPayload = {
 		owner: owner,
@@ -240,6 +256,7 @@ export const transformDeployment = async (githubInstallationClient: GitHubInstal
 		deployment.sha,
 		deployment.id,
 		deployment_status.environment,
+		deployment_status.updated_at,
 		githubInstallationClient,
 		logger
 	);

--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -85,7 +85,7 @@ const getCommitsSinceLastSuccessfulDeployment = async (
 
 	const lastSuccessfullyDeployedCommit = await getLastSuccessfulDeployCommitSha(owner, repoName, githubInstallationClient, currentDeployDate, filteredDeployments, logger);
 	if (!lastSuccessfullyDeployedCommit) {
-		logger?.info(`Skipped comparing commit base for deployment_status event as there's no past deployments`);
+		logger.info(`Skipped comparing commit base for deployment_status event as there's no past deployments`);
 		return undefined;
 	}
 


### PR DESCRIPTION
**What's in this PR?**
Add a check to only compare with past deployments when processing webhook and backfill (well, in backfill, this will most likely ends up as compared to nothing).

**Why**
1. This will "slightly" enhance the logic, to make it more accurate.
2. Also might "slightly" increase the efficiency by skipping comparing to base commit, especially in backfill.

**Added feature flags**

**Affected issues**  
ARC-2144

**How has this been tested?**  
Unit test

**Whats Next?**
1. Try filter by deployment branch as well.
3. Try ignore the commit compare if they are from different branches. 
4. See weather we can find some api to fetch "last deployments" from past date, instead of from current date. I haven't found any api successfully yet.
