### PR TITLE
Adding log for `resetGithubToken`

### DIFF
--- a/src/routes/github/github-oauth-router.ts
+++ b/src/routes/github/github-oauth-router.ts
@@ -147,6 +147,7 @@ export const GithubAuthMiddleware = async (req: Request, res: Response, next: Ne
 			delete query["resetGithubToken"];
 
 			const newUrl = originalUrl.split("?")[0] + "?" + queryToQueryString(query);
+			req.log.info("Github Token reset for URL: ", newUrl);
 			return res.redirect(newUrl);
 		}
 


### PR DESCRIPTION
**What's in this PR?**
- Adding a log to know if the users are clicking on the reset link with the reset parameter `resetGithubToken`

**Why**
- Due to the lack of event tracking in the frontend, adding logs so that we can have some info.