### PR TITLE
ARC-2103 - Getting unauthorised when clicking on Connect a GitHub Organization in the list of Applications for Reversed Proxy Servers 

### DIFF
--- a/static/js/jira-configuration.js
+++ b/static/js/jira-configuration.js
@@ -150,7 +150,10 @@ $('.jiraConfiguration__option').click(function (event) {
 
 $(".jiraConfiguration__connectNewApp").click((event) => {
 	event.preventDefault();
-	openChildWindow(`/github/${$(event.target).data("app-uuid")}/configuration`);
+	window.AP.context.getToken(function(token) {
+		const child = openChildWindow(`/session/github/${$(event.target).data("app-uuid")}/configuration?ghRedirect=to`);
+		child.window.jwt = token;
+	});
 });
 
 const syncStatusBtn = document.getElementById("sync-status-modal-btn");


### PR DESCRIPTION
**What's in this PR?**
- Got rid of the ugly "Unauthorised" screen by updating the URL for **Connect a GitHub Organization**.

**Why**
-  The users were getting a blank Unauthorised screen when trying to click on the link **Connect a GitHub Organization** when the token was not available (e.g. opening in private window).

**How has this been tested?**  
- Local

**Video**

https://github.com/atlassian/github-for-jira/assets/13076255/fe35c008-1d1c-484e-9fa7-841dd0fb43c7

