### PR TITLE
NONE: show only connected repos on create-branch page

### DIFF
--- a/src/routes/github/create-branch/github-create-branch-get.test.ts
+++ b/src/routes/github/create-branch/github-create-branch-get.test.ts
@@ -5,6 +5,27 @@ import { generateSignedSessionCookieHeader } from "test/utils/cookies";
 import { Subscription } from "models/subscription";
 import { GetRepositoriesQuery } from "~/src/github/client/github-queries";
 import { generateBranchName } from "routes/github/create-branch/github-create-branch-get";
+import reposFixture from "fixtures/api/graphql/repositories.json";
+import _ from "lodash";
+import { RepoSyncState } from "models/reposyncstate";
+
+const REPOS_FIXTURE_EXPANDED = _.cloneDeep(reposFixture);
+REPOS_FIXTURE_EXPANDED.data.viewer.repositories.edges = [];
+for (let i = 0; i < 100; i++) {
+	REPOS_FIXTURE_EXPANDED.data.viewer.repositories.edges.push({
+		node: {
+			id: 1000 + i,
+			name: "SampleRepo" + i,
+			full_name: "user1/SampleRepo" + i,
+			owner: {
+				login: "user1"
+			},
+			html_url: "https://github.com/user1/SampleRepo" + i,
+			updated_at: new Date(i * 1000).toISOString()
+		}
+	});
+}
+REPOS_FIXTURE_EXPANDED.data.viewer.repositories.totalCount = REPOS_FIXTURE_EXPANDED.data.viewer.repositories.edges.length;
 
 describe("GitHub Create Branch Get", () => {
 	let app: Application;
@@ -18,34 +39,76 @@ describe("GitHub Create Branch Get", () => {
 		app.use(getFrontendApp());
 	});
 	describe("Testing the GET route", () => {
+		let subscription: Subscription;
 		beforeEach(async () => {
-			await Subscription.create({
+			subscription = await Subscription.create({
 				gitHubInstallationId,
 				jiraHost
 			});
+			// eslint-disable-next-line no-console
+			console.log(subscription);
 		});
 
-		it("should hit the create branch on GET if authorized", async () => {
+		describe("happy path supertest", () => {
+			beforeEach(async () => {
+				githubNock
+					.post(`/app/installations/${gitHubInstallationId}/access_tokens`)
+					.reply(200);
 
-			githubNock
-				.post(`/app/installations/${gitHubInstallationId}/access_tokens`)
-				.reply(200);
+				githubNock
+					.post("/graphql", { query: GetRepositoriesQuery, variables: { per_page: 100, order_by: "UPDATED_AT" } })
+					.reply(200, REPOS_FIXTURE_EXPANDED);
+			});
 
-			githubNock
-				.post("/graphql", { query: GetRepositoriesQuery, variables: { per_page: 20, order_by: "UPDATED_AT" } })
-				.reply(200, { data: { viewer: { repositories: { edges: [] } } } });
+			it("should hit the create branch on GET if authorized", async () => {
+				const response = await supertest(app)
+					.get("/github/create-branch").set(
+						"Cookie",
+						generateSignedSessionCookieHeader({
+							jiraHost,
+							githubToken: "random-token"
+						}));
 
-			await supertest(app)
-				.get("/github/create-branch").set(
-					"Cookie",
-					generateSignedSessionCookieHeader({
-						jiraHost,
-						githubToken: "random-token"
-					}))
-				.expect(res => {
-					expect(res.status).toBe(200);
-					expect(res.text).toContain("<div class=\"gitHubCreateBranch__header\">Create GitHub Branch</div>");
-				});
+				expect(response.status).toBe(200);
+				expect(response.text).toContain("<div class=\"gitHubCreateBranch__header\">Create GitHub Branch</div>");
+			});
+
+			it("should limit the number of repos to 20", async () => {
+				await Promise.all(REPOS_FIXTURE_EXPANDED.data.viewer.repositories.edges.map(async (edge) =>
+					RepoSyncState.create({
+						subscriptionId: subscription.id,
+						repoId: edge.node.id,
+						repoName: edge.node.name,
+						repoOwner: edge.node.owner.login,
+						repoFullName: edge.node.full_name,
+						repoUrl: edge.node.html_url
+					})
+				));
+				const response = await supertest(app)
+					.get("/github/create-branch").set(
+						"Cookie",
+						generateSignedSessionCookieHeader({
+							jiraHost,
+							githubToken: "random-token"
+						}));
+
+				expect(response.status).toBe(200);
+				expect(response.text.split("SampleRepo")).toHaveLength(21); // not 20 because this is how .spit() works
+			});
+
+			it("should exclude repos that are not connected", async () => {
+				const response = await supertest(app)
+					.get("/github/create-branch").set(
+						"Cookie",
+						generateSignedSessionCookieHeader({
+							jiraHost,
+							githubToken: "random-token"
+						}));
+
+				expect(response.status).toBe(200);
+				expect(response.text).not.toContain("hidden default-repos");
+				expect(response.text).not.toContain("SampleRepo");
+			});
 		});
 	});
 

--- a/src/routes/github/create-branch/github-create-branch-get.ts
+++ b/src/routes/github/create-branch/github-create-branch-get.ts
@@ -7,6 +7,7 @@ import { Repository, Subscription } from "models/subscription";
 import Logger from "bunyan";
 import { getLogger } from "config/logger";
 import { envVars } from "config/env";
+import { RepoSyncState } from "models/reposyncstate";
 const MAX_REPOS_RETURNED = 20;
 
 export const GithubCreateBranchGet = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
@@ -109,8 +110,13 @@ const getReposBySubscriptions = async (subscriptions: Subscription[], logger: Lo
 	const repoTasks = subscriptions.map(async (subscription) => {
 		try {
 			const gitHubInstallationClient = await createInstallationClient(subscription.gitHubInstallationId, jiraHost, { trigger: "github-create-branch" }, logger, subscription.gitHubAppId);
-			const response = await gitHubInstallationClient.getRepositoriesPage(MAX_REPOS_RETURNED, undefined, "UPDATED_AT");
-			return response.viewer.repositories.edges;
+			const response = await gitHubInstallationClient.getRepositoriesPage(100, undefined, "UPDATED_AT");
+			// The app can be installed in a GitHub org but that org might not be connected to Jira, therefore we must filter them out, or
+			// the next steps (e.g. get repo branches to branch of) will fail
+			const subscriptionRepos = await RepoSyncState.findAllFromSubscription(subscription);
+			const subscriptionRepoIds = new Set(subscriptionRepos.map(repo => repo.repoId));
+			const filteredRepos =  response.viewer.repositories.edges.filter(edge => subscriptionRepoIds.has(edge.node.id));
+			return filteredRepos.slice(0, MAX_REPOS_RETURNED);
 		} catch (err) {
 			logger.error({ err }, "Create branch - Failed to fetch repos for installation");
 			throw err;

--- a/test/fixtures/api/graphql/repositories.json
+++ b/test/fixtures/api/graphql/repositories.json
@@ -1,0 +1,39 @@
+{
+	"data": {
+		"viewer": {
+			"repositories": {
+				"totalCount": 2,
+				"pageInfo": {
+					"endCursor": "Y3Vyc29yOnYyOpK5MjAyMS0wOS0wNVQyMDozMTo1NSswMDowMM4wrst8",
+					"hasNextPage": false
+				},
+				"edges": [
+					{
+						"node": {
+							"id": 123456789,
+							"name": "SampleRepo1",
+							"full_name": "user1/SampleRepo1",
+							"owner": {
+								"login": "user1"
+							},
+							"html_url": "https://github.com/user1/SampleRepo1",
+							"updated_at": "2022-10-10T20:31:55Z"
+						}
+					},
+					{
+						"node": {
+							"id": 987654321,
+							"name": "SampleRepo2",
+							"full_name": "user2/SampleRepo2",
+							"owner": {
+								"login": "user2"
+							},
+							"html_url": "https://github.com/user2/SampleRepo2",
+							"updated_at": "2022-10-10T19:30:45Z"
+						}
+					}
+				]
+			}
+		}
+	}
+}


### PR DESCRIPTION
**What's in this PR?**
On create-branch, show only connected repos

**Why**
Otherwise the next call will fail (see this line: https://github.com/atlassian/github-for-jira/blob/b38d0b426569351c3d6fdcaacff668eab44226d6/src/routes/github/create-branch/github-branches-get.ts#L27-L27

**Added feature flags**
🤠 

**Affected issues**  
disturbed

**How has this been tested?**  
locally, tests

**Whats Next?**
moar disturbed
