### PR TITLE
HOT: loose condition on RepoSyncState

### DIFF
--- a/src/models/reposyncstate.test.ts
+++ b/src/models/reposyncstate.test.ts
@@ -416,4 +416,37 @@ describe("RepoSyncState", () => {
 			expect(result).toMatchObject(repo);
 		});
 	});
+
+	describe("findAllRepoOwners", () => {
+		it("should return empty list when no orgs were connected", async () => {
+			const result = await RepoSyncState.findAllRepoOwners(sub);
+			expect(result).toStrictEqual(new Set([]));
+		});
+
+		it("should return connected orgs", async () => {
+			await RepoSyncState.create(repo);
+
+			const anotherRepo = {
+				...repo,
+				repoOwner: "anotherOne"
+			};
+			await RepoSyncState.create(anotherRepo);
+
+			const result = await RepoSyncState.findAllRepoOwners(sub);
+			expect(result).toStrictEqual(new Set(["atlassian", "anotherOne"]));
+		});
+
+		it("should dedup records", async () => {
+			await RepoSyncState.create(repo);
+
+			const anotherRepo = {
+				...repo,
+				repoName: "github-for-jira"
+			};
+			await RepoSyncState.create(anotherRepo);
+
+			const result = await RepoSyncState.findAllRepoOwners(sub);
+			expect(result).toStrictEqual(new Set(["atlassian"]));
+		});
+	});
 });

--- a/src/models/reposyncstate.ts
+++ b/src/models/reposyncstate.ts
@@ -200,6 +200,20 @@ export class RepoSyncState extends Model implements RepoSyncStateProperties {
 		return result || [];
 	}
 
+	// TODO: move repoOwner to Subscription table and get rid of this.
+	// The current schema implies a subscription might have multiple
+	// "repoOwner"s associated with it, while that's impossible
+	static async findAllRepoOwners(subscription: Subscription): Promise<Set<string>> {
+		const owners = await RepoSyncState.findAll({
+			attributes: ["repoOwner"],
+			where: {
+				subscriptionId: subscription.id
+			},
+			group: "repoOwner"
+		});
+		return new Set(owners.map((owner) => owner.getDataValue("repoOwner")));
+	}
+
 	static async findOneFromSubscription(subscription: Subscription, options: FindOptions = {}): Promise<RepoSyncState | null> {
 		return RepoSyncState.findOne(merge(options, {
 			where: {

--- a/src/routes/github/create-branch/github-create-branch-get.ts
+++ b/src/routes/github/create-branch/github-create-branch-get.ts
@@ -113,9 +113,8 @@ const getReposBySubscriptions = async (subscriptions: Subscription[], logger: Lo
 			const response = await gitHubInstallationClient.getRepositoriesPage(100, undefined, "UPDATED_AT");
 			// The app can be installed in a GitHub org but that org might not be connected to Jira, therefore we must filter them out, or
 			// the next steps (e.g. get repo branches to branch of) will fail
-			const subscriptionRepos = await RepoSyncState.findAllFromSubscription(subscription);
-			const subscriptionRepoIds = new Set(subscriptionRepos.map(repo => repo.repoId));
-			const filteredRepos =  response.viewer.repositories.edges.filter(edge => subscriptionRepoIds.has(edge.node.id));
+			const repoOwners = await RepoSyncState.findAllRepoOwners(subscription);
+			const filteredRepos =  response.viewer.repositories.edges.filter(edge => repoOwners.has(edge.node.owner.login));
 			return filteredRepos.slice(0, MAX_REPOS_RETURNED);
 		} catch (err) {
 			logger.error({ err }, "Create branch - Failed to fetch repos for installation");

--- a/src/routes/github/repository/github-repository-get.ts
+++ b/src/routes/github/repository/github-repository-get.ts
@@ -80,10 +80,9 @@ const getReposBySubscriptions = async (repoName: string, subscriptions: Subscrip
 
 			// We don't want to return repos that are not in Database, otherwise we won't be able to fetch branches to branch from later
 			// The app can be installed in a GitHub org but that org might not be connected to Jira, therefore we must filter them out, or
-			// the next steps (e.g. get repo branches to branch of) will fail
-			const subscriptionRepos = await RepoSyncState.findAllFromSubscription(subscription);
-			const subscriptionRepoIds = new Set(subscriptionRepos.map(repo => repo.repoId));
-			return installationSearch.filter(repo => subscriptionRepoIds.has(repo.id));
+			// the next step (e.g. get repo branches to branch of) will fail
+			const subscriptionOwners = await RepoSyncState.findAllRepoOwners(subscription);
+			return installationSearch.filter(repo => subscriptionOwners.has(repo.owner.login));
 
 		} catch (err) {
 			logger.error({ err }, "Create branch - Failed to search repos for installation");


### PR DESCRIPTION
**What's in this PR?**
- Check only that the app knows about the org, don't look for exact repo

**Why**
- In case the repo somehow is not in RepoSyncState table (e.g. was created before we enabled create-repo event, or we missed the event whatsoever...)

**Added feature flags**
Nah

**Affected issues**  
HOT

**How has this been tested?**  
tests, locally
