### PR TITLE
ARC-2156: store API key on manifest complete and use it for calls

### DIFF
--- a/src/models/github-server-app.ts
+++ b/src/models/github-server-app.ts
@@ -19,6 +19,8 @@ interface GitHubServerAppPayload {
 	privateKey: string;
 	gitHubAppName: string;
 	installationId: number;
+	apiKeyHeaderName?: string | null;
+	encryptedApiKeyValue?: string | null; // must be encrypted with GitHubServerApp.encrypt()
 }
 
 interface GitHubServerAppUpdatePayload {
@@ -31,9 +33,12 @@ interface GitHubServerAppUpdatePayload {
 	privateKey?: string;
 	gitHubAppName?: string;
 	installationId?: number;
+	apiKeyHeaderName?: string | null;
+	encryptedApiKeyValue?: string | null; // must be encrypted with GitHubServerApp.encrypt()
 }
 
-type SECRETE_FIELD = "gitHubClientSecret" | "webhookSecret" | "privateKey";
+// TODO: rename all other columns to prefix with "encrypted"
+type SECRETE_FIELD = "gitHubClientSecret" | "webhookSecret" | "privateKey" | "encryptedApiKeyValue";
 
 export class GitHubServerApp extends Model {
 	id: number;
@@ -41,11 +46,11 @@ export class GitHubServerApp extends Model {
 	appId: number;
 	gitHubBaseUrl: string;
 	gitHubClientId: string;
-	gitHubClientSecret: string;
-	webhookSecret: string;
-	privateKey: string;
+	gitHubClientSecret: string; // TODO: rename column to prefix with "encrypted"
+	webhookSecret: string; // TODO: rename column to prefix with "encrypted"
+	privateKey: string; // TODO: rename column to prefix with "encrypted"
 	gitHubAppName: string;
-	installationId: number;
+	installationId: number; // TODO: rename to "installationIdPk" to distinguish from gitHubInstallationId
 	apiKeyHeaderName: string | null;
 	encryptedApiKeyValue: string | null;
 	updatedAt: Date;
@@ -63,12 +68,24 @@ export class GitHubServerApp extends Model {
 		return this.decrypt(jiraHost, "webhookSecret");
 	}
 
+	getDecryptedApiKeyValue(jiraHost: string): Promise<string>  {
+		if (!this.encryptedApiKeyValue) {
+			return Promise.resolve("");
+		}
+		return this.decrypt(jiraHost, "encryptedApiKeyValue");
+	}
+
 	private async decrypt(jiraHost: string, field: SECRETE_FIELD): Promise<string> {
+		const encryptedField = this[field];
+		if (!encryptedField) {
+			log.error({ field }, "Cannot decrypt empty/null");
+			throw new Error("Cannot decrypt empty/null " + field);
+		}
 		try {
-			return await EncryptionClient.decrypt(this[field], GitHubServerApp.getEncryptContext(jiraHost));
+			return await GitHubServerApp.decrypt(jiraHost, encryptedField);
 		} catch (e1) {
 			try {
-				const plainText = await EncryptionClient.decrypt(this[field], {});
+				const plainText = await EncryptionClient.decrypt(encryptedField, {});
 				log.warn(`Fail to decrypt ${field} with jiraHost as encryptionContext, but empty encryptionContext success`);
 				return plainText;
 			} catch (e2) {
@@ -76,11 +93,14 @@ export class GitHubServerApp extends Model {
 				throw e2;
 			}
 		}
-
 	}
 
-	private static async encrypt(jiraHost: string, plainText: string) {
+	public static async encrypt(jiraHost: string, plainText: string) {
 		return await EncryptionClient.encrypt(EncryptionSecretKeyEnum.GITHUB_SERVER_APP, plainText, GitHubServerApp.getEncryptContext(jiraHost));
+	}
+
+	public static async decrypt(jiraHost: string, encryptedText: string) {
+		return await EncryptionClient.decrypt(encryptedText, GitHubServerApp.getEncryptContext(jiraHost));
 	}
 
 	private static getEncryptContext(jiraHost: string) {
@@ -149,7 +169,9 @@ export class GitHubServerApp extends Model {
 			gitHubClientSecret,
 			webhookSecret,
 			privateKey,
-			installationId
+			installationId,
+			apiKeyHeaderName,
+			encryptedApiKeyValue
 		} = payload;
 
 		const [gitHubServerApp] = await this.findOrCreate({
@@ -165,7 +187,9 @@ export class GitHubServerApp extends Model {
 				webhookSecret: await GitHubServerApp.encrypt(jiraHost, webhookSecret),
 				privateKey: await GitHubServerApp.encrypt(jiraHost, privateKey),
 				gitHubAppName,
-				installationId
+				installationId,
+				apiKeyHeaderName,
+				encryptedApiKeyValue
 			}
 		});
 
@@ -194,7 +218,9 @@ export class GitHubServerApp extends Model {
 			gitHubClientSecret,
 			webhookSecret,
 			privateKey,
-			installationId
+			installationId,
+			apiKeyHeaderName,
+			encryptedApiKeyValue
 		} = payload;
 
 		const existApp = await this.findForUuid(uuid);
@@ -207,7 +233,9 @@ export class GitHubServerApp extends Model {
 				webhookSecret: webhookSecret ? await GitHubServerApp.encrypt(jiraHost, webhookSecret) : undefined,
 				privateKey: privateKey ? await GitHubServerApp.encrypt(jiraHost, privateKey) : undefined,
 				gitHubAppName,
-				installationId
+				installationId,
+				apiKeyHeaderName: apiKeyHeaderName || null,
+				encryptedApiKeyValue: encryptedApiKeyValue || null
 			});
 		}
 
@@ -270,6 +298,14 @@ GitHubServerApp.init({
 	installationId: {
 		type: DataTypes.INTEGER,
 		allowNull: false
+	},
+	apiKeyHeaderName: {
+		type: DataTypes.STRING,
+		allowNull: true
+	},
+	encryptedApiKeyValue: {
+		type: DataTypes.TEXT,
+		allowNull: true
 	}
 }, {
 	sequelize

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-post.test.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-post.test.ts
@@ -108,6 +108,9 @@ describe("jira-connect-enterprise-app-post", () => {
 				gitHubClientSecret: "encrypted:" + TEST_GHE_APP_PARTIAL.gitHubClientSecret,
 				webhookSecret: "encrypted:" + TEST_GHE_APP_PARTIAL.webhookSecret,
 
+				apiKeyHeaderName: null,
+				encryptedApiKeyValue: null,
+
 				createdAt: expect.any(Date),
 				updatedAt: expect.any(Date)
 			});


### PR DESCRIPTION
**What's in this PR?**
 - On manifest complete store API key and value to Db
 - Use the values in backend calls

**Why**
- Part of BTF work

**Added feature flags**
Existing one.

**Affected issues**  
ARC-2156

**How has this been tested?**  
Unit tests, staging
<img width="300" alt="image" src="https://user-images.githubusercontent.com/20631664/236957425-c4475e8e-4a95-4b13-a809-ba13bef9e931.png">
-the first one was created as a new one; the second one was created for the same server (values were copied over)

**Whats Next?**
Manual flow.
