### PR TITLE
NONE: behave more similarly to production on ghe connect page

### DIFF
--- a/src/config/logger.test.ts
+++ b/src/config/logger.test.ts
@@ -485,7 +485,7 @@ describe("logger behaviour", () => {
 
 			const client = await createAnonymousClient(gheUrl, jiraHost, { trigger: "test" }, getLogger("test"));
 
-			const response = await client.getMainPage(1000);
+			const response = await client.getPage(1000);
 
 			logger.error({
 				err: new GithubClientGraphQLError(
@@ -561,7 +561,7 @@ describe("logger behaviour", () => {
 
 			const client = await createAnonymousClient(gheUrl, jiraHost, { trigger: "test" }, logger);
 
-			await client.getMainPage(1000).catch(noop);
+			await client.getPage(1000).catch(noop);
 
 			const record = JSON.parse(ringBuffer.records[ringBuffer.records.length - 1]);
 

--- a/src/github/client/github-anonymous-client.ts
+++ b/src/github/client/github-anonymous-client.ts
@@ -20,8 +20,8 @@ export class GitHubAnonymousClient extends GitHubClient {
 		super(githubConfig, jiraHost, metrics, logger);
 	}
 
-	public getMainPage(timeoutMs: number): Promise<AxiosResponse> {
-		return this.axios.get(this.baseUrl, { timeout: timeoutMs });
+	public getPage(timeoutMs: number, path = "", extraHeaders: { [name: string]: string } = {}): Promise<AxiosResponse> {
+		return this.axios.get(this.baseUrl + path, { timeout: timeoutMs, headers: extraHeaders });
 	}
 
 	public async createGitHubApp(code: string): Promise<CreatedGitHubAppResponse> {

--- a/src/github/client/github-client-interceptors.test.ts
+++ b/src/github/client/github-client-interceptors.test.ts
@@ -12,7 +12,7 @@ describe("github-client-interceptors", () => {
 		let error: Error;
 		const client = await createAnonymousClient(gheUrl, jiraHost, { trigger: "test" }, getLogger("test"));
 		try {
-			await client.getMainPage(1000);
+			await client.getPage(1000);
 		} catch (err) {
 			error = err;
 		}
@@ -28,7 +28,7 @@ describe("github-client-interceptors", () => {
 		let error: Error;
 		const client = await createAnonymousClient(gheUrl, jiraHost, { trigger: "test" }, getLogger("test"));
 		try {
-			await client.getMainPage(1000);
+			await client.getPage(1000);
 		} catch (err) {
 			error = err;
 		}

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.test.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.test.ts
@@ -101,7 +101,7 @@ describe("POST /jira/connect/enterprise", () => {
 
 	it("POST Jira Connect Enterprise - valid new URL to GHE", async () => {
 		const response = mockResponse();
-		gheNock.get("/").reply(200, { }, { "X-GitHub-Request-id": "blah" });
+		gheNock.get("/api/v3/rate_limit").reply(200, { }, { "X-GitHub-Request-id": "blah" });
 		await JiraConnectEnterprisePost(mockRequest(gheUrl), response);
 		expect(response.status).toHaveBeenCalledWith(200);
 		expect(response.send).toHaveBeenCalledWith({ success: true, connectConfigUuid: expect.any(String), appExists: false });
@@ -112,7 +112,7 @@ describe("POST /jira/connect/enterprise", () => {
 
 	it("POST Jira Connect Enterprise - valid new URL to not GHE", async () => {
 		const response = mockResponse();
-		gheNock.get("/").reply(200, { });
+		gheNock.get("/api/v3/rate_limit").reply(200, { });
 		await JiraConnectEnterprisePost(mockRequest(gheUrl), response);
 		expect(response.status).toHaveBeenCalledWith(200);
 		expect(response.send).toHaveBeenCalledWith({
@@ -126,7 +126,7 @@ describe("POST /jira/connect/enterprise", () => {
 	it("POST Jira Connect Enterprise - URL timed out", async () => {
 		process.env.JIRA_CONNECT_ENTERPRISE_POST_TIMEOUT_MSEC = "100";
 		const response = mockResponse();
-		gheNock.get("/").delayConnection(2000).reply(200);
+		gheNock.get("/api/v3/rate_limit").delayConnection(2000).reply(200);
 		await JiraConnectEnterprisePost(mockRequest(gheUrl), response);
 		expect(response.status).toHaveBeenCalledWith(200);
 		expect(response.send).toHaveBeenCalledWith({
@@ -139,7 +139,7 @@ describe("POST /jira/connect/enterprise", () => {
 
 	it("POST Jira Connect Enterprise - DNS resolution failure", async () => {
 		const response = mockResponse();
-		gheNock.get("/").replyWithError({ code: "ENOTFOUND" });
+		gheNock.get("/api/v3/rate_limit").replyWithError({ code: "ENOTFOUND" });
 		await JiraConnectEnterprisePost(mockRequest(gheUrl), response);
 		expect(response.status).toHaveBeenCalledWith(200);
 		expect(response.send).toHaveBeenCalledWith({
@@ -153,7 +153,7 @@ describe("POST /jira/connect/enterprise", () => {
 	it("POST Jira Connect Enterprise - invalid status code without GHE headers", async () => {
 
 		const response = mockResponse();
-		gheNock.get("/").reply(500);
+		gheNock.get("/api/v3/rate_limit").reply(500);
 		await JiraConnectEnterprisePost(mockRequest(gheUrl), response);
 		expect(response.status).toHaveBeenCalledWith(200);
 		expect(response.send).toHaveBeenCalledWith({
@@ -169,7 +169,11 @@ describe("POST /jira/connect/enterprise", () => {
 	it("POST Jira Connect Enterprise - invalid status code with GHE headers", async () => {
 
 		const response = mockResponse();
-		gheNock.get("/").reply(401, { }, { "X-GitHub-Request-id": "blah" });
+
+		gheNock.get("/api/v3/rate_limit").matchHeader("authorization", (value) => {
+			return !!value && value.startsWith("Bearer");
+		}).reply(401, { }, { "X-GitHub-Request-id": "blah" });
+
 		await JiraConnectEnterprisePost(mockRequest(gheUrl), response);
 		expect(response.status).toHaveBeenCalledWith(200);
 		expect(response.send).toHaveBeenCalledWith({ success: true, connectConfigUuid: expect.any(String), appExists: false });
@@ -178,7 +182,7 @@ describe("POST /jira/connect/enterprise", () => {
 	it("POST Jira Connect Enterprise - invalid status code with GHE server headers", async () => {
 
 		const response = mockResponse();
-		gheNock.get("/").reply(401, { }, { "server": "GitHub.com" });
+		gheNock.get("/api/v3/rate_limit").reply(401, { }, { "server": "GitHub.com" });
 		await JiraConnectEnterprisePost(mockRequest(gheUrl), response);
 		expect(response.status).toHaveBeenCalledWith(200);
 		expect(response.send).toHaveBeenCalledWith({ success: true, connectConfigUuid: expect.any(String), appExists: false });

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.ts
@@ -107,7 +107,12 @@ export const JiraConnectEnterprisePost = async (
 
 	try {
 		const client = await createAnonymousClient(gheServerURL, jiraHost, { trigger: "jira-connect-enterprise-post" }, req.log);
-		const response = await client.getMainPage(TIMEOUT_PERIOD_MS);
+
+		// We want to simulate a production-like call, that's why call real endpoint with
+		// some fake Auth header
+		const response = await client.getPage(TIMEOUT_PERIOD_MS, "/api/v3/rate_limit", {
+			authorization: "Bearer ghs_fake0fake1fake2w1xVgkCPL2vk8L52AeEkv"
+		});
 
 		if (!isResponseFromGhe(req.log, response)) {
 			req.log.warn("Received OK response, but not GHE server");

--- a/src/sqs/backfill-error-handler.test.ts
+++ b/src/sqs/backfill-error-handler.test.ts
@@ -64,7 +64,7 @@ describe("backfillErrorHandler", () => {
 
 		const client = await createAnonymousClient(gheUrl, jiraHost, { trigger: "test" }, getLogger("test"));
 		try {
-			await client.getMainPage(1000);
+			await client.getPage(1000);
 		} catch (err) {
 			return err;
 		}
@@ -77,7 +77,7 @@ describe("backfillErrorHandler", () => {
 
 		const client = await createAnonymousClient(gheUrl, jiraHost, { trigger: "test" }, getLogger("test"));
 		try {
-			await client.getMainPage(1000);
+			await client.getPage(1000);
 		} catch (err) {
 			return err;
 		}

--- a/src/util/get-github-client-config.test.ts
+++ b/src/util/get-github-client-config.test.ts
@@ -115,7 +115,7 @@ describe("anonymous client", () => {
 			.matchHeader("ApiKeyHeader", "super-key")
 			.reply(200);
 		const client = await createAnonymousClient(gheUrl, jiraHost, { trigger: "test" }, getLogger("test"));
-		const response = await client.getMainPage(1000);
+		const response = await client.getPage(1000);
 		expect(response).toBeDefined();
 	});
 })


### PR DESCRIPTION
**What's in this PR?**
Call a real API endpoint on GHE URL check page with some fake Auth header

**Why**
Our customers might configure their API gateway to filter out requests that doesn't look like real ones. And we don't care which status will be returned as we look at GitHub headers mostly.

