### PR TITLE
ARC-2226 use whold word to regex parse jira issue key

### DIFF
--- a/src/util/jira-utils.test.ts
+++ b/src/util/jira-utils.test.ts
@@ -109,6 +109,21 @@ describe("Jira Utils", () => {
 		it("should extract multiple issue keys in a single string", () => {
 			expect(jiraIssueKeyParser("JRA-123 Jra-456-jra-901\n[bah-321]")).toEqual(["JRA-123", "JRA-456", "JRA-901", "BAH-321"]);
 		});
+
+		describe.each([
+			["JIRA-123", "JIRA-123"],
+			["abcd JIRA-123", "JIRA-123"],
+			["abcd-JIRA-123", "JIRA-123"],
+			["JIRA-123-abcd", "JIRA-123"],
+			["JIRA-123 abcd", "JIRA-123"],
+			["JIRA-123 JIRA-456 abcd", "JIRA-123", "JIRA-456"],
+			["JIRA-123abcd"],
+			["JIRA-123abcd JIRA-456 abcd", "JIRA-456"]
+		])("matching with whole word", (full, ...issueKeys) => {
+			it(`should match "${full}" to "${issueKeys}"`, () => {
+				expect(jiraIssueKeyParser(full)).toEqual(issueKeys ? issueKeys : []);
+			});
+		});
 	});
 
 	describe("isGitHubCloudApp", () => {

--- a/src/util/jira-utils.ts
+++ b/src/util/jira-utils.ts
@@ -106,9 +106,7 @@ export const jiraIssueKeyParser = (str: string): string[] => {
 	}
 
 	// Parse all issue keys from string then we UPPERCASE the matched string and remove duplicate issue keys
-	return uniq(Array.from(str.matchAll(jiraIssueRegex()), m => {
-		return m[2].toUpperCase()
-	}));
+	return uniq(Array.from(str.matchAll(jiraIssueRegex()), m => m[2].toUpperCase()));
 };
 
 export const hasJiraIssueKey = (str: string): boolean => !isEmpty(jiraIssueKeyParser(str));

--- a/src/util/jira-utils.ts
+++ b/src/util/jira-utils.ts
@@ -69,8 +69,8 @@ interface Author {
  *  then must be at least one more unicode-digit character up to 256 length to prefix the ID -\p{Nd}{1,255} means that it must be separated by a dash,
  *  then at least 1 number character up to 256 length
  */
-export const jiraIssueRegex = (): RegExp => {
-	return /(^|[^A-Z\d])([A-Z][A-Z\d]{1,255}-[1-9]\d{0,255})/giu;
+const jiraIssueRegex = (): RegExp => {
+	return /(^|[^A-Z\d])([A-Z][A-Z\d]{1,255}-[1-9]\d{0,255})(?=$|[^A-Z\d])/giu;
 };
 
 /**
@@ -106,7 +106,9 @@ export const jiraIssueKeyParser = (str: string): string[] => {
 	}
 
 	// Parse all issue keys from string then we UPPERCASE the matched string and remove duplicate issue keys
-	return uniq(Array.from(str.matchAll(jiraIssueRegex()), m => m[2].toUpperCase()));
+	return uniq(Array.from(str.matchAll(jiraIssueRegex()), m => {
+		return m[2].toUpperCase()
+	}));
 };
 
 export const hasJiraIssueKey = (str: string): boolean => !isEmpty(jiraIssueKeyParser(str));


### PR DESCRIPTION
**What's in this PR?**
Add some regex to the parsing

**Why**
Right now we parse the branch name to extra Jira issue key

Current behaviour:

abcd-123lfr1m will yield Jira issue key abcd-123

As discussed, we  want to make it as:

abcd-123lfr1m will yield NO Jira issue key

The be more specific, we should parse that Jira issue key only when it is “sort of” like whole word:

abcd-admin-6lfr1m --> ❌
abcd-admin-6-lfr1m --> ✅
abcd-admin-6 --> ✅
abcd-admin-6_ --> ✅
admin-6lfr1m --> ❌
admin-6-lfr1m

**Added feature flags**
N/A

**Affected issues**  
ARC-2226

**How has this been tested?**  
Unit test

**Whats Next?**
N/A
