### PR TITLE
ARC-2157: add fields to manual page config

### DIFF
--- a/src/models/github-server-app.ts
+++ b/src/models/github-server-app.ts
@@ -188,8 +188,8 @@ export class GitHubServerApp extends Model {
 				privateKey: await GitHubServerApp.encrypt(jiraHost, privateKey),
 				gitHubAppName,
 				installationId,
-				apiKeyHeaderName,
-				encryptedApiKeyValue
+				apiKeyHeaderName: apiKeyHeaderName || null,
+				encryptedApiKeyValue: encryptedApiKeyValue || null
 			}
 		});
 

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.frontend.test.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.frontend.test.ts
@@ -1,0 +1,229 @@
+import { Installation } from "models/installation";
+import { Express } from "express";
+import { Server } from "http";
+import { Browser, chromium, Page } from "playwright";
+import { getFrontendApp } from "~/src/app";
+import { createQueryStringHash, encodeSymmetric } from "atlassian-jwt";
+import { getLogger } from "config/logger";
+import { DatabaseStateCreator } from "test/utils/database-state-creator";
+import { GitHubServerApp } from "models/github-server-app";
+import { when } from "jest-when";
+import { booleanFlag, BooleanFlags } from "config/feature-flags";
+import path from "path";
+
+jest.setTimeout(20000);
+
+jest.mock("config/feature-flags");
+
+declare global {
+	interface Window {
+		AP: {
+			context: {
+				getToken: (callack: (string) => void) => void
+			},
+			navigator: {
+				go: (arg1: any, arg2: any) => void
+			}
+		}
+	}
+}
+
+describe("jira-connect-enterprise-get.frontend(jira-server-url.hbs + jira-server-url.js)", () => {
+	let installation: Installation;
+	let gitHubServerApp: GitHubServerApp;
+
+	let app: Express;
+	const port = 3000;
+	let server: Server;
+	let browser: Browser;
+	let page: Page;
+
+	beforeAll(async () => {
+		app = getFrontendApp();
+		server = app.listen(port);
+
+		const options = {
+			headless: false, slowMo: 100  // uncomment for debugging
+		};
+		browser = await chromium.launch(options);
+		page = await browser.newPage();
+	});
+
+	afterAll(async () => {
+		await browser.close();
+
+		server.close();
+	});
+
+	beforeEach(async () => {
+		const result = await (new DatabaseStateCreator()).forServer().create();
+		installation = result.installation;
+		gitHubServerApp = result.gitHubServerApp!;
+	});
+
+	const generateJwt = async (query: any = {}) => {
+		return encodeSymmetric({
+			qsh: createQueryStringHash({
+				method: "GET",
+				pathname: `/jira/connect/enterprise/${gitHubServerApp.uuid}/app/new`,
+				query
+			}, false),
+			iss: installation.plainClientKey
+		}, await installation.decrypt("encryptedSharedSecret", getLogger("test")));
+	};
+
+	const submitForm = async () =>
+		page.click("#Next");
+
+	const getInputError = async (eltId: string) => {
+		return await page.$eval(`#${eltId}`, (el) => {
+			const nextElement = el.nextElementSibling;
+			return nextElement ? nextElement.innerHTML : null;
+		});
+	};
+
+	const getAppNameInputError = () => getInputError("gitHubAppNameInput");
+
+	const getApiKeyHeaderNameInputError = () => getInputError("apiKeyHeaderName");
+
+	const getApiKeyValueInputError = () => getInputError("apiKeyValue");
+
+	const focusAndEnterInputValue = async (eltId: string, value: string) => {
+		await page.focus(`#${eltId}`);
+		await page.fill(`#${eltId}`, value);
+		await page.keyboard.up("Enter");
+	};
+
+	const enterApiKeyHeaderName = (name) => focusAndEnterInputValue("apiKeyHeaderName", name);
+
+	const enterAppName = (name) => focusAndEnterInputValue("gitHubAppNameInput", name);
+
+	const enterAppId = (id) => focusAndEnterInputValue("appId", id);
+
+	const enterWebhookSecret = (secret) => focusAndEnterInputValue("webhookSecret", secret);
+
+	const enterClientId = (clientId) => focusAndEnterInputValue("gitHubClientId", clientId);
+
+	const enterClientSecret = (clientSecret) => focusAndEnterInputValue("gitHubClientSecret", clientSecret);
+
+	const enterApiKeyValue = (value) => focusAndEnterInputValue("apiKeyValue", value);
+
+	const uploadPrivateKey = async (filePath) => {
+		const fileInput = (await page.$("#privateKeyFile"))!;
+		await fileInput.setInputFiles(filePath);
+	};
+
+	it.each([true, false])("when FF %s validates github app name", async (flagValue) => {
+		when(booleanFlag).calledWith(
+			BooleanFlags.ENABLE_API_KEY_FEATURE,
+			jiraHost
+		).mockResolvedValue(flagValue);
+
+		await page.goto(`http://localhost:3000/jira/connect/enterprise/${gitHubServerApp.uuid}/app/new?jwt=${await generateJwt()}`);
+		expect(await getAppNameInputError()).toBeNull();
+
+		await submitForm();
+
+		expect(await getAppNameInputError()).toStrictEqual(`<ul><li><span class="aui-icon aui-icon-small aui-iconfont-error aui-icon-notification">This is a required field</span>This is a required field</li></ul>`);
+	});
+
+	const mockAp = async () => {
+		await page.evaluate(
+			(jwt) => {
+				window.AP = window.AP || {};
+				window.AP.context = window.AP.context || {};
+				window.AP.context.getToken = (callback) => {
+					callback(jwt);
+				};
+				window.AP.navigator = window.AP.navigator || {};
+				window.AP.navigator.go = (arg1, arg2) => {
+					window["redirectData"] = {
+						arg1, arg2
+					};
+				};
+			},
+			encodeSymmetric({
+				qsh: "context-qsh",
+				iss: installation.plainClientKey
+			}, await installation.decrypt("encryptedSharedSecret", getLogger("test")))
+		);
+	};
+
+	describe("with FF ON", () => {
+		beforeEach(async () => {
+			when(booleanFlag).calledWith(
+				BooleanFlags.ENABLE_API_KEY_FEATURE,
+				jiraHost
+			).mockResolvedValue(true);
+
+			await page.goto(`http://localhost:3000/jira/connect/enterprise/${gitHubServerApp.uuid}/app/new?jwt=${await generateJwt()}`);
+
+			await mockAp();
+		});
+
+		it("known HTTP headers cannot be used as an API key header", async () => {
+			expect(await getApiKeyHeaderNameInputError()).toBeNull();
+			await enterApiKeyHeaderName("authorization");
+
+			await submitForm();
+
+			expect(await getApiKeyHeaderNameInputError()).toStrictEqual("<ul><li><span class=\"aui-icon aui-icon-small aui-iconfont-error aui-icon-notification\">authorization is a reserved string and cannot be used.</span>authorization is a reserved string and cannot be used.</li></ul>");
+		});
+
+		it("API key value cannot be used without API key header", async () => {
+			expect(await getApiKeyValueInputError()).toBeNull();
+			await enterApiKeyHeaderName("x-foo");
+
+			await submitForm();
+
+			expect(await getApiKeyValueInputError()).toStrictEqual("<ul><li><span class=\"aui-icon aui-icon-small aui-iconfont-error aui-icon-notification\">Cannot be empty.</span>Cannot be empty.</li></ul>");
+		});
+
+		it("submits data and creates the page", async () => {
+			await enterAppName("foo");
+			await enterWebhookSecret("myWebhookSecret");
+			await enterAppId("12321");
+			await enterClientId("myclientid");
+			await enterClientSecret("myclientsecret");
+			await enterApiKeyHeaderName("x-foo");
+			await enterApiKeyValue("myapikey");
+			await uploadPrivateKey(path.resolve(__dirname, "../../../../../../test/setup/test-key.pem"));
+
+			await submitForm();
+
+			const childWindow = (await new Promise(resolve => page.once("popup", resolve)))!;
+			const childWindowUrl = (childWindow as any).url();
+
+			const apps = await GitHubServerApp.findAll({ where: { installationId: installation.id } });
+			const newApp = apps.filter(app => app.uuid !== gitHubServerApp.uuid)[0];
+
+			expect(childWindowUrl).toStrictEqual(`http://localhost:3000/session/github/${newApp.uuid}/configuration?ghRedirect=to`);
+			expect(newApp.apiKeyHeaderName).toStrictEqual("x-foo");
+			expect(newApp.encryptedApiKeyValue).toStrictEqual("encrypted:myapikey");
+		});
+	});
+
+	// TODO: delete when FF is removed
+	describe("with FF OFF", () => {
+		it("submits data", async () => {
+			await enterAppName("foo");
+			await enterWebhookSecret("myWebhookSecret");
+			await enterAppId("12321");
+			await enterClientId("myclientid");
+			await enterClientSecret("myclientsecret");
+			await uploadPrivateKey(path.resolve(__dirname, "../../../../../../test/setup/test-key.pem"));
+
+			await submitForm();
+
+			const childWindow = (await new Promise(resolve => page.once("popup", resolve)))!;
+			const childWindowUrl = (childWindow as any).url();
+
+			const apps = await GitHubServerApp.findAll({ where: { installationId: installation.id } });
+			const newApp = apps.filter(app => app.uuid !== gitHubServerApp.uuid)[0];
+
+			expect(childWindowUrl).toStrictEqual(`http://localhost:3000/session/github/${newApp.uuid}/configuration?ghRedirect=to`);
+		});
+	});
+
+
+});

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.frontend.test.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.frontend.test.ts
@@ -43,7 +43,7 @@ describe("jira-connect-enterprise-get.frontend(jira-server-url.hbs + jira-server
 		server = app.listen(port);
 
 		const options = {
-			headless: false, slowMo: 100  // uncomment for debugging
+			// headless: false, slowMo: 100  // uncomment for debugging
 		};
 		browser = await chromium.launch(options);
 		page = await browser.newPage();

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.test.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.test.ts
@@ -7,6 +7,10 @@ import { Installation } from "models/installation";
 import supertest from "supertest";
 import { GheConnectConfigTempStorage } from "utils/ghe-connect-config-temp-storage";
 import { GitHubServerApp } from "models/github-server-app";
+import { when } from "jest-when";
+import { booleanFlag, BooleanFlags } from "config/feature-flags";
+
+jest.mock("config/feature-flags");
 
 describe("jira-connect-enterprise-app-create-or-edit-get", () => {
 
@@ -73,7 +77,73 @@ describe("jira-connect-enterprise-app-create-or-edit-get", () => {
 				expect(response.text).toContain(`<input type="hidden" id="gitHubBaseUrl" name="gitHubBaseUrl" value="http://foobar.com">`);
 			});
 
-			it("renders creation form and puts connect config onto page from existing ghe", async () => {
+			it("when FF ON, renders form and puts API key config onto page from temp storage", async () => {
+				when(booleanFlag).calledWith(
+					BooleanFlags.ENABLE_API_KEY_FEATURE,
+					jiraHost
+				).mockResolvedValue(true);
+
+				const uuid = await new GheConnectConfigTempStorage().store({
+					serverUrl: "http://foobar.com",
+					apiKeyHeaderName: "myApiKeyName",
+					encryptedApiKeyValue: "encrypted:myApiKeyValue"
+				}, installation.id);
+
+				const response = await supertest(app)
+					.get(`/jira/connect/enterprise/${uuid}/app/new`)
+					.query({
+						jwt: await generateJwt(uuid)
+					});
+				expect(response.status).toStrictEqual(200);
+				expect(response.text).toContain(`name="apiKeyHeaderName" value="myApiKeyName"`);
+				expect(response.text).toContain(`name="apiKeyValue" value="myApiKeyValue"`);
+			});
+
+			it("when FF ON, renders form and puts API key empty config onto page when temp storage doesn't contain it", async () => {
+				when(booleanFlag).calledWith(
+					BooleanFlags.ENABLE_API_KEY_FEATURE,
+					jiraHost
+				).mockResolvedValue(true);
+
+				const uuid = await new GheConnectConfigTempStorage().store({
+					serverUrl: "http://foobar.com",
+					apiKeyHeaderName: null,
+					encryptedApiKeyValue: null
+				}, installation.id);
+
+				const response = await supertest(app)
+					.get(`/jira/connect/enterprise/${uuid}/app/new`)
+					.query({
+						jwt: await generateJwt(uuid)
+					});
+				expect(response.status).toStrictEqual(200);
+				expect(response.text).toContain(`name="apiKeyHeaderName" value=""`);
+				expect(response.text).toContain(`name="apiKeyValue" value=""`);
+			});
+
+			it("when FF OFF, renders form and doesn't put API key inputs", async () => {
+				when(booleanFlag).calledWith(
+					BooleanFlags.ENABLE_API_KEY_FEATURE,
+					jiraHost
+				).mockResolvedValue(false);
+
+				const uuid = await new GheConnectConfigTempStorage().store({
+					serverUrl: "http://foobar.com",
+					apiKeyHeaderName: "foo",
+					encryptedApiKeyValue: null
+				}, installation.id);
+
+				const response = await supertest(app)
+					.get(`/jira/connect/enterprise/${uuid}/app/new`)
+					.query({
+						jwt: await generateJwt(uuid)
+					});
+				expect(response.status).toStrictEqual(200);
+				expect(response.text).not.toContain(`name="apiKeyHeaderName"`);
+				expect(response.text).not.toContain(`name="apiKeyValue"`);
+			});
+
+			it("renders creation form and puts GHE URL from connect config onto page from existing ghe", async () => {
 				const response = await supertest(app)
 					.get(`/jira/connect/enterprise/${gheServerApp.uuid}/app/new`)
 					.query({
@@ -81,6 +151,42 @@ describe("jira-connect-enterprise-app-create-or-edit-get", () => {
 					});
 				expect(response.status).toStrictEqual(200);
 				expect(response.text).toContain(`<input type="hidden" id="gitHubBaseUrl" name="gitHubBaseUrl" value="${gheServerApp.gitHubBaseUrl}">`);
+			});
+
+			it("renders empty API KEY config on page from existing ghe", async () => {
+				when(booleanFlag).calledWith(
+					BooleanFlags.ENABLE_API_KEY_FEATURE,
+					jiraHost
+				).mockResolvedValue(true);
+
+				const response = await supertest(app)
+					.get(`/jira/connect/enterprise/${gheServerApp.uuid}/app/new`)
+					.query({
+						jwt: await generateJwt(gheServerApp.uuid)
+					});
+				expect(response.status).toStrictEqual(200);
+				expect(response.text).toContain(`name="apiKeyHeaderName" value=""`);
+				expect(response.text).toContain(`name="apiKeyValue" value=""`);
+			});
+
+			it("renders non-empty API KEY config on page from existing ghe", async () => {
+				when(booleanFlag).calledWith(
+					BooleanFlags.ENABLE_API_KEY_FEATURE,
+					jiraHost
+				).mockResolvedValue(true);
+
+				gheServerApp.apiKeyHeaderName = "myApiKeyName";
+				gheServerApp.encryptedApiKeyValue = "encrypted:myApiKeyValue";
+				await gheServerApp.save();
+
+				const response = await supertest(app)
+					.get(`/jira/connect/enterprise/${gheServerApp.uuid}/app/new`)
+					.query({
+						jwt: await generateJwt(gheServerApp.uuid)
+					});
+				expect(response.status).toStrictEqual(200);
+				expect(response.text).toContain(`name="apiKeyHeaderName" value="myApiKeyName"`);
+				expect(response.text).toContain(`name="apiKeyValue" value="myApiKeyValue"`);
 			});
 
 			it("does not reuse GHE uuid", async () => {

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.ts
@@ -6,6 +6,7 @@ import { sendAnalytics } from "utils/analytics-client";
 import { AnalyticsEventTypes, AnalyticsScreenEventsEnum } from "interfaces/common";
 import { resolveIntoConnectConfig } from "utils/ghe-connect-config-temp-storage";
 import { getAllKnownHeaders } from "utils/http-headers";
+import { booleanFlag, BooleanFlags } from "config/feature-flags";
 
 export const JiraConnectEnterpriseAppCreateOrEditGet = async (
 	req: Request,
@@ -36,7 +37,7 @@ export const JiraConnectEnterpriseAppCreateOrEditGet = async (
 				apiKeyHeaderName: app.apiKeyHeaderName,
 				apiKeyValue: app.encryptedApiKeyValue
 					? await app.getDecryptedApiKeyValue(jiraHost)
-					: '',
+					: "",
 				serverUrl: app.gitHubBaseUrl,
 				appUrl: envVars.APP_URL,
 				uuid: uuidOfServerAppToEdit,
@@ -61,7 +62,7 @@ export const JiraConnectEnterpriseAppCreateOrEditGet = async (
 				apiKeyHeaderName: newServerAppConnectConfig.apiKeyHeaderName,
 				apiKeyValue: newServerAppConnectConfig.encryptedApiKeyValue
 					? await GitHubServerApp.decrypt(res.locals.installation.jiraHost, newServerAppConnectConfig.encryptedApiKeyValue)
-					: '',
+					: "",
 				appUrl: envVars.APP_URL,
 				uuid: newUuid,
 				csrfToken: req.csrfToken()
@@ -75,7 +76,8 @@ export const JiraConnectEnterpriseAppCreateOrEditGet = async (
 
 		res.render("jira-manual-app-creation.hbs", {
 			... config,
-			knownHttpHeadersLowerCase: getAllKnownHeaders()
+			knownHttpHeadersLowerCase: getAllKnownHeaders(),
+			withApiKeyFeature: await booleanFlag(BooleanFlags.ENABLE_API_KEY_FEATURE, res.locals.installation.jiraHost)
 		});
 		req.log.debug("Jira create or edit app page rendered successfully.");
 	} catch (error) {

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-post.test.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-post.test.ts
@@ -79,6 +79,24 @@ describe("jira-connect-enterprise-app-post", () => {
 			expect(response.status).toStrictEqual(400);
 		});
 
+		it.each(["set-cookie: blah", "foo:", ":foo"])("validates API key fields %s", async (apiKeyNameValue) => {
+			const uuid = v4();
+
+			const response = await supertest(app)
+				.post("/jira/connect/enterprise/app")
+				.send({
+					... TEST_GHE_APP_PARTIAL,
+					uuid,
+					apiKeyHeaderName: apiKeyNameValue.split(":")[0].trim(),
+					apiKeyValue: apiKeyNameValue.split(":")[1].trim()
+				})
+				.query({
+					jwt: await generateJwt()
+				});
+
+			expect(response.status).toStrictEqual(400);
+		});
+
 		it("successfully creates an item without API key", async () => {
 			const uuid = v4();
 

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-post.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-post.ts
@@ -22,7 +22,9 @@ export const JiraConnectEnterpriseAppPost = async (
 			gitHubClientId,
 			gitHubClientSecret,
 			webhookSecret,
-			privateKey
+			privateKey,
+			apiKeyHeaderName,
+			apiKeyValue
 		} = req.body;
 
 		const existing = await GitHubServerApp.findForUuid(uuid);
@@ -41,7 +43,9 @@ export const JiraConnectEnterpriseAppPost = async (
 			gitHubClientSecret,
 			webhookSecret,
 			privateKey,
-			installationId: installation.id
+			installationId: installation.id,
+			apiKeyHeaderName,
+			encryptedApiKeyValue: apiKeyValue ? await GitHubServerApp.encrypt(installation.jiraHost, apiKeyValue) : null
 		}, jiraHost);
 
 		await new GheConnectConfigTempStorage().delete(uuid, installation.id);

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-put.test.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-put.test.ts
@@ -120,6 +120,8 @@ describe("PUT /jira/connect/enterprise/app/:uuid", () => {
 			webhookSecret: "newSecret",
 			gitHubClientId: "Iv1.msdnf2893rwhdbf",
 			gitHubClientSecret: "secret",
+			apiKeyHeaderName: "myNewApiKey",
+			apiKeyValue: "myApiKey",
 			uuid,
 			jiraHost
 		};
@@ -135,9 +137,45 @@ describe("PUT /jira/connect/enterprise/app/:uuid", () => {
 		const restoredApp = (await GitHubServerApp.findForUuid(uuid))!;
 
 		expect(restoredApp.gitHubAppName).toEqual("newName");
+		expect(restoredApp.apiKeyHeaderName).toEqual("myNewApiKey");
 		expect(await restoredApp.getDecryptedWebhookSecret(jiraHost)).toEqual("newSecret");
 		expect(await restoredApp.getDecryptedPrivateKey(jiraHost)).toEqual("privatekey");
 		expect(await restoredApp.getDecryptedGitHubClientSecret(jiraHost)).toEqual("secret");
+		expect(await restoredApp.getDecryptedApiKeyValue(jiraHost)).toEqual("myApiKey");
+	});
+
+	it("should drop API key values when not provided", async () => {
+		await GitHubServerApp.install({
+			uuid,
+			appId: 1,
+			gitHubAppName: "my awesome app",
+			gitHubBaseUrl: "http://myinternalinstance.com",
+			gitHubClientId: "lvl.1n23j12389wndd",
+			gitHubClientSecret: "secret",
+			webhookSecret: "anothersecret",
+			privateKey: "privatekey",
+			installationId: installation.id,
+			apiKeyHeaderName: "myApiKey",
+			encryptedApiKeyValue: "encrypted:myApiKeyValue"
+		}, jiraHost);
+
+		const payload ={
+			uuid,
+			jiraHost
+		};
+
+		await supertest(app)
+			.put(`/jira/connect/enterprise/app/${uuid}`)
+			.query({
+				jwt
+			})
+			.send(payload)
+			.expect(202);
+
+		const restoredApp = (await GitHubServerApp.findForUuid(uuid))!;
+
+		expect(restoredApp.apiKeyHeaderName).toBeNull();
+		expect(restoredApp.encryptedApiKeyValue).toBeNull();
 	});
 
 	it("should return 404 when wrong uuid param is passed", async () => {

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-put.test.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-put.test.ts
@@ -144,6 +144,39 @@ describe("PUT /jira/connect/enterprise/app/:uuid", () => {
 		expect(await restoredApp.getDecryptedApiKeyValue(jiraHost)).toEqual("myApiKey");
 	});
 
+	it.each(["set-cookie: blah", "foo:", ":foo"])("validates API key fields %s", async (apiKeyNameValue) => {
+		await GitHubServerApp.install({
+			uuid,
+			appId: 1,
+			gitHubAppName: "my awesome app",
+			gitHubBaseUrl: "http://myinternalinstance.com",
+			gitHubClientId: "lvl.1n23j12389wndd",
+			gitHubClientSecret: "secret",
+			webhookSecret: "anothersecret",
+			privateKey: "privatekey",
+			installationId: installation.id
+		}, jiraHost);
+
+		const payload ={
+			gitHubAppName: "newName",
+			webhookSecret: "newSecret",
+			gitHubClientId: "Iv1.msdnf2893rwhdbf",
+			gitHubClientSecret: "secret",
+			apiKeyHeaderName: apiKeyNameValue.split(":")[0].trim(),
+			apiKeyValue: apiKeyNameValue.split(":")[1].trim(),
+			uuid,
+			jiraHost
+		};
+
+		await supertest(app)
+			.put(`/jira/connect/enterprise/app/${uuid}`)
+			.query({
+				jwt
+			})
+			.send(payload)
+			.expect(400);
+	});
+
 	it("should drop API key values when not provided", async () => {
 		await GitHubServerApp.install({
 			uuid,

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-put.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-put.ts
@@ -22,7 +22,12 @@ export const JiraConnectEnterpriseAppPut = async (
 			updatedAppPayload.privateKey = undefined;
 		}
 
-		await GitHubServerApp.updateGitHubAppByUUID(req.body, jiraHost);
+		await GitHubServerApp.updateGitHubAppByUUID({
+			... req.body,
+			encryptedApiKeyValue: req.body.apiKeyValue
+				? await GitHubServerApp.encrypt(res.locals.installation.jiraHost, req.body.apiKeyValue)
+				: null
+		}, jiraHost);
 
 		sendAnalytics(AnalyticsEventTypes.TrackEvent, {
 			name: AnalyticsTrackEventsEnum.UpdateGitHubServerAppTrackEventName,

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-get.frontend.test.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-get.frontend.test.ts
@@ -41,7 +41,7 @@ describe("jira-connect-enterprise-get.frontend(jira-server-url.hbs + jira-server
 		server = app.listen(port);
 
 		const options = {
-			// headless: false, slowMo: 100  // uncomment for debugging
+			headless: false, slowMo: 100  // uncomment for debugging
 		};
 		browser = await chromium.launch(options);
 		page = await browser.newPage();
@@ -76,14 +76,14 @@ describe("jira-connect-enterprise-get.frontend(jira-server-url.hbs + jira-server
 	};
 
 	const enterApiKeyHeaderName = async (name) => {
-		await page.focus("#gheApiKeyHeader");
-		await page.fill("#gheApiKeyHeader", name);
+		await page.focus("#apiKeyHeaderName");
+		await page.fill("#apiKeyHeaderName", name);
 		await page.keyboard.up("Enter");
 	};
 
 	const enterApiKeyHeaderValue = async (value) => {
-		await page.focus("#gheApiKeyValue");
-		await page.fill("#gheApiKeyValue", value);
+		await page.focus("#apiKeyValue");
+		await page.fill("#apiKeyValue", value);
 		await page.keyboard.up("Enter");
 	};
 

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-get.frontend.test.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-get.frontend.test.ts
@@ -75,23 +75,20 @@ describe("jira-connect-enterprise-get.frontend(jira-server-url.hbs + jira-server
 		expect(disabledValue || null).toBeNull();
 	};
 
-	const enterApiKeyHeaderName = async (name) => {
-		await page.focus("#apiKeyHeaderName");
-		await page.fill("#apiKeyHeaderName", name);
+	const focusAndEnterInputValue = async (eltId: string, value: string) => {
+		await page.focus(`#${eltId}`);
+		await page.fill(`#${eltId}`, value);
 		await page.keyboard.up("Enter");
 	};
 
-	const enterApiKeyHeaderValue = async (value) => {
-		await page.focus("#apiKeyValue");
-		await page.fill("#apiKeyValue", value);
-		await page.keyboard.up("Enter");
-	};
+	const enterApiKeyHeaderName = (name) =>
+		focusAndEnterInputValue("apiKeyHeaderName", name);
 
-	const enterServerUrl = async (url) => {
-		await page.focus("#gheServerURL");
-		await page.fill("#gheServerURL", url);
-		await page.keyboard.up("Enter");
-	};
+	const enterApiKeyHeaderValue = (value) =>
+		focusAndEnterInputValue("apiKeyValue", value);
+
+	const enterServerUrl = (url) =>
+		focusAndEnterInputValue("gheServerURL", url);
 
 	const submitForm = async () =>
 		page.click("#gheServerBtnText");

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-get.frontend.test.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-get.frontend.test.ts
@@ -41,7 +41,7 @@ describe("jira-connect-enterprise-get.frontend(jira-server-url.hbs + jira-server
 		server = app.listen(port);
 
 		const options = {
-			headless: false, slowMo: 100  // uncomment for debugging
+			// headless: false, slowMo: 100  // uncomment for debugging
 		};
 		browser = await chromium.launch(options);
 		page = await browser.newPage();

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-get.test.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-get.test.ts
@@ -7,6 +7,10 @@ import { Installation } from "models/installation";
 import supertest from "supertest";
 import { GitHubServerApp } from "models/github-server-app";
 import { getFrontendApp } from "~/src/app";
+import { when } from "jest-when";
+import { booleanFlag, BooleanFlags } from "config/feature-flags";
+
+jest.mock("config/feature-flags");
 
 describe("GET /jira/connect/enterprise", () => {
 
@@ -90,12 +94,16 @@ describe("GET /jira/connect/enterprise", () => {
 		});
 
 		it("populates list of known HTTP headers", async () => {
+			when(booleanFlag).calledWith(
+				BooleanFlags.ENABLE_API_KEY_FEATURE,
+				jiraHost
+			).mockResolvedValue(true);
+
 			const response = await supertest(app)
 				.get("/jira/connect/enterprise")
 				.query({
 					jwt: await generateJwt()
 				});
-			expect(response.text).toContain(`window.knownHttpHeadersLowerCase = ["`);
 			expect(response.text).toContain(`"sec-fetch-dest"`);
 		});
 	});

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-get.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-get.ts
@@ -36,7 +36,7 @@ export const JiraConnectEnterpriseGet = async (
 			res.render("jira-server-url.hbs", {
 				csrfToken: req.csrfToken(),
 				installationId: res.locals.installation.id,
-				withApiKeyFeature: await booleanFlag(BooleanFlags.ENABLE_API_KEY_FEATURE, res.locals.installation.jiraHost),
+				withApiKeyFeature: true || await booleanFlag(BooleanFlags.ENABLE_API_KEY_FEATURE, res.locals.installation.jiraHost),
 				knownHttpHeadersLowerCase: getAllKnownHeaders()
 			});
 		}

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-get.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-get.ts
@@ -36,7 +36,7 @@ export const JiraConnectEnterpriseGet = async (
 			res.render("jira-server-url.hbs", {
 				csrfToken: req.csrfToken(),
 				installationId: res.locals.installation.id,
-				withApiKeyFeature: true || await booleanFlag(BooleanFlags.ENABLE_API_KEY_FEATURE, res.locals.installation.jiraHost),
+				withApiKeyFeature: await booleanFlag(BooleanFlags.ENABLE_API_KEY_FEATURE, res.locals.installation.jiraHost),
 				knownHttpHeadersLowerCase: getAllKnownHeaders()
 			});
 		}

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.test.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.test.ts
@@ -246,7 +246,7 @@ describe("POST /jira/connect/enterprise", () => {
 		it("throws 400 when a header is a known one", async () => {
 			const response = await callEnterprisePostEndpoint({
 				gheServerURL: gitHubServerApp.gitHubBaseUrl,
-				apiKeyHeader: "Set-Cookie",
+				apiKeyHeaderName: "Set-Cookie",
 				apiKeyValue: "jwt=bad-stuff"
 			});
 
@@ -256,7 +256,7 @@ describe("POST /jira/connect/enterprise", () => {
 		it("throws 400 when a header name is longer than 1024", async () => {
 			const response = await callEnterprisePostEndpoint({
 				gheServerURL: gitHubServerApp.gitHubBaseUrl,
-				apiKeyHeader: Array.from({ length: 1025 }, () => "x").join(""),
+				apiKeyHeaderName: Array.from({ length: 1025 }, () => "x").join(""),
 				apiKeyValue: "jwt=bad-stuff"
 			});
 
@@ -266,13 +266,13 @@ describe("POST /jira/connect/enterprise", () => {
 		it("throws 400 when a header name is provided but the value is not", async () => {
 			const response1 = await callEnterprisePostEndpoint({
 				gheServerURL: gitHubServerApp.gitHubBaseUrl,
-				apiKeyHeader: "OK-HEADER"
+				apiKeyHeaderName: "OK-HEADER"
 			});
 			expect(response1.status).toStrictEqual(400);
 
 			const response2 = await callEnterprisePostEndpoint({
 				gheServerURL: gitHubServerApp.gitHubBaseUrl,
-				apiKeyHeader: "OK-HEADER",
+				apiKeyHeaderName: "OK-HEADER",
 				apiKeyValue: "  "
 			});
 			expect(response2.status).toStrictEqual(400);
@@ -281,7 +281,7 @@ describe("POST /jira/connect/enterprise", () => {
 		it("throws 400 when the value is longer than 8096 characters", async () => {
 			const response = await callEnterprisePostEndpoint({
 				gheServerURL: gitHubServerApp.gitHubBaseUrl,
-				apiKeyHeader: "OK-HEADER",
+				apiKeyHeaderName: "OK-HEADER",
 				apiKeyValue: Array.from({ length: 9000 }, () => "x").join("")
 			});
 
@@ -295,7 +295,7 @@ describe("POST /jira/connect/enterprise", () => {
 
 			const response = await callEnterprisePostEndpoint({
 				gheServerURL: gitHubServerApp.gitHubBaseUrl,
-				apiKeyHeader: "OK-HEADER",
+				apiKeyHeaderName: "OK-HEADER",
 				apiKeyValue: "foo"
 			});
 
@@ -309,7 +309,7 @@ describe("POST /jira/connect/enterprise", () => {
 
 			const response = await callEnterprisePostEndpoint({
 				gheServerURL: gitHubServerApp.gitHubBaseUrl,
-				apiKeyHeader: "OK-HEADER ",
+				apiKeyHeaderName: "OK-HEADER ",
 				apiKeyValue: "foo "
 			});
 

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.ts
@@ -87,7 +87,7 @@ export const JiraConnectEnterprisePost = async (
 	const TIMEOUT_PERIOD_MS = parseInt(process.env.JIRA_CONNECT_ENTERPRISE_POST_TIMEOUT_MSEC || "30000");
 
 	const gheServerURL = req.body.gheServerURL?.trim();
-	const apiKeyHeader = req.body.apiKeyHeader?.trim();
+	const apiKeyHeader = req.body.apiKeyHeaderName?.trim();
 	const apiKeyValue = req.body.apiKeyValue?.trim();
 
 	const { id: installationId } = res.locals.installation;

--- a/src/util/api-key-validator.test.ts
+++ b/src/util/api-key-validator.test.ts
@@ -1,10 +1,10 @@
 import { validateApiKeyInputsAndReturnErrorIfAny } from "utils/api-key-validator";
 
 describe("api-key-validator", () => {
-	it("does nothing if apiKeyHeaderName is empty", () => {
+	it("does nothing if both header name and value are empty", () => {
 		expect(validateApiKeyInputsAndReturnErrorIfAny(
 			undefined,
-			Array.from({ length: 9000 }, () => "x").join("")
+			undefined
 		)).toBeUndefined();
 	});
 
@@ -41,5 +41,12 @@ describe("api-key-validator", () => {
 			"bar",
 			undefined
 		)).toStrictEqual("apiKeyHeaderName was provided but apiKeyValue was empty");
+	});
+
+	it("checks apiKeyName is not empty", () => {
+		expect(validateApiKeyInputsAndReturnErrorIfAny(
+			undefined,
+			"bar"
+		)).toStrictEqual("cannot use apiKeyValue without apiKeyHeaderName");
 	});
 });

--- a/src/util/api-key-validator.test.ts
+++ b/src/util/api-key-validator.test.ts
@@ -1,0 +1,45 @@
+import { validateApiKeyInputsAndReturnErrorIfAny } from "utils/api-key-validator";
+
+describe("api-key-validator", () => {
+	it("does nothing if apiKeyHeaderName is empty", () => {
+		expect(validateApiKeyInputsAndReturnErrorIfAny(
+			undefined,
+			Array.from({ length: 9000 }, () => "x").join("")
+		)).toBeUndefined();
+	});
+
+	it("returns undefined if all good", () => {
+		expect(validateApiKeyInputsAndReturnErrorIfAny(
+			"foo",
+			"bar"
+		)).toBeUndefined();
+	});
+
+	it("checks length of apiKeyHeaderName", () => {
+		expect(validateApiKeyInputsAndReturnErrorIfAny(
+			Array.from({ length: 2000 }, () => "x").join(""),
+			"bar"
+		)).toStrictEqual("apiKeyHeaderName max length is 1024");
+	});
+
+	it("checks apiKeyHeaderName is not an existing header", () => {
+		expect(validateApiKeyInputsAndReturnErrorIfAny(
+			"authorization",
+			"bar"
+		)).toStrictEqual("Provided apiKeyHeaderName cannot be used as API key header");
+	});
+
+	it("checks apiKeyValue does not exceed allowed length", () => {
+		expect(validateApiKeyInputsAndReturnErrorIfAny(
+			"bar",
+			Array.from({ length: 10000 }, () => "x").join("")
+		)).toStrictEqual("apiKeyValue max length is 8096");
+	});
+
+	it("checks apiKeyValue is not empty", () => {
+		expect(validateApiKeyInputsAndReturnErrorIfAny(
+			"bar",
+			undefined
+		)).toStrictEqual("apiKeyHeaderName was provided but apiKeyValue was empty");
+	});
+});

--- a/src/util/api-key-validator.ts
+++ b/src/util/api-key-validator.ts
@@ -1,0 +1,21 @@
+import { canBeUsedAsApiKeyHeader } from "utils/http-headers";
+
+export const validateApiKeyInputsAndReturnErrorIfAny = (apiKeyHeaderName: string | undefined, apiKeyValue: string | undefined) => {
+	if (apiKeyHeaderName) {
+		let error: string | undefined = undefined;
+		if (!apiKeyValue) {
+			error = "apiKeyHeaderName was provided but apiKeyValue was empty";
+		}
+		if (!canBeUsedAsApiKeyHeader(apiKeyHeaderName)) {
+			error = "Provided apiKeyHeaderName cannot be used as API key header";
+		}
+		if (apiKeyHeaderName.length > 1024) {
+			error = "apiKeyHeaderName max length is 1024";
+		}
+		if (apiKeyValue && apiKeyValue.length > 8096) {
+			error = "apiKeyValue max length is 8096";
+		}
+		return error;
+	}
+	return undefined;
+};

--- a/src/util/api-key-validator.ts
+++ b/src/util/api-key-validator.ts
@@ -17,5 +17,8 @@ export const validateApiKeyInputsAndReturnErrorIfAny = (apiKeyHeaderName: string
 		}
 		return error;
 	}
+	if (apiKeyValue && !apiKeyHeaderName) {
+		return "cannot use apiKeyValue without apiKeyHeaderName";
+	}
 	return undefined;
 };

--- a/static/css/jira-manual-app-creation.css
+++ b/static/css/jira-manual-app-creation.css
@@ -14,7 +14,7 @@ h1 {
   font-size: 1.2rem;
   font-weight: 600;
   margin: 1.25em 0 1em;
-  display: flex;
+  display: block;
   align-items: center;
 }
 

--- a/static/js/jira-api-key-validation.js
+++ b/static/js/jira-api-key-validation.js
@@ -1,7 +1,4 @@
 function initApiKeyValidation(apiKeyHeaderName, apiKeyHeaderValue, knownHttpHeadersLowerCase, onValidationFinished) {
-	console.log("aaaaa");
-	console.log(apiKeyHeaderName, apiKeyHeaderValue);
-	console.log("bbbbb");
 
 	AJS.formValidation.register([apiKeyHeaderName.auiTag], (field) => {
 		const inputStr = field.el.value;

--- a/static/js/jira-api-key-validation.js
+++ b/static/js/jira-api-key-validation.js
@@ -1,0 +1,42 @@
+function initApiKeyValidation(apiKeyHeaderName, apiKeyHeaderValue, knownHttpHeadersLowerCase, onValidationFinished) {
+	console.log("aaaaa");
+	console.log(apiKeyHeaderName, apiKeyHeaderValue);
+	console.log("bbbbb");
+
+	AJS.formValidation.register([apiKeyHeaderName.auiTag], (field) => {
+		const inputStr = field.el.value;
+		if (inputStr.trim().length) {
+			if (inputStr.trim().length > 1024) {
+				field.invalidate(AJS.format('Max length is 1,024 characters.'));
+			} else if (knownHttpHeadersLowerCase.indexOf(inputStr.trim().toLowerCase()) >= 0) {
+				field.invalidate(AJS.format(inputStr.trim() + ' is a reserved string and cannot be used.'));
+			} else {
+				field.validate();
+			}
+		} else {
+			field.validate();
+		}
+		AJS.formValidation.validate(apiKeyHeaderValue.elt);
+	});
+
+	AJS.formValidation.register([apiKeyHeaderValue.auiTag], (field) => {
+		const inputStr = field.el.value;
+		if (apiKeyHeaderName.elt.value.trim().length === 0) {
+			if (inputStr.trim().length === 0) {
+				field.validate();
+			} else {
+				field.invalidate(AJS.format('Cannot be used without HTTP header name.'));
+			}
+		} else if (inputStr.trim().length === 0) {
+			field.invalidate(AJS.format('Cannot be empty.'));
+		} else if (inputStr.trim().length > 8096) {
+			field.invalidate(AJS.format('Max length is 8,096 characters.'));
+		} else {
+			field.validate();
+		}
+		if (onValidationFinished) {
+			onValidationFinished();
+		}
+	});
+
+}

--- a/static/js/jira-manual-app-creation.js
+++ b/static/js/jira-manual-app-creation.js
@@ -86,6 +86,19 @@ $(document).ready(function() {
 		const renderedFilename = document.getElementById("jiraManualAppCreation__uploadedFile").innerText;
 		const isFileChanged = renderedFilename !== `${appName}.private-key.pem`;
 
+		function submitData() {
+			AP.context.getToken((token) => {
+				data.jwt = token;
+				data.jiraHost = jiraHost;
+
+				if (isUpdatePage()) {
+					gitHubAppPutRequest(uuid, data);
+				} else {
+					gitHubAppPostRequest(data, token);
+				}
+			});
+		}
+
 		if (isFileChanged || isCreatePage()) {
 			const file = $("#privateKeyFile")[0].files[0];
 			const reader = new FileReader();
@@ -93,19 +106,11 @@ $(document).ready(function() {
 
 			reader.onload = () => {
 				data.privateKey = reader.result;
+				submitData();
 			};
+		} else {
+			submitData();
 		}
-
-		AP.context.getToken((token) => {
-			data.jwt = token;
-			data.jiraHost = jiraHost;
-
-			if (isUpdatePage()) {
-				gitHubAppPutRequest(uuid, data);
-			} else {
-				gitHubAppPostRequest(data, token);
-			}
-		});
 	});
 
 	const replaceSpacesAndChangeCasing = (str) => str.replace(/\s+/g, '-').toLowerCase();

--- a/static/js/jira-server-url.js
+++ b/static/js/jira-server-url.js
@@ -3,14 +3,14 @@ const params = new URLSearchParams(window.location.search.substring(1));
 const jiraHost = params.get("xdm_e");
 
 const gheServerURLElt = document.getElementById("gheServerURL");
-const gheApiKeyHeaderElt = document.getElementById("gheApiKeyHeader");
-const gheApiKeyValueElt = document.getElementById("gheApiKeyValue");
+const apiKeyHeaderNameElt = document.getElementById("apiKeyHeaderName");
+const apiKeyValueElt = document.getElementById("apiKeyValue");
 
 function syncGheServerBtn() {
 	if (
 		gheServerURLElt.getAttribute("data-aui-validation-state") === "invalid" ||
-		(gheApiKeyHeaderElt && gheApiKeyHeaderElt.getAttribute("data-aui-validation-state") === "invalid") ||
-		(gheApiKeyValueElt && gheApiKeyValueElt.getAttribute("data-aui-validation-state") === "invalid")
+		(apiKeyHeaderNameElt && apiKeyHeaderNameElt.getAttribute("data-aui-validation-state") === "invalid") ||
+		(apiKeyValueElt && apiKeyValueElt.getAttribute("data-aui-validation-state") === "invalid")
 	) {
 		$("#gheServerBtn").attr({ "aria-disabled": true, "disabled": true });
 	} else {
@@ -27,40 +27,6 @@ AJS.formValidation.register(['ghe-url'], (field) => {
 		field.validate();
 		syncGheServerBtn();
 	}
-});
-
-AJS.formValidation.register(['api-key-header'], (field) => {
-	const inputStr = field.el.value;
-	if (inputStr.trim().length) {
-		if (inputStr.trim().length > 1024) {
-			field.invalidate(AJS.format('Max length is 1,024 characters.'));
-		} else if (window.knownHttpHeadersLowerCase.indexOf(inputStr.trim().toLowerCase()) >= 0) {
-			field.invalidate(AJS.format(inputStr.trim() + ' is a reserved string and cannot be used.'));
-		} else {
-			field.validate();
-		}
-	} else {
-		field.validate();
-	}
-	AJS.formValidation.validate(gheApiKeyValueElt);
-});
-
-AJS.formValidation.register(['api-key-header-value'], (field) => {
-	const inputStr = field.el.value;
-	if (gheApiKeyHeaderElt.value.trim().length === 0) {
-		if (inputStr.trim().length === 0) {
-			field.validate();
-		} else {
-			field.invalidate(AJS.format('Cannot be used without HTTP header name.'));
-		}
-	} else if (inputStr.trim().length === 0) {
-		field.invalidate(AJS.format('Cannot be empty.'));
-	} else if (inputStr.trim().length > 8096) {
-		field.invalidate(AJS.format('Max length is 8,096 characters.'));
-	} else {
-		field.validate();
-	}
-	syncGheServerBtn();
 });
 
 const activeRequest = () => {
@@ -114,13 +80,13 @@ const handleGheUrlRequestErrors = (err) => {
 	$(".errorMessageBox__message").empty().append(message);
 }
 
-const verifyGitHubServerUrl = (gheServerURL, apiKeyHeader, apiKeyValue) => {
+const verifyGitHubServerUrl = (gheServerURL, apiKeyHeaderName, apiKeyValue) => {
 	const csrf = document.getElementById("_csrf").value
 
 	AP.context.getToken(function(token) {
 		$.post("/jira/connect/enterprise", {
 				gheServerURL,
-				apiKeyHeader,
+				apiKeyHeaderName,
 				apiKeyValue,
 				_csrf: csrf,
 				jwt: token
@@ -170,8 +136,8 @@ AJS.$("#jiraServerUrl__form").on("aui-valid-submit", event => {
 		activeRequest();
 		verifyGitHubServerUrl(
 			gheServerURL,
-			gheApiKeyHeaderElt ? gheApiKeyHeaderElt.value : '',
-			gheApiKeyValueElt ? gheApiKeyValueElt.value : ''
+			apiKeyHeaderNameElt ? apiKeyHeaderNameElt.value : '',
+			apiKeyValueElt ? apiKeyValueElt.value : ''
 		);
 	}
 });

--- a/views/jira-manual-app-creation.hbs
+++ b/views/jira-manual-app-creation.hbs
@@ -175,6 +175,33 @@
           <div class="jiraManualAppCreation__formFileErrorBorder"></div>
         </div>
 
+        <div class="jiraManualAppCreation__formTitle">API key <small>(Optional)</small></div>
+        <div class="jiraManualAppCreation__formSubTitle">
+          Add an additional layer of security by creating or using an API key. Remember the key for future use.
+          <a href="#">Learn more about API keys</a>
+        </div>
+
+        <div class="field-group ">
+          <label for="apiKeyHeaderName">HTTP request header name  </label>
+          <input class="text full-width-field" type="text"
+                data-aui-validation-field
+                data-aui-validation-api-key-header-name
+                placeholder="X-Accept-Me"
+                value="{{apiKeyHeaderName}}"
+                id="apiKeyHeaderName"
+                name="apiKeyHeaderName" />
+        </div>
+
+        <div class="field-group">
+          <label for="apiKeyValue">Value</label>
+          <input class="text full-width-field" type="password"
+                data-aui-validation-field
+                data-aui-validation-api-key-header-value
+                value="{{apiKeyValue}}"
+                id="apiKeyValue"
+                name="apiKeyValue" />
+        </div>
+
         <input type="hidden" id="_csrf" value="{{csrfToken}}">
         <input type="hidden" name="uuid" value="{{uuid}}">
         <input type="hidden" id="gitHubBaseUrl" name="gitHubBaseUrl" value="{{serverUrl}}">
@@ -206,6 +233,20 @@
       nonce="{{nonce}}"
     ></script>
   <script src="/public/js/jira-manual-app-creation.js" nonce="{{nonce}}"></script>
+  <script src="/public/js/jira-api-key-validation.js" nonce="{{nonce}}"></script>
+      <script>
+          initApiKeyValidation(
+              {
+                  auiTag: "api-key-header-name",
+                  elt: document.getElementById("apiKeyHeaderName")
+              },
+              {
+                  auiTag: "api-key-header-value",
+                  elt: document.getElementById("apiKeyValue")
+              },
+              {{{json knownHttpHeadersLowerCase}}}
+          );
+      </script>
   <script src="/public/js/navigation.js" nonce="{{nonce}}"></script>
   </body>
 </html>

--- a/views/jira-manual-app-creation.hbs
+++ b/views/jira-manual-app-creation.hbs
@@ -175,6 +175,7 @@
           <div class="jiraManualAppCreation__formFileErrorBorder"></div>
         </div>
 
+{{#if withApiKeyFeature}}
         <div class="jiraManualAppCreation__formTitle">API key <small>(Optional)</small></div>
         <div class="jiraManualAppCreation__formSubTitle">
           Add an additional layer of security by creating or using an API key. Remember the key for future use.
@@ -187,7 +188,7 @@
                 data-aui-validation-field
                 data-aui-validation-api-key-header-name
                 placeholder="X-Accept-Me"
-                value="{{apiKeyHeaderName}}"
+                name="apiKeyHeaderName" value="{{apiKeyHeaderName}}"
                 id="apiKeyHeaderName"
                 name="apiKeyHeaderName" />
         </div>
@@ -197,10 +198,11 @@
           <input class="text full-width-field" type="password"
                 data-aui-validation-field
                 data-aui-validation-api-key-header-value
-                value="{{apiKeyValue}}"
+                name="apiKeyValue" value="{{apiKeyValue}}"
                 id="apiKeyValue"
-                name="apiKeyValue" />
+                 />
         </div>
+{{/if}}
 
         <input type="hidden" id="_csrf" value="{{csrfToken}}">
         <input type="hidden" name="uuid" value="{{uuid}}">
@@ -233,6 +235,7 @@
       nonce="{{nonce}}"
     ></script>
   <script src="/public/js/jira-manual-app-creation.js" nonce="{{nonce}}"></script>
+{{#if withApiKeyFeature}}
   <script src="/public/js/jira-api-key-validation.js" nonce="{{nonce}}"></script>
       <script>
           initApiKeyValidation(
@@ -247,6 +250,7 @@
               {{{json knownHttpHeadersLowerCase}}}
           );
       </script>
+{{/if}}
   <script src="/public/js/navigation.js" nonce="{{nonce}}"></script>
   </body>
 </html>

--- a/views/jira-manual-app-creation.hbs
+++ b/views/jira-manual-app-creation.hbs
@@ -112,6 +112,7 @@
           <input class="text full-width-field" type="text"
                  data-aui-validation-field required
                  value="{{decryptedWebhookSecret}}"
+                 id="webhookSecret"
                  name="webhookSecret"  />
         </div>
 
@@ -125,6 +126,7 @@
           <input class="text full-width-field" type="number"
                  data-aui-validation-field required
                  value="{{app.appId}}"
+                 id="appId"
                  name="appId" />
         </div>
 
@@ -133,6 +135,7 @@
           <input class="text full-width-field" type="text"
                  data-aui-validation-field required
                  value="{{app.gitHubClientId}}"
+                 id="gitHubClientId"
                  name="gitHubClientId" />
         </div>
 
@@ -141,6 +144,7 @@
           <input class="text full-width-field" type="password"
                  data-aui-validation-field required
                  value="{{decryptedGheSecret}}"
+                 id="gitHubClientSecret"
                  name="gitHubClientSecret" />
         </div>
 

--- a/views/jira-server-url.hbs
+++ b/views/jira-server-url.hbs
@@ -91,22 +91,24 @@
                 <a href='#'>Learn more about API keys</a>
               </div>
                 <div class="field-group">
-                  <label for="gheApiKeyHeader">HTTP request header name</label>
+                  <label for="apiKeyHeaderName">HTTP request header name</label>
                   <input class="text full-width-field" type="text"
                          data-aui-validation-field
-                         data-aui-validation-api-key-header
+                         data-aui-validation-api-key-header-name
                          data-aui-validation-when="keyup"
                          placeholder="X-Accept-Me"
-                         id="gheApiKeyHeader" name="gheApiKeyHeader" />
+                         id="apiKeyHeaderName"
+                         name="apiKeyHeaderName" />
                 </div>
 
                 <div class="field-group">
-                  <label for="gheApiKeyValue">Value</label>
+                  <label for="apiKeyValue">Value</label>
                   <input class="text full-width-field" type="password"
                          data-aui-validation-field
                          data-aui-validation-api-key-header-value
                          data-aui-validation-when="keyup"
-                         id="gheApiKeyValue" name="gheApiKeyValue" />
+                         id="apiKeyValue"
+                         name="apiKeyValue" />
                 </div>
             {{/if}}
 
@@ -140,10 +142,25 @@
       referrerpolicy="no-referrer"
       nonce="{{nonce}}"
     ></script>
-    <script>
-      window.knownHttpHeadersLowerCase = {{{json knownHttpHeadersLowerCase}}};
-    </script>
     <script src="/public/js/jira-server-url.js" nonce="{{nonce}}"></script>
+
+{{#if withApiKeyFeature}}
+    <script src="/public/js/jira-api-key-validation.js" nonce="{{nonce}}"></script>
+    <script>
+        initApiKeyValidation(
+            {
+                auiTag: "api-key-header-name",
+                elt: document.getElementById("apiKeyHeaderName")
+            },
+            {
+                auiTag: "api-key-header-value",
+                elt: document.getElementById("apiKeyValue")
+            },
+            {{{json knownHttpHeadersLowerCase}}},
+            syncGheServerBtn
+        );
+    </script>
+{{/if}}
     <script src="/public/js/navigation.js" nonce="{{nonce}}"></script>
   </body>
 </html>


### PR DESCRIPTION
**What's in this PR?**
Adding API key header name and value to the manual form

**Why**
Unblock BTF customers who are using manual way of connecting to GHE

**Added feature flags**
Existing one

**Affected issues**  
ARC-2157

**How has this been tested?**  
Manuall, unit tests, including frontend ones

<img width="300" alt="image" src="https://github.com/atlassian/github-for-jira/assets/20631664/8d2b36e8-1752-47be-8533-fd20816b66ac">

<img width="300" alt="image" src="https://github.com/atlassian/github-for-jira/assets/20631664/eb8368ae-018d-43cd-903e-482d145b33ce">

<img width="300" alt="image" src="https://github.com/atlassian/github-for-jira/assets/20631664/47ca165d-9a35-4b37-bd23-fc9e8ea9d605">


