### PR TITLE
NONE: add develop to deployment dev mapping

### DIFF
--- a/src/transforms/transform-deployment.test.ts
+++ b/src/transforms/transform-deployment.test.ts
@@ -95,6 +95,7 @@ describe("deployment environment mapping", () => {
 		expect(mapEnvironment("development")).toBe("development");
 		expect(mapEnvironment("dev")).toBe("development");
 		expect(mapEnvironment("trunk")).toBe("development");
+		expect(mapEnvironment("develop")).toBe("development");
 
 		// Testing
 		expect(mapEnvironment("testing")).toBe("testing");

--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -175,7 +175,7 @@ export const mapEnvironment = (environment: string, config?: Config): string => 
 	// we fall back to hardcoded mapping
 
 	const environmentMapping = {
-		development: ["development", "dev", "trunk"],
+		development: ["development", "dev", "trunk", "develop"],
 		testing: ["testing", "test", "tests", "tst", "integration", "integ", "intg", "int", "acceptance", "accept", "acpt", "qa", "qc", "control", "quality", "uat", "sit"],
 		staging: ["staging", "stage", "stg", "preprod", "model", "internal"],
 		production: ["production", "prod", "prd", "live"]


### PR DESCRIPTION
**What's in this PR?**
Added 'develop' to our development deployment mapping.

**Why**
To try and help resolve the [mapping issue](https://customerfeedback.atlassian.net/browse/JSF-8662) until we can find the root cause

**How has this been tested?**  
Locally

**Whats Next?**
Keep looking into the issue and chat with Solaris