### PR TITLE
Skip resetting fail code is target task is empty

### DIFF
--- a/src/sync/sync-utils.test.ts
+++ b/src/sync/sync-utils.test.ts
@@ -1,6 +1,7 @@
 import { findOrStartSync } from "./sync-utils";
 import { sqsQueues } from "../sqs/queues";
 import { Subscription } from "models/subscription";
+import { RepoSyncState } from "models/reposyncstate";
 import { GitHubServerApp } from "models/github-server-app";
 import { getLogger } from "config/logger";
 import { v4 as uuid } from "uuid";
@@ -21,6 +22,38 @@ describe("sync utils", () => {
 		const JIRA_CLIENT_KEY = "jira-client-key";
 		const CUTOFF_IN_MSECS = 1000;
 		const CUTOFF_IN_MSECS__DISABLED = -1;
+		describe("resetting fail code", () => {
+			let subscription: Subscription;
+			let repo1: RepoSyncState;
+			let repo2: RepoSyncState;
+			beforeEach(async () => {
+				subscription = await Subscription.install({
+					installationId: JIRA_INSTALLATION_ID,
+					host: jiraHost,
+					hashedClientKey: JIRA_CLIENT_KEY,
+					gitHubAppId: undefined
+				});
+				const repoBasicInfo = (repoId: number): Partial<RepoSyncState> => ({
+					repoId, repoName: `name-${repoId}`, repoFullName: `fullname-${repoId}`, repoOwner: `owner`, repoUrl: "blah"
+				});
+				repo1 = await RepoSyncState.createForSubscription(subscription, { ...repoBasicInfo(1), failedCode: "FAIL_1" });
+				repo2 = await RepoSyncState.createForSubscription(subscription, { ...repoBasicInfo(2), failedCode: "FAIL_2" });
+			});
+			it("should reset failedCode when target task provided", async () => {
+				await findOrStartSync(subscription, getLogger("test"), undefined, undefined, ["commit", "branch"]);
+				await repo1.reload();
+				await repo2.reload();
+				expect(repo1.failedCode).toBe(null);
+				expect(repo2.failedCode).toBe(null);
+			});
+			it("should NOT reset failedCode when target task NOT provided", async () => {
+				await findOrStartSync(subscription, getLogger("test"), undefined, undefined, undefined);
+				await repo1.reload();
+				await repo2.reload();
+				expect(repo1.failedCode).toBe("FAIL_1");
+				expect(repo2.failedCode).toBe("FAIL_2");
+			});
+		});
 		describe("commit since date", () => {
 			let subscription: Subscription;
 			beforeEach(async () => {

--- a/src/sync/sync-utils.ts
+++ b/src/sync/sync-utils.ts
@@ -40,7 +40,7 @@ export const findOrStartSync = async (
 	}
 
 	// reset failedCode for Partial or targetted syncs
-	await resetFailedCode(subscription, syncType, targetTasks);
+	await resetFailedCode(subscription, targetTasks);
 
 	const gitHubAppConfig = await getGitHubAppConfig(subscription, logger);
 
@@ -110,9 +110,8 @@ const resetTargetedTasks = async (subscription: Subscription, syncType?: SyncTyp
 
 };
 
-const resetFailedCode = async (subscription: Subscription, syncType?: SyncType, targetTasks?: TaskType[]) => {
-	// a full sync without target tasks has reposyncstates removed so dont update.
-	if (syncType === "full" && !targetTasks?.length) {
+const resetFailedCode = async (subscription: Subscription, targetTasks?: TaskType[]) => {
+	if (!targetTasks?.length) {
 		return;
 	}
 	await RepoSyncState.update({ failedCode: null }, {


### PR DESCRIPTION
**What's in this PR?**
Skip resetting the failed code if target task is emtpy.

**Why**
We are about to turn on ff for create repo (and kick off partial sync) on repo_created webhooks.
However existing logic reset the failCode for all existing repos. We should skip that.

**Added feature flags**

**Affected issues**  
ARC-968

**How has this been tested?**  
Unit test.

**Whats Next?**
