### PR TITLE
NONE: allow OAuth tail to finish for non-jira-admins

### DIFF
--- a/src/github/client/key-locator.ts
+++ b/src/github/client/key-locator.ts
@@ -7,9 +7,9 @@ import isBase64 from "is-base64";
 /**
  * Look for a Github app's private key
  */
-export const keyLocator = async (gitHubAppId: number | undefined, jiraHost: string): Promise<string> => {
-	if (gitHubAppId) {
-		const gitHubServerApp = await GitHubServerApp.getForGitHubServerAppId(gitHubAppId);
+export const keyLocator = async (gitHubServerAppIdPk: number | undefined, jiraHost: string): Promise<string> => {
+	if (gitHubServerAppIdPk) {
+		const gitHubServerApp = await GitHubServerApp.getByIdPk(gitHubServerAppIdPk);
 		if (gitHubServerApp) {
 			return await gitHubServerApp.getDecryptedPrivateKey(jiraHost);
 		}
@@ -35,6 +35,6 @@ export const keyLocator = async (gitHubAppId: number | undefined, jiraHost: stri
 			}
 		}
 	}
-	throw new Error(`Private key doesn not found for Github app ${gitHubAppId}`);
+	throw new Error(`Private key doesn not found for Github app ${gitHubServerAppIdPk}`);
 };
 

--- a/src/middleware/github-server-app-middleware.ts
+++ b/src/middleware/github-server-app-middleware.ts
@@ -35,11 +35,11 @@ export const GithubServerAppMiddleware = async (req: Request, res: Response, nex
 
 		req.log.info("Found server app for installation. Defining GitHub app config for GitHub Enterprise Server.");
 
-		//TODO: ARC-1515 decide how to put `gitHubAppId ` inside `gitHubAppConfig`
+		//TODO: we should kill the duplicate thing
 		res.locals.gitHubAppId = gitHubServerApp.id;
 		res.locals.gitHubAppConfig = {
-			gitHubAppId: gitHubServerApp.id,
-			appId: gitHubServerApp.appId,
+			gitHubAppId: gitHubServerApp.id, // TODO: This should be renamed to gitHubServerAppIdPk
+			appId: gitHubServerApp.appId, // TODO: should be renamed to gitHubAppId
 			uuid: gitHubServerApp.uuid,
 			hostname: gitHubServerApp.gitHubBaseUrl,
 			clientId: gitHubServerApp.gitHubClientId

--- a/src/models/github-server-app.ts
+++ b/src/models/github-server-app.ts
@@ -43,7 +43,7 @@ type SECRETE_FIELD = "gitHubClientSecret" | "webhookSecret" | "privateKey" | "en
 export class GitHubServerApp extends Model {
 	id: number;
 	uuid: string;
-	appId: number;
+	appId: number; // TODO: rename to gitHubAppId
 	gitHubBaseUrl: string;
 	gitHubClientId: string;
 	gitHubClientSecret: string; // TODO: rename column to prefix with "encrypted"
@@ -107,16 +107,16 @@ export class GitHubServerApp extends Model {
 		return { jiraHost };
 	}
 
-	static async getForGitHubServerAppId(
-		gitHubServerAppId: number
+	static async getByIdPk(
+		idPk: number
 	): Promise<GitHubServerApp | null> {
-		if (!gitHubServerAppId) {
+		if (!idPk) {
 			return null;
 		}
 
 		return this.findOne({
 			where: {
-				id: gitHubServerAppId
+				id: idPk
 			}
 		});
 	}

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -41,7 +41,7 @@ export class Subscription extends Model {
 	numberOfSyncedRepos?: number;
 	repositoryCursor?: string;
 	repositoryStatus?: TaskStatus;
-	gitHubAppId: number | undefined;
+	gitHubAppId: number | undefined; // TODO: rename  to gitHubServerAppIdPk, that's GitHubSubscription::id (primary key)
 
 	static async getAllForHost(jiraHost: string, gitHubAppId?: number): Promise<Subscription[]> {
 		return this.findAll({

--- a/src/routes/github/create-branch/github-create-branch-options-get.ts
+++ b/src/routes/github/create-branch/github-create-branch-options-get.ts
@@ -89,7 +89,7 @@ const getGitHubServers = async (jiraHost: string) => {
 	const gheServerInfos = new Array<{ uuid: string, baseUrl: string, appName: string }>();
 	for (const gitHubAppId of uniqueGithubAppIds) {
 		if (gitHubAppId) {
-			const gitHubServerApp = await GitHubServerApp.getForGitHubServerAppId(gitHubAppId);
+			const gitHubServerApp = await GitHubServerApp.getByIdPk(gitHubAppId);
 			if (gitHubServerApp) {
 				gheServerInfos.push({
 					"uuid": gitHubServerApp.uuid,

--- a/src/routes/github/github-oauth.test.ts
+++ b/src/routes/github/github-oauth.test.ts
@@ -83,14 +83,15 @@ describe("github-oauth", () => {
 				gitHubServerApp = await DatabaseStateCreator.createServerApp(installation.id);
 			});
 
-			it("populates session with github token", async () => {
+			it("populates session with github token, refresh token and server UUID", async () => {
 				const nockUrl = `/login/oauth/access_token?client_id=${gitHubServerApp.gitHubClientId}&client_secret=${await gitHubServerApp.getDecryptedGitHubClientSecret(jiraHost)}&code=barCode&state=fooState`;
 				nock(gitHubServerApp.gitHubBaseUrl)
 					.get(nockUrl)
 					.matchHeader("accept", "application/json")
 					.matchHeader("content-type", "application/json")
 					.reply(200, {
-						access_token: "behold!"
+						access_token: "behold!",
+						refresh_token: "my-refresh-token"
 					});
 
 				const app = await getFrontendApp();
@@ -112,6 +113,8 @@ describe("github-oauth", () => {
 				const { session } = parseCookiesAndSession(response);
 				expect(response.status).toEqual(302);
 				expect(session["githubToken"]).toStrictEqual("behold!");
+				expect(session["githubRefreshToken"]).toStrictEqual("my-refresh-token");
+				expect(session["gitHubUuid"]).toStrictEqual(gitHubServerApp.uuid);
 				expect(response.headers.location).toEqual("/my-redirect");
 			});
 		});

--- a/src/routes/github/github-oauth.test.ts
+++ b/src/routes/github/github-oauth.test.ts
@@ -156,10 +156,15 @@ describe("github-oauth", () => {
 					);
 				const session = parseCookiesAndSession(response).session!;
 				const state = Object.entries(session).find((keyValue) =>
-					keyValue[1] instanceof Object && keyValue[1]["postLoginRedirectUrl"] === "/github/configuration?"
+					keyValue[1] instanceof Object && keyValue[1]["postLoginRedirectUrl"]
 				)![0];
 				expect(state.length).toBeGreaterThan(6);
 				expect(response.status).toEqual(302);
+				expect(session[state]).toStrictEqual({
+					installationIdPk: installation.id,
+					postLoginRedirectUrl: "/github/configuration?",
+					gitHubClientId: envVars.GITHUB_CLIENT_ID
+				});
 				expect(response.headers.location).toStrictEqual(
 					`https://github.com/login/oauth/authorize?client_id=${
 						envVars.GITHUB_CLIENT_ID
@@ -188,10 +193,16 @@ describe("github-oauth", () => {
 					);
 				const session = parseCookiesAndSession(response).session!;
 				const state = Object.entries(session).find((keyValue) =>
-					keyValue[1] instanceof Object && keyValue[1]["postLoginRedirectUrl"] === "/github/configuration?"
+					keyValue[1] instanceof Object && keyValue[1]["postLoginRedirectUrl"]
 				)![0];
 				expect(state.length).toBeGreaterThan(6);
 				expect(response.status).toEqual(302);
+				expect(session[state]).toStrictEqual({
+					installationIdPk: installation.id,
+					postLoginRedirectUrl: "/github/configuration?",
+					gitHubClientId: gitHubServerApp.gitHubClientId,
+					gitHubServerUuid: gitHubServerApp.uuid
+				});
 				expect(response.headers.location).toStrictEqual(
 					`${gitHubServerApp.gitHubBaseUrl}/login/oauth/authorize?client_id=${
 						gitHubServerApp.gitHubClientId

--- a/src/routes/github/github-oauth.ts
+++ b/src/routes/github/github-oauth.ts
@@ -16,8 +16,7 @@ import { Installation } from "models/installation";
 const logger = getLogger("github-oauth");
 const appUrl = envVars.APP_URL;
 export const OAUTH_CALLBACK_SUBPATH = "/callback";
-const callbackPathCloud = `/github${OAUTH_CALLBACK_SUBPATH}`;
-const callbackPathServer = `/github/<uuid>${OAUTH_CALLBACK_SUBPATH}`;
+const fullCallbackPath = `/github${OAUTH_CALLBACK_SUBPATH}`;
 
 interface OAuthState {
 	postLoginRedirectUrl: string;
@@ -27,17 +26,11 @@ interface OAuthState {
 }
 
 const getRedirectUrl = async (res: Response, state: string) => {
-	// TODO: revert this logic and calculate redirect URL from req once create branch supports JWT and GitHubAuthMiddleware is a router-level middleware again
-	let callbackPath = callbackPathCloud;
-	if (res.locals?.gitHubAppConfig?.uuid) {
-		callbackPath = callbackPathServer.replace("<uuid>", res.locals.gitHubAppConfig.uuid);
-	}
-
 	const definedScopes = await stringFlag(StringFlags.GITHUB_SCOPES, "user,repo", res.locals.jiraHost);
 	const scopes = definedScopes.split(",");
 
 	const { hostname, clientId } = res.locals.gitHubAppConfig;
-	const callbackURI = `${appUrl}${callbackPath}`;
+	const callbackURI = `${appUrl}${fullCallbackPath}`;
 	return `${hostname}/login/oauth/authorize?client_id=${clientId}&scope=${encodeURIComponent(scopes.join(" "))}&redirect_uri=${encodeURIComponent(callbackURI)}&state=${state}`;
 };
 

--- a/src/routes/github/github-oauth.ts
+++ b/src/routes/github/github-oauth.ts
@@ -56,7 +56,7 @@ export const GithubOAuthLoginGet = async (req: Request, res: Response): Promise<
 		`/github/configuration${parsedOriginalUrl.search || ""}`,
 		installationIdPk: res.locals.installation.id,
 		gitHubServerUuid: res.locals.gitHubAppConfig.uuid,
-		gitHubClientId: res.locals.gitHubAppConfig.gitHubClientId
+		gitHubClientId: res.locals.gitHubAppConfig.clientId
 	};
 
 	req.session[stateKey] = state;

--- a/src/routes/github/github-oauth.ts
+++ b/src/routes/github/github-oauth.ts
@@ -146,7 +146,7 @@ export const GithubOAuthCallbackGet = async (req: Request, res: Response, next: 
 		req.session.githubRefreshToken = refreshToken;
 
 		// Saving UUID for each GitHubServerApp
-		req.session.gitHubUuid = uuid;
+		req.session.gitHubUuid = state.gitHubServerUuid;
 
 		if (!req.session.githubToken) {
 			req.log.debug(`didn't get access token from GitHub`);

--- a/src/routes/github/github-router.test.ts
+++ b/src/routes/github/github-router.test.ts
@@ -6,7 +6,7 @@ import { GitHubServerApp } from "models/github-server-app";
 import { Installation } from "models/installation";
 import { v4 as v4uuid } from "uuid";
 import { envVars } from "config/env";
-import { generateSignedSessionCookieHeader } from "test/utils/cookies";
+import { findOAuthStateInSession, generateSignedSessionCookieHeader, parseCookiesAndSession } from "test/utils/cookies";
 import { when } from "jest-when";
 import { stringFlag, StringFlags } from "config/feature-flags";
 import * as cookie from "cookie";
@@ -101,22 +101,28 @@ describe("GitHub router", () => {
 				when(stringFlag)
 					.calledWith(StringFlags.GITHUB_SCOPES, expect.anything(), jiraHost)
 					.mockResolvedValue(TESTING_SCOPES);
-				await supertest(app)
+				const response = await supertest(app)
 					.get(`/github/configuration`)
+					.set("x-forwarded-proto", "https") // otherwise cookies won't be returned cause they are "secure"
 					.set(
 						"Cookie",
 						generateSignedSessionCookieHeader({
 							jiraHost
 						})
-					)
-					.expect(302)
-					.then((response) => {
-						const resultUrl = response.headers.location;
-						const resultUrlWithoutState = resultUrl.split("&state")[0];// Ignoring state here cause state is different everytime
-						const redirectUrl = `${envVars.APP_URL}/github/callback`;
-						const expectedUrlWithoutState = `https://github.com/login/oauth/authorize?client_id=${envVars.GITHUB_CLIENT_ID}&scope=scope1%20scope2&redirect_uri=${encodeURIComponent(redirectUrl)}`;
-						expect(resultUrlWithoutState).toEqual(expectedUrlWithoutState);
-					});
+					);
+
+				expect(response.statusCode).toStrictEqual(302);
+
+				const resultUrl = response.headers.location;
+				const resultUrlWithoutState = resultUrl.split("&state")[0];// Ignoring state here cause state is different everytime
+				const redirectUrl = `${envVars.APP_URL}/github/callback`;
+				const expectedUrlWithoutState = `https://github.com/login/oauth/authorize?client_id=${envVars.GITHUB_CLIENT_ID}&scope=scope1%20scope2&redirect_uri=${encodeURIComponent(redirectUrl)}`;
+
+				expect(resultUrlWithoutState).toEqual(expectedUrlWithoutState);
+
+				const { session } = parseCookiesAndSession(response);
+				const oauthState = findOAuthStateInSession(session) as any;
+				expect(oauthState["postLoginRedirectUrl"]).toStrictEqual(`/github/configuration`);
 			});
 			it("should skip uuid when absent", async () => {
 				setupGitHubCloudPingNock();
@@ -206,44 +212,55 @@ describe("GitHub router", () => {
 				mockConfigurationGetProceed();
 			});
 			it("testing the redirect URL in GithubOAuthLoginGet middleware when FF is off", async () => {
-				await supertest(app)
+				const response = await supertest(app)
 					.get(`/github/${GITHUB_SERVER_APP_UUID}/configuration`)
+					.set("x-forwarded-proto", "https") // otherwise cookies won't be returned cause they are "secure"
 					.set(
 						"Cookie",
 						generateSignedSessionCookieHeader({
 							jiraHost
 						})
-					)
-					.expect(302)
-					.then((response) => {
-						const resultUrl = response.headers.location;
-						const resultUrlWithoutState = resultUrl.split("&state")[0];// Ignoring state here cause state is different everytime
-						const redirectUrl = `${envVars.APP_URL}/github/${GITHUB_SERVER_APP_UUID}/callback`;
-						const expectedUrlWithoutState = `${gheUrl}/login/oauth/authorize?client_id=${GITHUB_SERVER_CLIENT_ID}&scope=user%20repo&redirect_uri=${encodeURIComponent(redirectUrl)}`;
-						expect(resultUrlWithoutState).toEqual(expectedUrlWithoutState);
-					});
+					);
+
+				expect(response.statusCode).toStrictEqual(302);
+				const resultUrl = response.headers.location;
+				const resultUrlWithoutState = resultUrl.split("&state")[0];// Ignoring state here cause state is different everytime
+				const redirectUrl = `${envVars.APP_URL}/github/callback`;
+				const expectedUrlWithoutState = `${gheUrl}/login/oauth/authorize?client_id=${GITHUB_SERVER_CLIENT_ID}&scope=user%20repo&redirect_uri=${encodeURIComponent(redirectUrl)}`;
+				expect(resultUrlWithoutState).toEqual(expectedUrlWithoutState);
+
+				const { session } = parseCookiesAndSession(response);
+				const oauthState = findOAuthStateInSession(session) as any;
+				expect(oauthState["postLoginRedirectUrl"]).toStrictEqual(`/github/${GITHUB_SERVER_APP_UUID}/configuration`);
 			});
+
 			it("testing the redirect URL in GithubOAuthLoginGet middleware when FF is on", async () => {
 				when(stringFlag)
 					.calledWith(StringFlags.GITHUB_SCOPES, expect.anything(), jiraHost)
 					.mockResolvedValue(TESTING_SCOPES);
-				await supertest(app)
+				const response = await supertest(app)
 					.get(`/github/${GITHUB_SERVER_APP_UUID}/configuration`)
+					.set("x-forwarded-proto", "https") // otherwise cookies won't be returned cause they are "secure"
 					.set(
 						"Cookie",
 						generateSignedSessionCookieHeader({
 							jiraHost
 						})
-					)
-					.expect(302)
-					.then((response) => {
-						const resultUrl = response.headers.location;
-						const resultUrlWithoutState = resultUrl.split("&state")[0];// Ignoring state here cause state is different everytime
-						const redirectUrl = `${envVars.APP_URL}/github/${GITHUB_SERVER_APP_UUID}/callback`;
-						const expectedUrlWithoutState = `${gheUrl}/login/oauth/authorize?client_id=${GITHUB_SERVER_CLIENT_ID}&scope=scope1%20scope2&redirect_uri=${encodeURIComponent(redirectUrl)}`;
-						expect(resultUrlWithoutState).toEqual(expectedUrlWithoutState);
-					});
+					);
+
+				expect(response.status).toStrictEqual(302);
+
+				const resultUrl = response.headers.location;
+				const resultUrlWithoutState = resultUrl.split("&state")[0];// Ignoring state here cause state is different everytime
+				const redirectUrl = `${envVars.APP_URL}/github/callback`;
+				const expectedUrlWithoutState = `${gheUrl}/login/oauth/authorize?client_id=${GITHUB_SERVER_CLIENT_ID}&scope=scope1%20scope2&redirect_uri=${encodeURIComponent(redirectUrl)}`;
+				expect(resultUrlWithoutState).toEqual(expectedUrlWithoutState);
+
+				const { session } = parseCookiesAndSession(response);
+				const oauthState = findOAuthStateInSession(session) as any;
+				expect(oauthState["postLoginRedirectUrl"]).toStrictEqual(`/github/${GITHUB_SERVER_APP_UUID}/configuration`);
 			});
+
 			it("should extract uuid when present", async () => {
 				setupGHEPingNock();
 				await supertest(app)

--- a/src/routes/github/github-router.ts
+++ b/src/routes/github/github-router.ts
@@ -23,13 +23,7 @@ import { jiraAdminPermissionsMiddleware } from "middleware/jira-admin-permission
 
 export const GithubRouter = Router();
 const subRouter = Router({ mergeParams: true });
-GithubRouter.use(`/:uuid(${UUID_REGEX})?`, subRouter);
 
-// Webhook Route
-subRouter.post("/webhooks",
-	header(["x-github-event", "x-hub-signature-256", "x-github-delivery"]).exists(),
-	returnOnValidationError,
-	WebhookReceiverPost);
 
 // We want to restrict the tail of OAuth flow to the same scope as the starting point had (where GitHubOAuthMiddleware
 // fired), therefore we are not including neither jira*middlewares nor github*middlewares. GithubOAuthCallbackGet will
@@ -38,6 +32,14 @@ subRouter.post("/webhooks",
 // We don't want to artificially limit ourselves by including those middlewares, because there are scenarios when
 // OAuth flow was triggered outside of Jira admin scope (e.g. create-branch, or approve-connection).
 subRouter.use(OAUTH_CALLBACK_SUBPATH, GithubOAuthCallbackGet);
+
+GithubRouter.use(`/:uuid(${UUID_REGEX})?`, subRouter);
+
+// Webhook Route
+subRouter.post("/webhooks",
+	header(["x-github-event", "x-hub-signature-256", "x-github-delivery"]).exists(),
+	returnOnValidationError,
+	WebhookReceiverPost);
 
 subRouter.use(jiraSymmetricJwtMiddleware);
 subRouter.use(GithubServerAppMiddleware);

--- a/src/routes/github/github-router.ts
+++ b/src/routes/github/github-router.ts
@@ -1,5 +1,9 @@
 import { Router } from "express";
-import { GithubAuthMiddleware, GithubOAuthRouter } from "./github-oauth-router";
+import {
+	GithubAuthMiddleware,
+	GithubOAuthCallbackGet, GithubOAuthLoginGet,
+	OAUTH_CALLBACK_SUBPATH
+} from "./github-oauth";
 import { csrfMiddleware } from "middleware/csrf-middleware";
 import { GithubSubscriptionRouter } from "./subscription/github-subscription-router";
 import { GithubSetupRouter } from "routes/github/setup/github-setup-router";
@@ -27,6 +31,14 @@ subRouter.post("/webhooks",
 	returnOnValidationError,
 	WebhookReceiverPost);
 
+// We want to restrict the tail of OAuth flow to the same scope as the starting point had (where GitHubOAuthMiddleware
+// fired), therefore we are not including neither jira*middlewares nor github*middlewares. GithubOAuthCallbackGet will
+// get all the data needed from session to obtain the token and then redirect to the original URL with all the
+// restrictions that are in place there.
+// We don't want to artificially limit ourselves by including those middlewares, because there are scenarios when
+// OAuth flow was triggered outside of Jira admin scope (e.g. create-branch, or approve-connection).
+subRouter.use(OAUTH_CALLBACK_SUBPATH, GithubOAuthCallbackGet);
+
 subRouter.use(jiraSymmetricJwtMiddleware);
 subRouter.use(GithubServerAppMiddleware);
 
@@ -36,7 +48,7 @@ subRouter.use("/branch", csrfMiddleware, GithubBranchRouter);
 
 subRouter.use(jiraAdminPermissionsMiddleware); // This must stay after jiraSymmetricJwtMiddleware
 
-subRouter.use(GithubOAuthRouter);
+subRouter.use("/login",  GithubOAuthLoginGet);
 
 subRouter.post("/encrypt/header", GithubEncryptHeaderPost);
 

--- a/src/util/get-github-client-config.test.ts
+++ b/src/util/get-github-client-config.test.ts
@@ -4,7 +4,7 @@ import {
 	createAnonymousClient, createAppClient,
 	createInstallationClient,
 	createUserClient,
-	getGitHubClientConfigFromAppId
+	getGitHubClientConfigFromServerAppIdPk
 } from "utils/get-github-client-config";
 import { getLogger } from "config/logger";
 import { DatabaseStateCreator } from "test/utils/database-state-creator";
@@ -37,12 +37,12 @@ describe("get-github-client-config", () => {
 	});
 
 	it("does not skip proxy for GHES", async () => {
-		const config = await getGitHubClientConfigFromAppId(gitHubServerApp.id, jiraHost);
+		const config = await getGitHubClientConfigFromServerAppIdPk(gitHubServerApp.id, jiraHost);
 		expect(config.proxyBaseUrl).toEqual("http://proxy:8080");
 	});
 
 	it("does not skip proxy for GitHub cloud", async () => {
-		const config = await getGitHubClientConfigFromAppId(undefined, jiraHost);
+		const config = await getGitHubClientConfigFromServerAppIdPk(undefined, jiraHost);
 		expect(config.proxyBaseUrl).toEqual("http://proxy:8080");
 	});
 
@@ -51,13 +51,13 @@ describe("get-github-client-config", () => {
 		gitHubServerApp.encryptedApiKeyValue = "encrypted:super-db-key";
 		await gitHubServerApp.save();
 
-		const config = await getGitHubClientConfigFromAppId(gitHubServerApp.id, jiraHost);
+		const config = await getGitHubClientConfigFromServerAppIdPk(gitHubServerApp.id, jiraHost);
 		expect(config.apiKeyConfig!.headerName).toEqual("ApiKeyHeaderFromDb");
 		expect(await config.apiKeyConfig!.apiKeyGenerator()).toEqual("super-db-key");
 	});
 
 	it("does not include API key config when not provided", async () => {
-		const config = await getGitHubClientConfigFromAppId(gitHubServerApp.id, jiraHost);
+		const config = await getGitHubClientConfigFromServerAppIdPk(gitHubServerApp.id, jiraHost);
 		expect(config.apiKeyConfig).toBeUndefined();
 	});
 

--- a/src/util/get-github-client-config.ts
+++ b/src/util/get-github-client-config.ts
@@ -75,8 +75,8 @@ const buildGitHubClientCloudConfig = async (jiraHost: string): Promise<GitHubCli
 };
 
 // TODO: make private because it is only exported for testing (and must not be used in other places!)
-export const getGitHubClientConfigFromAppId = async (gitHubAppId: number | undefined, jiraHost: string): Promise<GitHubClientConfig> => {
-	const gitHubServerApp = gitHubAppId && await GitHubServerApp.getForGitHubServerAppId(gitHubAppId);
+export const getGitHubClientConfigFromServerAppIdPk = async (gitHubServerAppIdPk: number | undefined, jiraHost: string): Promise<GitHubClientConfig> => {
+	const gitHubServerApp = gitHubServerAppIdPk && await GitHubServerApp.getByIdPk(gitHubServerAppIdPk);
 	if (gitHubServerApp) {
 		return buildGitHubClientServerConfig(gitHubServerApp, jiraHost);
 	}
@@ -88,7 +88,7 @@ export const getGitHubClientConfigFromAppId = async (gitHubAppId: number | undef
  * get all installation or get more info for the app
  */
 export const createAppClient = async (logger: Logger, jiraHost: string, gitHubAppId: number | undefined, metrics: Metrics): Promise<GitHubAppClient> => {
-	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
+	const gitHubClientConfig = await getGitHubClientConfigFromServerAppIdPk(gitHubAppId, jiraHost);
 	return new GitHubAppClient(gitHubClientConfig, jiraHost, metrics, logger, gitHubClientConfig.appId.toString(), gitHubClientConfig.privateKey);
 };
 
@@ -96,16 +96,16 @@ export const createAppClient = async (logger: Logger, jiraHost: string, gitHubAp
  * Factory function to create a GitHub client that authenticates as the installation of our GitHub app to get
  * information specific to an organization.
  */
-export const createInstallationClient = async (gitHubInstallationId: number, jiraHost: string, metrics: Metrics, logger: Logger, gitHubAppId: number | undefined): Promise<GitHubInstallationClient> => {
-	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
+export const createInstallationClient = async (gitHubInstallationId: number, jiraHost: string, metrics: Metrics, logger: Logger, gitHubServerAppIdPk: number | undefined): Promise<GitHubInstallationClient> => {
+	const gitHubClientConfig = await getGitHubClientConfigFromServerAppIdPk(gitHubServerAppIdPk, jiraHost);
 	return new GitHubInstallationClient(getInstallationId(gitHubInstallationId, gitHubClientConfig.baseUrl, gitHubClientConfig.appId), gitHubClientConfig, jiraHost, metrics, logger, gitHubClientConfig.serverId);
 };
 
 /**
  * Factory function to create a GitHub client that authenticates as the user (with a user access token).
  */
-export const createUserClient = async (githubToken: string, jiraHost: string, metrics: Metrics, logger: Logger, gitHubAppId: number | undefined): Promise<GitHubUserClient> => {
-	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
+export const createUserClient = async (githubToken: string, jiraHost: string, metrics: Metrics, logger: Logger, gitHubServerAppIdPk: number | undefined): Promise<GitHubUserClient> => {
+	const gitHubClientConfig = await getGitHubClientConfigFromServerAppIdPk(gitHubServerAppIdPk, jiraHost);
 	return new GitHubUserClient(githubToken, gitHubClientConfig, jiraHost, metrics, logger);
 };
 
@@ -118,7 +118,7 @@ export const createAnonymousClient = async (
 ): Promise<GitHubAnonymousClient> =>
 	new GitHubAnonymousClient(await buildGitHubServerConfig(gitHubBaseUrl, apiKeyConfig), jiraHost, metrics, logger);
 
-export const createAnonymousClientByGitHubAppId = async (gitHubAppId: number | undefined, jiraHost: string, metrics: Metrics, logger: Logger): Promise<GitHubAnonymousClient> => {
-	const config = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
+export const createAnonymousClientByGitHubAppId = async (gitHubServerAppIdPk: number | undefined, jiraHost: string, metrics: Metrics, logger: Logger): Promise<GitHubAnonymousClient> => {
+	const config = await getGitHubClientConfigFromServerAppIdPk(gitHubServerAppIdPk, jiraHost);
 	return new GitHubAnonymousClient(config, jiraHost, metrics, logger);
 };

--- a/src/util/jira-utils.test.ts
+++ b/src/util/jira-utils.test.ts
@@ -134,7 +134,7 @@ describe("Jira Utils", () => {
 				privateKey: "myprivatekey",
 				installationId: 2
 			};
-			mocked(GitHubServerApp.getForGitHubServerAppId).mockResolvedValue(payload);
+			mocked(GitHubServerApp.getByIdPk).mockResolvedValue(payload);
 			expect(await isGitHubCloudApp(1)).toBeFalsy();
 		});
 	});

--- a/src/util/jira-utils.ts
+++ b/src/util/jira-utils.ts
@@ -112,5 +112,5 @@ export const jiraIssueKeyParser = (str: string): string[] => {
 export const hasJiraIssueKey = (str: string): boolean => !isEmpty(jiraIssueKeyParser(str));
 
 export const isGitHubCloudApp = async (gitHubAppId: number | undefined): Promise<boolean> => {
-	return !(gitHubAppId && await GitHubServerApp.getForGitHubServerAppId(gitHubAppId));
+	return !(gitHubAppId && await GitHubServerApp.getByIdPk(gitHubAppId));
 };

--- a/test/utils/cookies.ts
+++ b/test/utils/cookies.ts
@@ -24,3 +24,11 @@ export const parseCookiesAndSession = (response: Response): { cookies: any, sess
 	return { cookies: parsedCookies };
 };
 
+export const 	findOAuthStateInSession = (session: any) => Object.entries(session).find(keyValue =>
+	keyValue[1] instanceof Object && keyValue[1]["postLoginRedirectUrl"]
+)![1];
+
+export const 	findOAuthStateKeyInSession = (session: any) => Object.entries(session).find(keyValue =>
+	keyValue[1] instanceof Object && keyValue[1]["postLoginRedirectUrl"]
+)![0];
+


### PR DESCRIPTION
**What's in this PR?**
- Making OAuth flow "tail" to work without jwt & github middlewares

**Why**
- To implement org "approval" flow, we must allow non-Jira admins to get the user token.

**Added feature flags**
Nah

**Affected issues**  

**How has this been tested?**  
- unit tests
- locally for cloud
- locally for server (still in progress)

**Whats Next?**
- Implement the flow itself