### PR TITLE
Early exit to avoid marked as error entry

### DIFF
--- a/src/transforms/transform-deployment.ts
+++ b/src/transforms/transform-deployment.ts
@@ -72,6 +72,30 @@ const getLastSuccessDeploymentShaFromCache = async (
 
 		statsd.increment(metricDeploymentCache.lookup, tags, info);
 
+		if (!githubInstallationClient.baseUrl) {
+			logger.warn("Skip lookup from dynamodb as gitHub baseUrl is empty");
+			statsd.increment(metricDeploymentCache.miss, { missedType: "baseurl-empty", ...tags }, info);
+			return undefined;
+		}
+
+		if (!currentDeployEnv) {
+			logger.warn("Skip lookup from dynamodb as currentDeployEnv is empty");
+			statsd.increment(metricDeploymentCache.miss, { missedType: "env-empty", ...tags }, info);
+			return undefined;
+		}
+
+		if (!currentDeployDate) {
+			logger.warn("Skip lookup from dynamodb as currentDeployDate is empty");
+			statsd.increment(metricDeploymentCache.miss, { missedType: "date-empty", ...tags }, info);
+			return undefined;
+		}
+
+		if (!repoId) {
+			logger.warn("Skip lookup from dynamodb as repoId is empty");
+			statsd.increment(metricDeploymentCache.miss, { missedType: "repoId-empty", ...tags }, info);
+			return undefined;
+		}
+
 		const lastSuccessful = await findLastSuccessDeploymentFromCache({
 			gitHubBaseUrl: githubInstallationClient.baseUrl,
 			env: currentDeployEnv,


### PR DESCRIPTION
**What's in this PR?**
Early exit on empty param

**Why**
There're lots of error on searching dynamodb due to empty create_at. Need to mark early exit as marked those as non error to reduce noises.

This is due to github not returning proper data I suspect. 

![image](https://github.com/atlassian/github-for-jira/assets/105693507/a0dfd971-9eee-4e25-892f-aa8f82115f34)


**Added feature flags**

**Affected issues**  
_Jira Issues_

**How has this been tested?**  
_Include how to test if applicable_

**Whats Next?**
