### PR TITLE
[EAZY kARMA] NONE: add more retries for discovery

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -82,7 +82,7 @@ resources:
   - type: sqs
     name: backfill
     attributes:
-      MaxReceiveCount: 3
+      MaxReceiveCount: 7
       MessageRetentionPeriod: 1209600
       VisibilityTimeout: 602 #Visibility timeout will be overridden by the SQS Listener when we read message from the queue. We set it here anyway in case if that override fails.
       dataType:

--- a/src/sqs/backfill-error-handler.ts
+++ b/src/sqs/backfill-error-handler.ts
@@ -54,7 +54,12 @@ const handleTaskError = async (sendSQSBackfillMessage: (message, delaySec, logge
 		};
 	}
 
-	if (context.lastAttempt) {
+	const isNotRepoTaskLastAttempt = (context.receiveCount >= 3 && task.task !== "repository");
+
+	if (context.lastAttempt || isNotRepoTaskLastAttempt) {
+		if (isNotRepoTaskLastAttempt) {
+			log.warn("Fail backfill task earlier to avoid slugging");
+		}
 		// Otherwise the sync will be "stuck", not something we want
 		log.warn("That was the last attempt: marking the task as failed and continue with the next one");
 		await markCurrentTaskAsFailedAndContinue(context.payload, task, false, sendSQSBackfillMessage, log, cause);

--- a/src/sqs/queues.ts
+++ b/src/sqs/queues.ts
@@ -29,7 +29,7 @@ backfillQueue = new SqsQueue<BackfillMessagePayload>(
 		queueRegion: envVars.SQS_BACKFILL_QUEUE_REGION,
 		longPollingIntervalSec: LONG_POLLING_INTERVAL_SEC,
 		timeoutSec: 10 * 60,
-		maxAttempts: 3
+		maxAttempts: 7
 	},
 	backfillQueueMessageHandler(backfillQueueMessageSender),
 	backfillErrorHandler(backfillQueueMessageSender)

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -371,6 +371,7 @@ export const markCurrentTaskAsFailedAndContinue = async (data: BackfillMessagePa
 	}
 
 	if (mainNextTask.task === "repository") {
+		log.warn("Cannot finish discovery task: marking the subscription as FAILED");
 		await subscription.update({ syncStatus: SyncStatus.FAILED });
 		return;
 	}


### PR DESCRIPTION
**What's in this PR?**
Increasing number of retries for repo discovery task.

**Why**
I was digging Db and spotted a backfill that was failing on repo sync. The interesting fact: it had 2 subscriptions for the same gitHubInstallationId and they were failing on different repos, which makes me think increasing number of retries might've solved the issue (see "n" column - this is the number of repos)

```
id   |         createdAt          | numberOfSyncedRepos |       backfillSince        | syncStatus | gitHubInstallationId |   n    |       lastupdatedat
--------+----------------------------+---------------------+----------------------------+------------+----------------------+--------+----------------------------
  70441 | 2021-04-26 13:06:54.071+00 |                   0 |                            | FAILED     |             13083610 | 131604 | 2023-05-22 09:19:26.339+00
  70393 | 2021-04-26 08:01:07.489+00 |                   0 |                            | FAILED     |             13083610 | 110410 | 2023-05-22 09:19:32.752+00
  ```
