### PR TITLE
ARC-2131 - unified logging for backfill tasks

### DIFF
--- a/src/sync/branches.ts
+++ b/src/sync/branches.ts
@@ -6,7 +6,7 @@ import { BackfillMessagePayload } from "~/src/sqs/sqs.types";
 
 // TODO: better typings
 export const getBranchTask = async (
-	logger: Logger,
+	parentLogger: Logger,
 	gitHubClient: GitHubInstallationClient,
 	_jiraHost: string,
 	repository: Repository,
@@ -14,16 +14,19 @@ export const getBranchTask = async (
 	perPage: number,
 	messagePayload: BackfillMessagePayload) => {
 
-	logger.info("Syncing branches: started");
+	const logger = parentLogger.child({ backfillTask: "Branch" });
+	const startTime = Date.now();
+
+	logger.info({ startTime }, "Backfill task started");
 
 	const commitSince = messagePayload.commitsFromDate ? new Date(messagePayload.commitsFromDate) : undefined;
 	const result = await gitHubClient.getBranchesPage(repository.owner.login, repository.name, perPage, commitSince, cursor as string);
 	const edges = result?.repository?.refs?.edges || [];
 	const branches = edges.map(edge => edge?.node);
 
-	logger.debug("Syncing branches: finished");
-
 	const jiraPayload = transformBranches({ branches, repository }, messagePayload.gitHubAppConfig?.gitHubBaseUrl);
+
+	logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: jiraPayload?.branches?.length }, "Backfill task complete");
 
 	return {
 		edges,

--- a/src/sync/branches.ts
+++ b/src/sync/branches.ts
@@ -26,7 +26,7 @@ export const getBranchTask = async (
 
 	const jiraPayload = transformBranches({ branches, repository }, messagePayload.gitHubAppConfig?.gitHubBaseUrl);
 
-	logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: jiraPayload?.branches?.length }, "Backfill task complete");
+	logger.info({ processingTime: Date.now() - startTime, jiraPayloadLength: jiraPayload?.branches?.length }, "Backfill task complete");
 
 	return {
 		edges,

--- a/src/sync/build.ts
+++ b/src/sync/build.ts
@@ -66,18 +66,22 @@ const doGetBuildTaskInParallel = (
 );
 
 const doGetBuildTask = async (
-	logger: Logger,
+	parentLogger: Logger,
 	gitHubInstallationClient: GitHubInstallationClient,
 	repository: Repository,
 	pageSizeAwareCursor: PageSizeAwareCounterCursor,
 	messagePayload: BackfillMessagePayload
 ) => {
+	const logger = parentLogger.child({ backfillTask: "Build" });
+	const startTime = Date.now();
 
+	logger.info({ startTime }, "Backfill task started");
 	const fromDate = messagePayload?.commitsFromDate ? new Date(messagePayload.commitsFromDate) : undefined;
 	const { data } = await gitHubInstallationClient.listWorkflowRuns(repository.owner.login, repository.name, pageSizeAwareCursor.perPage, pageSizeAwareCursor.pageNo);
 	const { workflow_runs } = data;
 
 	if (areAllBuildsEarlierThanFromDate(workflow_runs, fromDate)) {
+		logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
 		return {
 			edges: [],
 			jiraPayload: undefined
@@ -89,6 +93,7 @@ const doGetBuildTask = async (
 	const edgesWithCursor: BuildWithCursor[] = [{ total_count: data.total_count, workflow_runs, cursor: nextPageCursorStr }];
 
 	if (!workflow_runs?.length) {
+		logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
 		return {
 			edges: [],
 			jiraPayload: undefined
@@ -99,10 +104,10 @@ const doGetBuildTask = async (
 	logger.info(`First workflow_run.updated_at=${workflow_runs[0].updated_at}`);
 
 	const builds = await getTransformedBuilds(workflow_runs, gitHubInstallationClient, logger);
-	logger.info("Syncing Builds: finished");
 
 	// When there are no valid builds return early with undefined JiraPayload so that no Jira calls are made
 	if (!builds?.length) {
+		logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
 		return {
 			edges: edgesWithCursor,
 			jiraPayload: undefined
@@ -114,6 +119,7 @@ const doGetBuildTask = async (
 		builds
 	};
 
+	logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: jiraPayload.builds?.length }, "Backfill task complete");
 	return {
 		edges: edgesWithCursor,
 		jiraPayload

--- a/src/sync/build.ts
+++ b/src/sync/build.ts
@@ -81,7 +81,7 @@ const doGetBuildTask = async (
 	const { workflow_runs } = data;
 
 	if (areAllBuildsEarlierThanFromDate(workflow_runs, fromDate)) {
-		logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
+		logger.info({ processingTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
 		return {
 			edges: [],
 			jiraPayload: undefined
@@ -93,7 +93,7 @@ const doGetBuildTask = async (
 	const edgesWithCursor: BuildWithCursor[] = [{ total_count: data.total_count, workflow_runs, cursor: nextPageCursorStr }];
 
 	if (!workflow_runs?.length) {
-		logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
+		logger.info({ processingTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
 		return {
 			edges: [],
 			jiraPayload: undefined
@@ -107,7 +107,7 @@ const doGetBuildTask = async (
 
 	// When there are no valid builds return early with undefined JiraPayload so that no Jira calls are made
 	if (!builds?.length) {
-		logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
+		logger.info({ processingTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
 		return {
 			edges: edgesWithCursor,
 			jiraPayload: undefined
@@ -119,7 +119,7 @@ const doGetBuildTask = async (
 		builds
 	};
 
-	logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: jiraPayload.builds?.length }, "Backfill task complete");
+	logger.info({ processingTime: Date.now() - startTime, jiraPayloadLength: jiraPayload.builds?.length }, "Backfill task complete");
 	return {
 		edges: edgesWithCursor,
 		jiraPayload

--- a/src/sync/deployment.ts
+++ b/src/sync/deployment.ts
@@ -140,7 +140,7 @@ export const getDeploymentTask = async (
 
 	const fromDate = messagePayload.commitsFromDate ? new Date(messagePayload.commitsFromDate) : undefined;
 	if (areAllEdgesEarlierThanFromDate(edges, fromDate)) {
-		logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
+		logger.info({ processingTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
 		return {
 			edges: [],
 			jiraPayload: undefined
@@ -148,7 +148,7 @@ export const getDeploymentTask = async (
 	}
 
 	if (!deployments?.length) {
-		logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
+		logger.info({ processingTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
 		return {
 			edges,
 			jiraPayload: undefined
@@ -163,7 +163,7 @@ export const getDeploymentTask = async (
 
 	const jiraPayload = transformedDeployments.length > 0 ? { deployments: transformedDeployments } : undefined;
 
-	logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: jiraPayload?.deployments?.length }, "Backfill task complete");
+	logger.info({ processingTime: Date.now() - startTime, jiraPayloadLength: jiraPayload?.deployments?.length }, "Backfill task complete");
 
 	return {
 		edges,

--- a/src/sync/deployment.ts
+++ b/src/sync/deployment.ts
@@ -117,7 +117,7 @@ const saveDeploymentsForLaterUse = async (deployments: FetchDeploymentResponse["
 };
 
 export const getDeploymentTask = async (
-	logger: Logger,
+	parentLogger: Logger,
 	gitHubInstallationClient: GitHubInstallationClient,
 	jiraHost: string,
 	repository: Repository,
@@ -125,7 +125,11 @@ export const getDeploymentTask = async (
 	perPage: number,
 	messagePayload: BackfillMessagePayload
 ) => {
-	logger.debug("Syncing Deployments: started");
+
+	const logger = parentLogger.child({ backfillTask: "Deployment" });
+	const startTime = Date.now();
+
+	logger.info({ startTime }, "Backfill task started");
 
 	const { edges, deployments, extraDeployments } = await fetchDeployments(jiraHost, gitHubInstallationClient, repository, logger, cursor, perPage);
 
@@ -136,6 +140,7 @@ export const getDeploymentTask = async (
 
 	const fromDate = messagePayload.commitsFromDate ? new Date(messagePayload.commitsFromDate) : undefined;
 	if (areAllEdgesEarlierThanFromDate(edges, fromDate)) {
+		logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
 		return {
 			edges: [],
 			jiraPayload: undefined
@@ -143,6 +148,7 @@ export const getDeploymentTask = async (
 	}
 
 	if (!deployments?.length) {
+		logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
 		return {
 			edges,
 			jiraPayload: undefined
@@ -154,9 +160,10 @@ export const getDeploymentTask = async (
 	logger.info(`Last deployment's updated_at=${deployments[deployments.length - 1].latestStatus?.updatedAt}`);
 
 	const transformedDeployments = await getTransformedDeployments(useDynamoForBackfill, deployments, gitHubInstallationClient, jiraHost, logger, messagePayload.gitHubAppConfig?.gitHubAppId);
-	logger.debug("Syncing Deployments: finished");
 
 	const jiraPayload = transformedDeployments.length > 0 ? { deployments: transformedDeployments } : undefined;
+
+	logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: jiraPayload?.deployments?.length }, "Backfill task complete");
 
 	return {
 		edges,

--- a/src/sync/discovery.ts
+++ b/src/sync/discovery.ts
@@ -31,7 +31,7 @@ export const getRepositoryTask = async (
 
 	if (!subscription) {
 		logger.warn({ jiraHost, installationId, gitHubAppId }, "Subscription has been removed, ignoring repository task.");
-		logger.info({ endTime: Date.now() - startTime, RepositoriesLength: 0 }, "Backfill task complete");
+		logger.info({ processingTime: Date.now() - startTime, RepositoriesLength: 0 }, "Backfill task complete");
 		return { edges: [], jiraPayload: undefined };
 	}
 
@@ -61,7 +61,7 @@ export const getRepositoryTask = async (
 		totalCount,
 		nextCursor
 	}, `Repository Discovery Page Information`);
-	logger.info({ endTime: Date.now() - startTime, RepositoriesLength: repositories.length }, "Backfill task complete");
+	logger.info({ processingTime: Date.now() - startTime, RepositoriesLength: repositories.length }, "Backfill task complete");
 	logger.debug(hasNextPage ? "Repository Discovery: Continuing" : "Repository Discovery: finished");
 
 	const metrics = {

--- a/src/sync/discovery.ts
+++ b/src/sync/discovery.ts
@@ -7,7 +7,7 @@ import { BackfillMessagePayload } from "~/src/sqs/sqs.types";
 import { updateRepoConfigsFromGitHub } from "services/user-config-service";
 
 export const getRepositoryTask = async (
-	logger: Logger,
+	parentLogger: Logger,
 	githubInstallationClient: GitHubInstallationClient,
 	jiraHost: string,
 	_repository: Repository,
@@ -16,7 +16,11 @@ export const getRepositoryTask = async (
 	messagePayload: BackfillMessagePayload
 ): Promise<TaskResultPayload> => {
 
-	logger.debug("Repository Discovery: started");
+	const logger = parentLogger.child({ backfillTask: "Repository" });
+	const startTime = Date.now();
+
+	logger.info({ startTime }, "Backfill task started");
+
 	const installationId = githubInstallationClient.githubInstallationId.installationId;
 	const gitHubAppId = messagePayload.gitHubAppConfig?.gitHubAppId;
 	const subscription = await Subscription.getSingleInstallation(
@@ -27,6 +31,7 @@ export const getRepositoryTask = async (
 
 	if (!subscription) {
 		logger.warn({ jiraHost, installationId, gitHubAppId }, "Subscription has been removed, ignoring repository task.");
+		logger.info({ endTime: Date.now() - startTime, RepositoriesLength: 0 }, "Backfill task complete");
 		return { edges: [], jiraPayload: undefined };
 	}
 
@@ -56,7 +61,7 @@ export const getRepositoryTask = async (
 		totalCount,
 		nextCursor
 	}, `Repository Discovery Page Information`);
-	logger.info(`Added ${repositories.length} Repositories to state`);
+	logger.info({ endTime: Date.now() - startTime, RepositoriesLength: repositories.length }, "Backfill task complete");
 	logger.debug(hasNextPage ? "Repository Discovery: Continuing" : "Repository Discovery: finished");
 
 	const metrics = {

--- a/src/sync/pull-request.ts
+++ b/src/sync/pull-request.ts
@@ -127,7 +127,7 @@ const doGetPullRequestTask = async (
 	//So we have to do a filter after we fetch the data and stop (via return []) once the date has passed.
 	const fromDate = messagePayload?.commitsFromDate ? new Date(messagePayload.commitsFromDate) : undefined;
 	if (areAllEdgesEarlierThanFromDate(edges, fromDate)) {
-		logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
+		logger.info({ processingTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
 		return {
 			edges: [],
 			jiraPayload: undefined
@@ -161,7 +161,7 @@ const doGetPullRequestTask = async (
 		)
 	).filter((value) => !!value);
 
-	logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: pullRequests?.length }, "Backfill task complete");
+	logger.info({ processingTime: Date.now() - startTime, jiraPayloadLength: pullRequests?.length }, "Backfill task complete");
 
 	return {
 

--- a/src/sync/pull-request.ts
+++ b/src/sync/pull-request.ts
@@ -82,16 +82,17 @@ const doGetPullRequestTaskInParallel = (
 );
 
 const doGetPullRequestTask = async (
-	logger: Logger,
+	parentLogger: Logger,
 	gitHubInstallationClient: GitHubInstallationClient,
 	jiraHost: string,
 	repository: Repository,
 	pageSizeAwareCursor: PageSizeAwareCounterCursor,
 	messagePayload: BackfillMessagePayload
 ) => {
-	logger.debug("Syncing PRs: started");
-
+	const logger = parentLogger.child({ backfillTask: "Pull" });
 	const startTime = Date.now();
+
+	logger.info({ startTime }, "Backfill task started");
 
 	const {
 		data: edges,
@@ -126,6 +127,7 @@ const doGetPullRequestTask = async (
 	//So we have to do a filter after we fetch the data and stop (via return []) once the date has passed.
 	const fromDate = messagePayload?.commitsFromDate ? new Date(messagePayload.commitsFromDate) : undefined;
 	if (areAllEdgesEarlierThanFromDate(edges, fromDate)) {
+		logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: 0 }, "Backfill task complete");
 		return {
 			edges: [],
 			jiraPayload: undefined
@@ -159,9 +161,10 @@ const doGetPullRequestTask = async (
 		)
 	).filter((value) => !!value);
 
-	logger.info({ pullRequestsLength: pullRequests?.length || 0 }, "Syncing PRs: finished");
+	logger.info({ endTime: Date.now() - startTime, jiraPayloadLength: pullRequests?.length }, "Backfill task complete");
 
 	return {
+
 		edges: edgesWithCursor,
 		jiraPayload:
 			pullRequests?.length


### PR DESCRIPTION
**What's in this PR?**
Making all the start/complete logging for the 5 backfill tasks the same!!!

**Why**
Makes Splunking a lot easier, and it give us way easier debugging when trying to follow the backfill.

You can now search Splunk with "Backfill task *" and you will see when each task started and completed and whether there was data. JiraHost, messageId and githubInstallationId to filter it further.


**Whats Next?**
Probably a small runbook to help
