### PR TITLE
noissue: Bump issue_key limit from 100 to 500

### DIFF
--- a/src/jira/client/jira-client.test.ts
+++ b/src/jira/client/jira-client.test.ts
@@ -47,7 +47,7 @@ describe("Test getting a jira client", () => {
 					fileCount: 3,
 					hash: "hashihashhash",
 					id: "id",
-					issueKeys: Array.from(new Array(125)).map((_, i) => `TEST-${i}`),
+					issueKeys: Array.from(new Array(525)).map((_, i) => `TEST-${i}`),
 					message: "commit message",
 					url: "some-url",
 					updateSequenceId: 1234567890
@@ -81,7 +81,7 @@ describe("Test getting a jira client", () => {
 						updateSequenceId: 1234567890
 					},
 					id: "jiraId",
-					issueKeys: Array.from(new Array(125)).map((_, i) => `TEST-${i}`),
+					issueKeys: Array.from(new Array(525)).map((_, i) => `TEST-${i}`),
 					name: "ref",
 					url: "branch-url",
 					updateSequenceId: 1234567890
@@ -107,7 +107,7 @@ describe("Test getting a jira client", () => {
 					destinationBranchUrl: "dest-branch-url",
 					displayId: "#5",
 					id: 6,
-					issueKeys: Array.from(new Array(125)).map((_, i) => `TEST-${i}`),
+					issueKeys: Array.from(new Array(525)).map((_, i) => `TEST-${i}`),
 					reviewers: [],
 					sourceBranch: "source-branch",
 					sourceBranchUrl: "source-branch-url",
@@ -161,7 +161,7 @@ describe("Test getting a jira client", () => {
 					fileCount: 3,
 					hash: "hashihashhash",
 					id: "id",
-					issueKeys: Array.from(new Array(125)).map((_, i) => `TEST-${i}`),
+					issueKeys: Array.from(new Array(525)).map((_, i) => `TEST-${i}`),
 					message: "commit message",
 					url: "some-url",
 					updateSequenceId: 1234567890

--- a/src/jira/client/jira-client.ts
+++ b/src/jira/client/jira-client.ts
@@ -23,7 +23,7 @@ import { TransformedRepositoryId, transformRepositoryId } from "~/src/transforms
 import { getDeploymentDebugInfo } from "./jira-client-deployment-helper";
 
 // Max number of issue keys we can pass to the Jira API
-export const ISSUE_KEY_API_LIMIT = 100;
+export const ISSUE_KEY_API_LIMIT = 500;
 const issueKeyLimitWarning = "Exceeded issue key reference limit. Some issues may not be linked.";
 
 export interface DeploymentsResult {


### PR DESCRIPTION
**What's in this PR?**
Bumping ISSUE_KEY_API_LIMIT to 500 since DevInfo bumped on their end according to docs https://developer.atlassian.com/cloud/jira/software/rest/api-group-development-information/#api-group-development-information (and Saiyans)
