### PR TITLE
NONE: add state and environment to deployment log

### DIFF
--- a/src/github/deployment.ts
+++ b/src/github/deployment.ts
@@ -66,7 +66,7 @@ export const processDeployment = async (
 	logger.info({
 		deploymentState: state,
 		deploymentEnvironment: environment
-	},"processing deployment message!");
+	}, "processing deployment message!");
 
 	const metrics = {
 		trigger: "deployment_queue"

--- a/src/github/deployment.ts
+++ b/src/github/deployment.ts
@@ -15,7 +15,6 @@ import { metricDeploymentCache } from "config/metric-names";
 import { getCloudOrServerFromGitHubAppId } from "utils/get-cloud-or-server";
 
 export const deploymentWebhookHandler = async (context: WebhookContext, jiraClient, _util, gitHubInstallationId: number, subscription: Subscription): Promise<void> => {
-
 	if (context.payload.deployment_status.state === "success") {
 		if (await booleanFlag(BooleanFlags.USE_DYNAMODB_FOR_DEPLOYMENT_WEBHOOK, subscription.jiraHost)) {
 			await tryCacheSuccessfulDeploymentInfo(
@@ -62,7 +61,12 @@ export const processDeployment = async (
 		return;
 	}
 
-	logger.info("processing deployment message!");
+	const { state, environment } = webhookPayload.deployment_status;
+
+	logger.info({
+		deploymentState: state,
+		deploymentEnvironment: environment
+	},"processing deployment message!");
 
 	const metrics = {
 		trigger: "deployment_queue"

--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -352,6 +352,7 @@ export const transformDeployment = async (
 	}
 
 	const environment = mapEnvironment(deployment_status.environment, config);
+	const state = mapState(deployment_status.state);
 
 	if (environment === "unmapped") {
 		logger?.info({
@@ -359,6 +360,11 @@ export const transformDeployment = async (
 			description: deployment.description
 		}, "Unmapped environment detected.");
 	}
+
+	logger.info({
+		deploymentState: state,
+		deploymentEnvironment: environment
+	}, "Sending deployment data to Jira");
 
 	return {
 		deployments: [{
@@ -369,7 +375,7 @@ export const transformDeployment = async (
 			url: deployment_status.target_url || deployment.url,
 			description: (deployment.description || deployment_status.description || deployment.task || "").substring(0, 255),
 			lastUpdated: new Date(deployment_status.updated_at),
-			state: mapState(deployment_status.state),
+			state,
 			pipeline: {
 				id: deployment.task,
 				displayName: deployment.task,


### PR DESCRIPTION
**What's in this PR?**
Added some fields to the processing deployments log.

**Why**
Trying to debug a customer issue where their deployments are getting stuck in the 'in progress' state for certain environments. Logs aren't too helpful on this front currently.

**Whats Next?**
Wait for logs to start showing up, get customer to run some deployments, :blob_pray: