### PR TITLE
NONE: give support access to api/hash endpoint

### DIFF
--- a/etc/poco/README.md
+++ b/etc/poco/README.md
@@ -37,18 +37,20 @@ Refer to [Testing](https://developer.atlassian.com/platform/poco/policies/workfl
 Poco bundles can be manually published to dev and staging environments using atlas-cli. Note that this will apply
 to the deployment stack already in service without needing to redeploy.
 
+### Publish into dev
 ```shell
-# Publish into dev
 atlas poco bundle publish -s github-for-jira -e dev \
   -b etc/poco/bundle/main.json \
   -t etc/poco/bundle/main-test.json 
+```
 
-# Publish into staging
+### Publish into staging
+```shell
 atlas poco bundle publish -s github-for-jira -e staging \
-  -b etc/poco/bundle/main.json \
-  -b etc/poco/bundle/extras-stg.json \
-  -t etc/poco/bundle/main-test.json \
-  -t etc/poco/bundle/extras-stg-test.json
+-b etc/poco/bundle/main.json \
+-b etc/poco/bundle/extras-stg.json \
+-t etc/poco/bundle/main-test.json \
+-t etc/poco/bundle/extras-stg-test.json
 ```
 
 # Deployment to production

--- a/etc/poco/bundle/main-test.json
+++ b/etc/poco/bundle/main-test.json
@@ -87,6 +87,14 @@
 			"mechanism": "asap",
 			"principals": ["micros/manager-service"],
 			"allowed": true
+		},
+		{
+			"name": "Allow support team to call API endpoints",
+			"path": "/api/hars",
+			"method": "GET",
+			"mechanism": "open",
+			"principals": [],
+			"allowed": true
 		}
 	]
 }

--- a/etc/poco/bundle/main-test.json
+++ b/etc/poco/bundle/main-test.json
@@ -90,11 +90,19 @@
 		},
 		{
 			"name": "Allow support team to call API endpoints",
-			"path": "/api/hars",
+			"path": "/api/hash",
 			"method": "GET",
 			"mechanism": "open",
-			"principals": [],
+			"principals": ["enterprise-cloud-support-all"],
 			"allowed": true
+		},
+		{
+			"name": "Allow support team to call API endpoints",
+			"path": "/api/hash",
+			"method": "GET",
+			"mechanism": "open",
+			"principals": ["random-access"],
+			"allowed": false
 		}
 	]
 }

--- a/etc/poco/bundle/main-test.json
+++ b/etc/poco/bundle/main-test.json
@@ -91,17 +91,17 @@
 		{
 			"name": "Allow support team to call API endpoints",
 			"path": "/api/hash",
-			"method": "GET",
-			"mechanism": "open",
+			"method": "POST",
+			"mechanism": "group",
 			"principals": ["enterprise-cloud-support-all"],
 			"allowed": true
 		},
 		{
 			"name": "Allow support team to call API endpoints",
 			"path": "/api/hash",
-			"method": "GET",
-			"mechanism": "open",
-			"principals": ["random-access"],
+			"method": "POST",
+			"mechanism": "group",
+			"principals": ["random-group"],
 			"allowed": false
 		}
 	]

--- a/etc/poco/bundle/main.json
+++ b/etc/poco/bundle/main.json
@@ -64,7 +64,7 @@
 				"/api/hash"
 			],
 			"methods": [
-				"GET"
+				"POST"
 			],
 			"principals": {
 				"staff": {

--- a/etc/poco/bundle/main.json
+++ b/etc/poco/bundle/main.json
@@ -59,7 +59,7 @@
       }
     },
 		{
-			"description": "Allow service team to call hash endpoint",
+			"description": "Allow support team to call hash endpoint",
 			"paths": [
 				"/api/hash"
 			],

--- a/etc/poco/bundle/main.json
+++ b/etc/poco/bundle/main.json
@@ -59,6 +59,22 @@
       }
     },
 		{
+			"description": "Allow service team to call hash endpoint",
+			"paths": [
+				"/api/hash"
+			],
+			"methods": [
+				"GET"
+			],
+			"principals": {
+				"staff": {
+					"groups": [
+						"enterprise-cloud-support-all"
+					]
+				}
+			}
+		},
+		{
 			"description": "Microscope Panel Routes",
 			"paths": [
 				"/microscope/**"


### PR DESCRIPTION
**What's in this PR?**
Update to our poco config

**Why**
So support can access our hash endpoint

**Whats Next?**
Grant access to splunk logs for support