### PR TITLE
ARC-2253 delete backfill msg if there's another job running it

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -28,7 +28,7 @@ export enum BooleanFlags {
 	EARLY_EXIT_ON_VALIDATION_FAILED = "early-exit-on-validation-failed",
 	USE_REST_API_FOR_DISCOVERY = "use-rest-api-for-discovery-again",
 	ENABLE_GENERIC_CONTAINERS = "enable-generic-containers",
-	DELETE_MESSAGE_ON_BACKFILL_WHEN_OTHERS_WORKING_ON_IT = "delete_message_on_backfill_when_others_working_on_it",
+	DELETE_MESSAGE_ON_BACKFILL_WHEN_OTHERS_WORKING_ON_IT = "delete-message-on-backfill-when-others-working-on-it",
 }
 
 export enum StringFlags {

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -28,6 +28,7 @@ export enum BooleanFlags {
 	EARLY_EXIT_ON_VALIDATION_FAILED = "early-exit-on-validation-failed",
 	USE_REST_API_FOR_DISCOVERY = "use-rest-api-for-discovery-again",
 	ENABLE_GENERIC_CONTAINERS = "enable-generic-containers",
+	DELETE_MESSAGE_ON_BACKFILL_WHEN_OTHERS_WORKING_ON_IT = "delete_message_on_backfill_when_others_working_on_it",
 }
 
 export enum StringFlags {

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -13,7 +13,7 @@ import { getBuildTask } from "./build";
 import { getDeploymentTask } from "./deployment";
 import { metricSyncStatus, metricTaskStatus } from "config/metric-names";
 import { repoCountToBucket } from "config/metric-helpers";
-import { isBlocked, numberFlag, NumberFlags } from "config/feature-flags";
+import { isBlocked, numberFlag, NumberFlags, booleanFlag, BooleanFlags } from "config/feature-flags";
 import { Deduplicator, DeduplicatorResult, RedisInProgressStorageWithTimeout } from "./deduplicator";
 import { getRedisInfo } from "config/redis-info";
 import { BackfillMessagePayload } from "../sqs/sqs.types";
@@ -461,19 +461,25 @@ export const processInstallation = (sendBackfillMessage: (message: BackfillMessa
 					break;
 				}
 				case DeduplicatorResult.E_OTHER_WORKER_DOING_THIS_JOB: {
-					logger.warn("Duplicate job was detected, rescheduling");
-					// There could be one case where we might be losing the message even if we are sure that another worker is doing the work:
-					// Worker A - doing a long-running task
-					// Redis/SQS - reports that the task execution takes too long and sends it to another worker
-					// Worker B - checks the status of the task and sees that the Worker A is actually doing work, drops the message
-					// Worker A dies (e.g. node is rotated).
-					// In this situation we have a staled job since no message is on the queue an noone is doing the processing.
-					//
-					// Always rescheduling should be OK given that only one worker is working on the task right now: even if we
-					// gather enough messages at the end of the queue, they all will be processed very quickly once the sync
-					// is finished.
-					await sendBackfillMessage(data, RETRY_DELAY_BASE_SEC + RETRY_DELAY_BASE_SEC * Math.random(), logger);
-					break;
+					if (await booleanFlag(BooleanFlags.DELETE_MESSAGE_ON_BACKFILL_WHEN_OTHERS_WORKING_ON_IT, jiraHost)) {
+						logger.warn("Duplicate job was detected, ff [delete_message_on_backfill_when_others_working_on_it] is ON, so deleting the message instead of rescheduling it");
+						//doing nothing and return normally will endup delete the message.
+						break;
+					} else {
+						logger.warn("Duplicate job was detected, rescheduling");
+						// There could be one case where we might be losing the message even if we are sure that another worker is doing the work:
+						// Worker A - doing a long-running task
+						// Redis/SQS - reports that the task execution takes too long and sends it to another worker
+						// Worker B - checks the status of the task and sees that the Worker A is actually doing work, drops the message
+						// Worker A dies (e.g. node is rotated).
+						// In this situation we have a staled job since no message is on the queue an noone is doing the processing.
+						//
+						// Always rescheduling should be OK given that only one worker is working on the task right now: even if we
+						// gather enough messages at the end of the queue, they all will be processed very quickly once the sync
+						// is finished.
+						await sendBackfillMessage(data, RETRY_DELAY_BASE_SEC + RETRY_DELAY_BASE_SEC * Math.random(), logger);
+						break;
+					}
 				}
 			}
 		} catch (err) {


### PR DESCRIPTION
**What's in this PR?**
Delete the backfill message if it is found working on another worker

**Why**

1. Our backfill msg count climb. up very high
2. Alert fire off
3. msg count doesn't comes down
4. Rate limit slooooow the process
5. I think there're a lots of same backfill msg for one customer
6. Previously there's no retry on backfill message in some cases. Now we cover all cases to retry for backfill, so it is safe to delete the message it self.j

**Added feature flags**
enable-dedup-backfill-sqs-msg

**Affected issues**
ARC-2253

**How has this been tested?**
N/A

**Whats Next?**
Turn on ff and test.