### PR TITLE
Arc 2112 catch 405 on other jira api 2

### DIFF
--- a/src/jira/client/jira-client.test.ts
+++ b/src/jira/client/jira-client.test.ts
@@ -143,33 +143,38 @@ describe("Test getting a jira client", () => {
 	});
 
 	it("Should return success response for the bulk API redirects", async () => {
-		jiraNock.get("/status").reply(200);
 		jiraNock.get("/rest/devinfo/0.10/bulk").reply(405);
 		jiraNock.post("/rest/devinfo/0.10/bulk").reply(302, undefined, {
 			"Location": jiraHost + "/rest/devinfo/0.10/bulk"
 		});
 
-		const response = await client.devinfo.repository.update({
-			commits: [
-				{
-					author: {
-						email: "blarg@email.com",
-						name: "foo"
-					},
-					authorTimestamp: "Tue Oct 19 2021 11:52:08 GMT+1100",
-					displayId: "oajfojwe",
-					fileCount: 3,
-					hash: "hashihashhash",
-					id: "id",
-					issueKeys: Array.from(new Array(125)).map((_, i) => `TEST-${i}`),
-					message: "commit message",
-					url: "some-url",
-					updateSequenceId: 1234567890
-				}
-			]
-		});
+		let error;
+		try {
+			await client.devinfo.repository.update({
+				commits: [
+					{
+						author: {
+							email: "blarg@email.com",
+							name: "foo"
+						},
+						authorTimestamp: "Tue Oct 19 2021 11:52:08 GMT+1100",
+						displayId: "oajfojwe",
+						fileCount: 3,
+						hash: "hashihashhash",
+						id: "id",
+						issueKeys: Array.from(new Array(125)).map((_, i) => `TEST-${i}`),
+						message: "commit message",
+						url: "some-url",
+						updateSequenceId: 1234567890
+					}
+				]
+			});
+		} catch (e) {
+			error = e;
+		}
 
-		expect(response).toMatchObject([{ result: "SKIP_REDIRECTED" }]);
+		expect(error instanceof Axios.JiraClientError).toBe(true);
+		expect(error.status).toBe(404);
 	});
 
 	describe("Reading encryptedSharedSecret", () => {

--- a/src/sqs/backfill-error-handler.test.ts
+++ b/src/sqs/backfill-error-handler.test.ts
@@ -263,4 +263,20 @@ describe("backfillErrorHandler", () => {
 		expect(sendMessageMock.mock.calls[0][1]).toEqual(0);
 		expect((await RepoSyncState.findByPk(repoSyncState!.id))?.commitStatus).toEqual("complete");
 	});
+
+	it("jira not found error marks the task as done and continues", async () => {
+		const result = await backfillErrorHandler(sendMessageMock)(
+			new TaskError(task, new JiraClientError("not found", { } as unknown as AxiosError, 404)),
+			createContext(3, false)
+		);
+
+		expect(result).toEqual({
+			isFailure: false
+		});
+		expect(sendMessageMock.mock.calls[0][0]).toEqual(
+			{ installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost }
+		);
+		expect(sendMessageMock.mock.calls[0][1]).toEqual(0);
+		expect((await RepoSyncState.findByPk(repoSyncState!.id))?.commitStatus).toEqual("complete");
+	});
 });


### PR DESCRIPTION
**What's in this PR?**
1. Try/catch 405 for other similar jira api as well.
2. Merge into the previous logic to convert it into 404 instead of silently mark it as success
3. Modify the backfill to accept 404 as a success

**Why**
That try/catch 405 works well on the devinfo, would like to apply it to other jira api.

**Added feature flags**
N/A

**Affected issues**  
N/A

**How has this been tested?**  
Unit test.

**Whats Next?**
