### PR TITLE
Upgrade @octokit/webhooks-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
 	},
 	"devDependencies": {
 		"@octokit/rest": "16.43.2",
-		"@octokit/webhooks": "6.3.2",
+		"@octokit/webhooks-types": "^6.11.0",
 		"@playwright/test": "^1.33.0",
 		"@types/bunyan": "^1.8.6",
 		"@types/bunyan-format": "^0.2.4",

--- a/src/github/branch.test.ts
+++ b/src/github/branch.test.ts
@@ -64,8 +64,8 @@ describe("BranchhWebhookHandler", () => {
 			});
 		});
 	});
-	const getWebhookContext = ({ cloud }: {cloud: boolean}) => {
-		return new WebhookContext({
+	const getWebhookContext = <T>({ cloud }: {cloud: boolean}) => {
+		return new WebhookContext<T>({
 			id: "1",
 			name: "create",
 			log: getLogger("test"),
@@ -74,7 +74,7 @@ describe("BranchhWebhookHandler", () => {
 					id: 1
 				},
 				ref: "TEST-1"
-			},
+			} as unknown as T,
 			gitHubAppConfig: cloud ? {
 				uuid: undefined,
 				gitHubAppId: undefined,

--- a/src/github/branch.ts
+++ b/src/github/branch.ts
@@ -1,7 +1,7 @@
 import { transformBranch } from "../transforms/transform-branch";
 import { emitWebhookProcessedMetrics } from "utils/webhook-utils";
 import { isEmpty } from "lodash";
-import { WebhookPayloadCreate, WebhookPayloadDelete } from "@octokit/webhooks";
+import type { CreateEvent, DeleteEvent } from "@octokit/webhooks-types";
 import { sqsQueues } from "../sqs/queues";
 import Logger from "bunyan";
 import { getJiraClient } from "../jira/client/jira-client";
@@ -11,9 +11,9 @@ import { jiraIssueKeyParser } from "utils/jira-utils";
 import { WebhookContext } from "routes/github/webhook/webhook-context";
 import { transformRepositoryId } from "~/src/transforms/transform-repository-id";
 
-export const createBranchWebhookHandler = async (context: WebhookContext, jiraClient, _util, gitHubInstallationId: number): Promise<void> => {
+export const createBranchWebhookHandler = async (context: WebhookContext<CreateEvent>, jiraClient, _util, gitHubInstallationId: number): Promise<void> => {
 
-	const webhookPayload: WebhookPayloadCreate = context.payload;
+	const webhookPayload = context.payload;
 
 	await sqsQueues.branch.sendMessage({
 		jiraHost: jiraClient.baseURL,
@@ -28,7 +28,7 @@ export const createBranchWebhookHandler = async (context: WebhookContext, jiraCl
 export const processBranch = async (
 	github: GitHubInstallationClient,
 	webhookId: string,
-	webhookPayload: WebhookPayloadCreate,
+	webhookPayload: CreateEvent,
 	webhookReceivedDate: Date,
 	jiraHost: string,
 	gitHubInstallationId: number,
@@ -70,8 +70,8 @@ export const processBranch = async (
 	);
 };
 
-export const deleteBranchWebhookHandler = async (context: WebhookContext, jiraClient): Promise<void> => {
-	const payload: WebhookPayloadDelete = context.payload;
+export const deleteBranchWebhookHandler = async (context: WebhookContext<DeleteEvent>, jiraClient): Promise<void> => {
+	const payload = context.payload;
 	const issueKeys = jiraIssueKeyParser(payload.ref);
 
 	if (isEmpty(issueKeys)) {

--- a/src/github/deployment.test.ts
+++ b/src/github/deployment.test.ts
@@ -8,7 +8,7 @@ import { Subscription } from "models/subscription";
 import deployment_status from "fixtures/deployment_status-basic.json";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
 import { when } from "jest-when";
-import { WebhookPayloadDeploymentStatus } from "@octokit/webhooks";
+import type { DeploymentStatusEvent } from "@octokit/webhooks-types";
 import { dynamodb as ddb } from "config/dynamodb";
 import { createHashWithoutSharedSecret } from "utils/encryption";
 
@@ -70,11 +70,11 @@ describe("DeploymentWebhookHandler", () => {
 		});
 	});
 	describe("Processing webhook", () => {
-		let payload: WebhookPayloadDeploymentStatus;
+		let payload: DeploymentStatusEvent;
 		describe("Persistent to dynamoDB", () => {
 			beforeEach(async () => {
 				when(booleanFlag).calledWith(BooleanFlags.USE_DYNAMODB_FOR_DEPLOYMENT_WEBHOOK, expect.anything()).mockResolvedValue(true);
-				payload = JSON.parse(JSON.stringify(deployment_status.payload)) as WebhookPayloadDeploymentStatus;
+				payload = JSON.parse(JSON.stringify(deployment_status.payload)) as DeploymentStatusEvent;
 			});
 			it("should call to persist deployment info for success deployment status", async () => {
 				await deploymentWebhookHandler({ ...getWebhookContext({ cloud: true }), payload }, jiraClient, util, GITHUB_INSTALLATION_ID, subscription);

--- a/src/github/deployment.ts
+++ b/src/github/deployment.ts
@@ -2,7 +2,7 @@ import { transformDeployment } from "../transforms/transform-deployment";
 import { emitWebhookProcessedMetrics } from "utils/webhook-utils";
 import { getJiraClient, DeploymentsResult } from "../jira/client/jira-client";
 import { sqsQueues } from "../sqs/queues";
-import { WebhookPayloadDeploymentStatus } from "@octokit/webhooks";
+import type { DeploymentStatusEvent } from "@octokit/webhooks-types";
 import Logger from "bunyan";
 import { isBlocked, booleanFlag, BooleanFlags } from "config/feature-flags";
 import { GitHubInstallationClient } from "./client/github-installation-client";
@@ -40,7 +40,7 @@ export const deploymentWebhookHandler = async (context: WebhookContext, jiraClie
 export const processDeployment = async (
 	newGitHubClient: GitHubInstallationClient,
 	webhookId: string,
-	webhookPayload: WebhookPayloadDeploymentStatus,
+	webhookPayload: DeploymentStatusEvent,
 	webhookReceivedDate: Date,
 	jiraHost: string,
 	gitHubInstallationId: number,
@@ -107,7 +107,7 @@ const tryCacheSuccessfulDeploymentInfo = async (
 	jiraHost: string,
 	gitHubBaseUrl: string,
 	gitHubAppId: number | undefined,
-	webhookPayload: WebhookPayloadDeploymentStatus,
+	webhookPayload: DeploymentStatusEvent,
 	logger: Logger
 ) => {
 

--- a/src/github/issue.ts
+++ b/src/github/issue.ts
@@ -1,10 +1,10 @@
 import { emitWebhookProcessedMetrics } from "utils/webhook-utils";
-import { WebhookPayloadIssues } from "@octokit/webhooks";
+import type { IssuesOpenedEvent, IssuesEditedEvent } from "@octokit/webhooks-types";
 import { GitHubIssue, GitHubIssueData } from "interfaces/github";
 import { createInstallationClient } from "utils/get-github-client-config";
 import { WebhookContext } from "../routes/github/webhook/webhook-context";
 
-export const issueWebhookHandler = async (context: WebhookContext<WebhookPayloadIssues>, jiraClient, util, gitHubInstallationId: number): Promise<void> => {
+export const issueWebhookHandler = async (context: WebhookContext<IssuesOpenedEvent | IssuesEditedEvent>, jiraClient, util, gitHubInstallationId: number): Promise<void> => {
 	const {
 		issue,
 		repository: {
@@ -28,7 +28,9 @@ export const issueWebhookHandler = async (context: WebhookContext<WebhookPayload
 	// TODO: need to create reusable function for unfurling
 	let linkifiedBody;
 	try {
-		linkifiedBody = await util.unfurl(issue.body);
+		if (issue.body !== null) {
+			linkifiedBody = await util.unfurl(issue.body);
+		}
 		if (!linkifiedBody) {
 			context.log.info("Halting further execution for issue since linkifiedBody is empty");
 			return;

--- a/src/sqs/sqs.types.ts
+++ b/src/sqs/sqs.types.ts
@@ -1,5 +1,4 @@
-import { WebhookPayloadDeploymentStatus } from "@octokit/webhooks";
-import type { WebhookPayloadCreate } from "@octokit/webhooks";
+import type { CreateEvent, DeploymentStatusEvent } from "@octokit/webhooks-types";
 import type { TaskType, SyncType } from "~/src/sync/sync.types";
 import { Message } from "aws-sdk/clients/sqs";
 import Logger from "bunyan";
@@ -132,7 +131,7 @@ export type BranchMessagePayload = BaseMessagePayload & {
 	webhookId: string,
 	// The original webhook payload from GitHub. We don't need to worry about the SQS size limit because metrics show
 	// that payload size for deployment_status webhooks maxes out at 9KB.
-	webhookPayload: WebhookPayloadCreate,
+	webhookPayload: CreateEvent,
 }
 
 export type BackfillMessagePayload = BaseMessagePayload & {
@@ -148,7 +147,7 @@ export type DeploymentMessagePayload = BaseMessagePayload & {
 	webhookId: string,
 	// The original webhook payload from GitHub. We don't need to worry about the SQS size limit because metrics show
 	// that payload size for deployment_status webhooks maxes out at 13KB.
-	webhookPayload: WebhookPayloadDeploymentStatus,
+	webhookPayload: DeploymentStatusEvent,
 	rateLimited?: boolean
 }
 

--- a/src/sync/deployment.ts
+++ b/src/sync/deployment.ts
@@ -1,5 +1,5 @@
 import { Repository } from "models/subscription";
-import { WebhookPayloadDeploymentStatus } from "@octokit/webhooks";
+import type { DeploymentStatusEvent } from "@octokit/webhooks-types";
 import { GitHubInstallationClient } from "../github/client/github-installation-client";
 import { getDeploymentsResponse, DeploymentQueryNode } from "../github/client/github-queries";
 import Logger from "bunyan";
@@ -41,7 +41,8 @@ const getTransformedDeployments = async (deployments, gitHubInstallationClient: 
 				updated_at: deployment.latestStatus?.updatedAt,
 				state: deployment.latestStatus?.state
 			}
-		} as WebhookPayloadDeploymentStatus;
+		} as DeploymentStatusEvent;
+
 		const metrics = {
 			trigger: "backfill",
 			subTrigger: "deployment"

--- a/src/transforms/transform-branch.ts
+++ b/src/transforms/transform-branch.ts
@@ -1,7 +1,7 @@
 import { getJiraId } from "../jira/util/id";
 import { getJiraAuthor, jiraIssueKeyParser, limitCommitMessage } from "utils/jira-utils";
 import { isEmpty } from "lodash";
-import { WebhookPayloadCreate } from "@octokit/webhooks";
+import type { CreateEvent } from "@octokit/webhooks-types";
 import { generateCreatePullRequestUrl } from "./util/pull-request-link-generator";
 import { GitHubInstallationClient } from "../github/client/github-installation-client";
 import { JiraBranchBulkSubmitData, JiraCommit } from "src/interfaces/jira";
@@ -9,7 +9,7 @@ import { getLogger } from "config/logger";
 import Logger from "bunyan";
 import { transformRepositoryDevInfoBulk } from "~/src/transforms/transform-repository";
 
-const getLastCommit = async (github: GitHubInstallationClient, webhookPayload: WebhookPayloadCreate, issueKeys: string[]): Promise<JiraCommit> => {
+const getLastCommit = async (github: GitHubInstallationClient, webhookPayload: CreateEvent, issueKeys: string[]): Promise<JiraCommit> => {
 	const { data: { object: { sha } } } = await github.getRef(webhookPayload.repository.owner.login, webhookPayload.repository.name, `heads/${webhookPayload.ref}`);
 	const { data: { commit, author, html_url: url } } = await github.getCommit(webhookPayload.repository.owner.login, webhookPayload.repository.name, sha);
 
@@ -27,7 +27,7 @@ const getLastCommit = async (github: GitHubInstallationClient, webhookPayload: W
 	};
 };
 
-export const transformBranch = async (gitHubInstallationClient: GitHubInstallationClient, webhookPayload: WebhookPayloadCreate, logger: Logger = getLogger("transform-branch")): Promise<JiraBranchBulkSubmitData | undefined> => {
+export const transformBranch = async (gitHubInstallationClient: GitHubInstallationClient, webhookPayload: CreateEvent, logger: Logger = getLogger("transform-branch")): Promise<JiraBranchBulkSubmitData | undefined> => {
 	if (webhookPayload.ref_type !== "branch") {
 		return;
 	}

--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -1,6 +1,6 @@
 import Logger from "bunyan";
 import { JiraAssociation, JiraDeploymentBulkSubmitData } from "interfaces/jira";
-import { WebhookPayloadDeploymentStatus } from "@octokit/webhooks";
+import type { DeploymentStatusEvent } from "@octokit/webhooks-types";
 import { Octokit } from "@octokit/rest";
 import {
 	CommitSummary,
@@ -295,7 +295,7 @@ const mapJiraIssueIdsCommitsAndServicesToAssociationArray = (
 
 export const transformDeployment = async (
 	githubInstallationClient: GitHubInstallationClient,
-	payload: WebhookPayloadDeploymentStatus,
+	payload: DeploymentStatusEvent,
 	jiraHost: string,
 	type: "backfill" | "webhook",
 	metrics: {trigger: string, subTrigger?: string},

--- a/yarn.lock
+++ b/yarn.lock
@@ -831,12 +831,10 @@
   dependencies:
     "@octokit/openapi-types" "^7.2.3"
 
-"@octokit/webhooks@6.3.2":
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-6.3.2.tgz#72e940a0a1d19bd5afc2002d2a656dc1233c69df"
-  integrity sha512-qirhkNoOWwQF0IHZ+9nobfcM/LMRhsJ2FUrexzzJZIDTXLAGZLVpUnXUZ86hSlYfCluyTccIFOz+SFFzodft0g==
-  dependencies:
-    debug "^4.0.0"
+"@octokit/webhooks-types@^6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks-types/-/webhooks-types-6.11.0.tgz#1fb903bff3f2883490d6ba88d8cb8f8a55f68176"
+  integrity sha512-AanzbulOHljrku1NGfafxdpTCfw2ENaWzH01N2vqQM+cUFbk868Cgh0xylz0JIM9BoKbfI++bdD6EYX0Q/UTEw==
 
 "@playwright/test@^1.33.0":
   version "1.33.0"
@@ -2441,13 +2439,6 @@ debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
-  dependencies:
-    ms "2.1.2"
-
-debug@^4.0.0:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 


### PR DESCRIPTION
**What's in this PR?**
- Upgrade `@octokit/webhooks` to the latest `@octokit/webhooks-types`

**Why**
- Existing types are outdated. E.g. see #2132

**Added feature flags**
- No

**Affected issues**  
- None

**How has this been tested?**  
- Since this is a TypeScript-only change, as long as the build passes it should be safe

**Whats Next?**
- nothing?