### PR TITLE
increase the period test over 6 so its an hour instead of 50 minutes

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -629,7 +629,7 @@ environmentOverrides:
             Dimensions:
               - Name: QueueName
                 Value: { "Ref": "QueueName" }
-            EvaluationPeriods: 5
+            EvaluationPeriods: 6
             Period: 600
             ComparisonOperator: GreaterThanThreshold
             Statistic: Maximum


### PR DESCRIPTION
Increase the period test over 6 so its an hour instead of 50 minutes.

I considered adjusting the threshold or auto-scaling but settled on this as we are always minutes off.... I think it is worth reviewing our autoscaling as well though...next time