### PR TITLE
Maintain environmentMapping order from config.yml

### DIFF
--- a/src/services/user-config-service.test.ts
+++ b/src/services/user-config-service.test.ts
@@ -147,8 +147,8 @@ describe("User Config Service", () => {
 
 		githubUserTokenNock(gitHubInstallationId);
 		givenGitHubReturnsConfigFile({ fileContent });
-		await updateRepoConfig(subscription, repoSyncState.repoId, gitHubClient, ["random.yml", "ignored.yml", ".jira/config.yml"]);
-		const config = await getRepoConfig(subscription, gitHubClient, repoSyncState.repoId, repoSyncState.repoOwner, repoSyncState.repoName);
+		await updateRepoConfig(subscription, repoSyncState.repoId, gitHubClient, logger, ["random.yml", "ignored.yml", ".jira/config.yml"]);
+		const config = await getRepoConfig(subscription, gitHubClient, repoSyncState.repoId, repoSyncState.repoOwner, repoSyncState.repoName, logger);
 		expect(Object.keys(config?.deployments?.environmentMapping ?? {})).toStrictEqual(["development", "staging", "production", "testing"]);
 	});
 });

--- a/src/services/user-config-service.test.ts
+++ b/src/services/user-config-service.test.ts
@@ -131,7 +131,7 @@ describe("User Config Service", () => {
 		githubUserTokenNock(gitHubInstallationId);
 		givenGitHubReturnsConfigFile({ repoOwner: unknownRepoOwner, repoName: unknownRepoName });
 
-    const config = await getRepoConfig(subscription, gitHubClient, unknownRepoId, unknownRepoOwner, unknownRepoName, logger);
+		const config = await getRepoConfig(subscription, gitHubClient, unknownRepoId, unknownRepoOwner, unknownRepoName, logger);
 
 		expect(config).toBeTruthy();
 		expect(config?.deployments?.environmentMapping?.development).toHaveLength(4);

--- a/src/services/user-config-service.ts
+++ b/src/services/user-config-service.ts
@@ -116,12 +116,7 @@ const convertYamlToUserConfig = (input?: string): Config => {
 	const deployments = {};
 	if (configDeployments != null) {
 		if (configDeployments.environmentMapping) {
-			deployments["environmentMapping"] =  {
-				development: configDeployments.environmentMapping.development,
-				testing: configDeployments.environmentMapping.testing,
-				staging: configDeployments.environmentMapping.staging,
-				production: configDeployments.environmentMapping.production
-			};
+			deployments["environmentMapping"] = configDeployments.environmentMapping;
 		}
 		if (configDeployments.services?.ids) {
 			deployments["services"] = {

--- a/src/transforms/transform-deployment.test.ts
+++ b/src/transforms/transform-deployment.test.ts
@@ -11,6 +11,7 @@ import { when } from "jest-when";
 import { DatabaseStateCreator } from "test/utils/database-state-creator";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
 import { cacheSuccessfulDeploymentInfo } from "services/deployment-cache-service";
+import { Config } from "interfaces/common";
 
 jest.mock("services/user-config-service");
 jest.mock("config/feature-flags");
@@ -178,6 +179,19 @@ describe("deployment environment mapping", () => {
 		expect(mapEnvironment("banana-east")).toBe("unmapped");
 		expect(mapEnvironment("internet")).toBe("unmapped");
 		expect(mapEnvironment("製造")).toBe("unmapped");
+	});
+
+	it("classifies unknown user config entries as 'unmapped'", () => {
+		const userConfig = {
+			deployments: {
+				environmentMapping: {
+					// "prod" is not a valid key, it should be "production"
+					prod: ["prod-*"]
+				}
+			}
+		} as Config;
+
+		expect(mapEnvironment("prod-us-west-1", userConfig)).toBe("unmapped");
 	});
 });
 

--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -219,7 +219,8 @@ export const mapEnvironment = (environment: string, config?: Config): string => 
 	if (config) {
 		const environmentType = mapEnvironmentWithConfig(environment, config);
 		if (environmentType) {
-			return environmentType;
+			const validEnvs = ["development", "testing", "staging", "production"];
+			return validEnvs.includes(environmentType) ? environmentType : "unmapped";
 		}
 	}
 


### PR DESCRIPTION
**What's in this PR?**
Maintain environmentMapping order from config.yml

**Why**
- [the docs here](https://github.com/atlassian/github-for-jira/blob/3a0f6a47a9ea324f3f5def49dd77ae604eef79f2/SUPPORT.md#deployment-mapping) say "Think top-down if you ever need to override the mapping defined in GitHub for Jira" and suggest the order of environments matters for matching
- [the matching code respects ordering today](https://github.com/atlassian/github-for-jira/blob/e9f93406f398237bd2f4ed0228d70c3c6a1f5686/src/transforms/transform-deployment.ts#L194C1-L197), but the YML -> JS config parser does not, so the docs are inaccurate
- This PR fixes that

**Why - my specific use case**
- My team is trying to use this configuration:
```yml
  environmentMapping:
    development: ["local"]
    staging: ["uat"]
    production: ["production"]
    testing: ["*"]
```
- We have 50+ testing environments and there is no consistent naming convention today, so the idea is "if it's not one of our _special_ environments, then it must be a testing env"
- I have also tried this config, but the negation doesn't work correctly:
```yml
  environmentMapping:
    development: ["local"]
    testing: ["!(local|uat|production)"]
    staging: ["uat"]
    production: ["production"]
```

**Added feature flags**
- No

**Affected issues**  
- No

**How has this been tested?**  
- Added unit test, which failed before this change and passes after

**Whats Next?**
- N/A