### PR TITLE
Allow Jira users to navigate directly to a deployed environment from Deployments widget

### DIFF
--- a/src/sync/deployment.ts
+++ b/src/sync/deployment.ts
@@ -38,6 +38,7 @@ const getTransformedDeployments = async (deployments, gitHubInstallationClient: 
 				environment: deployment.environment,
 				id: deployment.databaseId,
 				target_url: deployment.latestStatus?.logUrl,
+				environment_url: deployment.latestStatus?.environmentUrl,
 				updated_at: deployment.latestStatus?.updatedAt,
 				state: deployment.latestStatus?.state
 			}

--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -372,7 +372,7 @@ export const transformDeployment = async (
 			deploymentSequenceNumber: deployment.id,
 			updateSequenceNumber: deployment_status.id,
 			displayName: (message || String(payload.deployment.id) || "").substring(0, 255),
-			url: deployment_status.target_url || deployment.url,
+			url: deployment_status.environment_url || deployment_status.target_url || deployment.url,
 			description: (deployment.description || deployment_status.description || deployment.task || "").substring(0, 255),
 			lastUpdated: new Date(deployment_status.updated_at),
 			state,


### PR DESCRIPTION
**What's in this PR?**
- Allow Jira users to navigate directly to a deployed environment from Deployments widget
- Uses the existing `environment_url` webhook field to parallel the `View Deployment` button from Github Deployments:
<img width="707" alt="image" src="https://github.com/atlassian/github-for-jira/assets/2145098/13ebfa56-8109-4d4f-bfaf-ceab041b53aa">


**Why**
- Our team uses transient/ephemeral environments per pull request
- When someone is trying to QA a Jira ticket, it's very helpful to be able to quickly navigate to the correct environment
- Here is what we see today, for example:
<img width="981" alt="image" src="https://github.com/atlassian/github-for-jira/assets/2145098/8ad3e06f-e0b4-4055-9de8-b7ea4abcc309">

- The `Pipeline` and `Deployment` columns both link to the exact same place - the Github Action job run that created the Github Deployment entry
- We would love for the `Environment name` column to link directly to the environment, but this doesn't appear to be possible
- Alternatively, what this PR proposes, is to have the `Deployment` column link to the actual deployed environment, rather than the Github Action job run (which `Pipeline` still links to)

**Added feature flags**
- none

**Affected issues**  
- None
- I tried to create a Github Issue, but that [redirects here](https://jira.atlassian.com/secure/Dashboard.jspa)
- I tried to create a product suggestion under Jira Software Cloud, but that redirected me to _Give Feedback_ within Jira

**How has this been tested?**  
- considered adding a test for this, but it felt unnecessary based on the level of tests in `transform-deployment.test.ts`. Happy to add one if I should