### PR TITLE
change name after request from support

### DIFF
--- a/etc/poco/bundle/main-test.json
+++ b/etc/poco/bundle/main-test.json
@@ -93,7 +93,7 @@
 			"path": "/api/hash",
 			"method": "POST",
 			"mechanism": "group",
-			"principals": ["enterprise-cloud-support-all"],
+			"principals": ["micros-sv--github-for-jira-dl-safe-logging-read"],
 			"allowed": true
 		},
 		{

--- a/etc/poco/bundle/main.json
+++ b/etc/poco/bundle/main.json
@@ -69,7 +69,7 @@
 			"principals": {
 				"staff": {
 					"groups": [
-						"enterprise-cloud-support-all"
+						"micros-sv--github-for-jira-dl-safe-logging-read"
 					]
 				}
 			}


### PR DESCRIPTION
**What's in this PR?**
Changed the name of the group that can make GET requests to our hash endpoint.

**Why**
Support asked if we could change the group.

**How has this been tested?**  
Updated main tests and ran locally.
