### PR TITLE
Arc-2243 Listen to dependabot alerts and post to Jira

### DIFF
--- a/src/github/branch.ts
+++ b/src/github/branch.ts
@@ -44,6 +44,18 @@ export const processBranch = async (
 
 	const jiraPayload: JiraBranchBulkSubmitData | undefined = await transformBranch(github, webhookPayload, logger);
 
+	const jiraClient = await getJiraClient(
+		jiraHost,
+		gitHubInstallationId,
+		gitHubAppId,
+		logger
+	);
+
+	if (!jiraClient) {
+		logger.info("Halting further execution for createBranch as JiraClient is empty for this installation");
+		return;
+	}
+
 	if (!jiraPayload) {
 		logger.info("Halting further execution for createBranch since jiraPayload is empty");
 		return;
@@ -51,12 +63,6 @@ export const processBranch = async (
 
 	logger.info(`Sending jira update for create branch event`);
 
-	const jiraClient = await getJiraClient(
-		jiraHost,
-		gitHubInstallationId,
-		gitHubAppId,
-		logger
-	);
 
 	const jiraResponse = await jiraClient.devinfo.repository.update(jiraPayload);
 

--- a/src/github/dependabot-alert.test.ts
+++ b/src/github/dependabot-alert.test.ts
@@ -1,0 +1,168 @@
+import { dependabotAlertWebhookHandler } from "./dependabot-alert";
+import { WebhookContext } from "routes/github/webhook/webhook-context";
+import { getLogger } from "config/logger";
+import { envVars } from "config/env";
+import {
+	GITHUB_CLOUD_API_BASEURL,
+	GITHUB_CLOUD_BASEURL
+} from "~/src/github/client/github-client-constants";
+import {
+	JiraVulnerabilityBulkSubmitData,
+	JiraVulnerabilityStatusEnum
+} from "../interfaces/jira";
+import { JiraClient } from "../jira/client/jira-client";
+import { emitWebhookProcessedMetrics } from "utils/webhook-utils";
+
+const GITHUB_INSTALLATION_ID = 1234;
+const GHES_GITHUB_APP_ID = 111;
+const GHES_GITHUB_UUID = "xxx-xxx-xxx-xxx";
+const GHES_GITHUB_APP_APP_ID = 1;
+const GHES_GITHUB_APP_CLIENT_ID = "client-id";
+const ID_1 = "1";
+const DEPENDABOT_ALERT = "dependabot_alert";
+const TEST_LOG = "test";
+const CREATED = "created";
+const OPEN = "open";
+const HIGH = "high";
+const PATH_TO_MANIFEST = "path/to/manifest";
+const SAMPLE_SECURITY_ADVISORY_SUMMARY = "Sample security advisory summary";
+const SAMPLE_SECURITY_ADVISORY_DESCRIPTION =
+	"Sample security advisory description";
+const SAMPLE_SECURITY_URL =
+	"https://github.com/user/repo/security/advisories/123";
+const JIRA_VULNERABILITY_STATUS_ENUM_OPEN = JiraVulnerabilityStatusEnum.OPEN;
+const SAMPLE_SECURITY_CREATED_DATE = "2022-01-01T00:00:00Z";
+const SAMPLE_SECURITY_UPDATED_DATE = "2022-01-02T00:00:00Z";
+jest.mock("utils/webhook-utils");
+
+describe("BranchhWebhookHandler", () => {
+	const RealDate = Date.now;
+
+	beforeAll(() => {
+		global.Date.now = jest.fn(() => new Date("2019-04-07T10:20:30Z").getTime());
+	});
+
+	afterAll(() => {
+		global.Date.now = RealDate;
+	});
+	let jiraClient: JiraClient;
+	beforeEach(() => {
+		jiraClient = {
+			baseURL: jiraHost,
+			security: { submit: jest.fn(() =>({ status: 200 })) }
+		} as unknown as JiraClient;
+	});
+	it("should call jira client with tarnsformed vulnerability", async () => {
+		await dependabotAlertWebhookHandler(
+			getWebhookContext({ cloud: true }),
+			jiraClient,
+			undefined,
+			GITHUB_INSTALLATION_ID
+		);
+		expect(jiraClient.security.submit).toBeCalledWith(
+			getVulnerabilityPayload()
+		);
+	});
+	it("should call the webhook logger", async () => {
+		await dependabotAlertWebhookHandler(
+			getWebhookContext({ cloud: true }),
+			jiraClient,
+			undefined,
+			GITHUB_INSTALLATION_ID
+		);
+		expect(emitWebhookProcessedMetrics).toBeCalledWith(
+			new Date(SAMPLE_SECURITY_UPDATED_DATE).getTime(),
+			"dependabot_alert",
+			jiraHost,
+			expect.any(Object),
+			200,
+			undefined
+		);
+	});
+
+
+	const getWebhookContext = <T>({ cloud }: { cloud: boolean }) => {
+		return new WebhookContext<T>({
+			id: ID_1,
+			name: DEPENDABOT_ALERT,
+			log: getLogger(TEST_LOG),
+			payload: {
+				action: CREATED,
+				alert: {
+					number: 123,
+					security_advisory: {
+						summary: SAMPLE_SECURITY_ADVISORY_SUMMARY,
+						description: SAMPLE_SECURITY_ADVISORY_DESCRIPTION,
+						identifiers: [],
+						references: []
+					},
+					html_url: SAMPLE_SECURITY_URL,
+					created_at: SAMPLE_SECURITY_CREATED_DATE,
+					updated_at: SAMPLE_SECURITY_UPDATED_DATE,
+					security_vulnerability: {
+						severity: HIGH
+					},
+					dependency: {
+						manifest_path: PATH_TO_MANIFEST
+					},
+					state: OPEN
+				},
+				repository: {
+					id: 456
+				},
+				webhookReceived: SAMPLE_SECURITY_UPDATED_DATE,
+				ref: "TEST-1"
+			} as unknown as T,
+			gitHubAppConfig: cloud
+				? {
+					uuid: undefined,
+					gitHubAppId: undefined,
+					appId: parseInt(envVars.APP_ID),
+					clientId: envVars.GITHUB_CLIENT_ID,
+					gitHubBaseUrl: GITHUB_CLOUD_BASEURL,
+					gitHubApiUrl: GITHUB_CLOUD_API_BASEURL
+				}
+				: {
+					uuid: GHES_GITHUB_UUID,
+					gitHubAppId: GHES_GITHUB_APP_ID,
+					appId: GHES_GITHUB_APP_APP_ID,
+					clientId: GHES_GITHUB_APP_CLIENT_ID,
+					gitHubBaseUrl: gheUrl,
+					gitHubApiUrl: gheUrl
+				}
+		});
+	};
+	const getVulnerabilityPayload = (): JiraVulnerabilityBulkSubmitData => {
+		return {
+			vulnerabilities: [
+				{
+					schemaVersion: "1.0",
+					id: "d-456-123",
+					updateSequenceNumber: Date.now(),
+					containerId: "456",
+					displayName: SAMPLE_SECURITY_ADVISORY_SUMMARY,
+					description: SAMPLE_SECURITY_ADVISORY_DESCRIPTION,
+					url: SAMPLE_SECURITY_URL,
+					type: "sca",
+					introducedDate: SAMPLE_SECURITY_CREATED_DATE,
+					lastUpdated: SAMPLE_SECURITY_UPDATED_DATE,
+					severity: {
+						level: HIGH
+					},
+					identifiers: [],
+					status: JIRA_VULNERABILITY_STATUS_ENUM_OPEN,
+					additionalInfo: {
+						content: "Manifest Path",
+						url: PATH_TO_MANIFEST
+					},
+					associations: [
+						{
+							associationType: "issueKeys",
+							values: ["placeholder"]
+						}
+					]
+				}
+			]
+		};
+	};
+});

--- a/src/github/dependabot-alert.ts
+++ b/src/github/dependabot-alert.ts
@@ -1,14 +1,15 @@
 import { emitWebhookProcessedMetrics } from "utils/webhook-utils";
 import { WebhookContext } from "routes/github/webhook/webhook-context";
 import { transformDependabotAlert } from "~/src/transforms/transform-dependabot-alert";
+import { JiraClient } from "../jira/client/jira-client";
 
-export const dependabotAlertWebhookHandler = async (context: WebhookContext, jiraClient, _util, gitHubInstallationId: number): Promise<void> => {
+export const dependabotAlertWebhookHandler = async (context: WebhookContext, jiraClient: JiraClient, _util, gitHubInstallationId: number): Promise<void> => {
 	context.log = context.log.child({
 		gitHubInstallationId,
 		jiraHost: jiraClient.baseURL
 	});
 
-	const jiraPayload = await transformDependabotAlert(context, gitHubInstallationId, jiraClient.baseUrl);
+	const jiraPayload = await transformDependabotAlert(context, gitHubInstallationId, jiraClient.baseURL);
 
 	if (!jiraPayload) {
 		context.log.info({ noop: "no_jira_payload_dependabot_alert" }, "Halting further execution for dependabot alert since jiraPayload is empty");
@@ -25,7 +26,7 @@ export const dependabotAlertWebhookHandler = async (context: WebhookContext, jir
 		"dependabot_alert",
 		jiraClient.baseURL,
 		context.log,
-		result?.status,
+		result.status,
 		gitHubAppId
 	);
 };

--- a/src/github/deployment.ts
+++ b/src/github/deployment.ts
@@ -75,6 +75,18 @@ export const processDeployment = async (
 
 	logger.info("deployment message transformed");
 
+	const jiraClient = await getJiraClient(
+		jiraHost,
+		gitHubInstallationId,
+		gitHubAppId,
+		logger
+	);
+
+	if (!jiraClient) {
+		logger.info("Halting further execution for deployment as JiraClient is empty for this installation");
+		return;
+	}
+
 	if (!jiraPayload) {
 		logger.info(
 			{ noop: "no_jira_payload_deployment" },
@@ -83,12 +95,6 @@ export const processDeployment = async (
 		return;
 	}
 
-	const jiraClient = await getJiraClient(
-		jiraHost,
-		gitHubInstallationId,
-		gitHubAppId,
-		logger
-	);
 
 	const result: DeploymentsResult = await jiraClient.deployment.submit(jiraPayload, webhookPayload.repository.id);
 

--- a/src/github/issue-comment.ts
+++ b/src/github/issue-comment.ts
@@ -94,6 +94,10 @@ const syncIssueCommentsToJira = async (jiraHost: string, context: WebhookContext
 		context.log
 	);
 
+	if (!jiraClient) {
+		context.log.info("Halting further execution for syncIssueCommentsToJira as JiraClient is empty for this installation");
+		return;
+	}
 	switch (context.action) {
 		case "created": {
 			await jiraClient.issues.comments.addForIssue(issueKey, {

--- a/src/interfaces/github.ts
+++ b/src/interfaces/github.ts
@@ -262,3 +262,12 @@ export interface GitHubPushData {
 	commits: GitHubCommit[];
 	installation: GitHubInstallation;
 }
+
+export interface GitHubVulnIdentifier {
+	value: string;
+	type: string;
+}
+
+export interface GitHubVulnReference {
+	url: string;
+}

--- a/src/interfaces/jira.ts
+++ b/src/interfaces/jira.ts
@@ -192,6 +192,49 @@ export interface JiraRemoteLinkStatus {
 	label: string;
 }
 
+export interface JiraVulnerabilityBulkSubmitData {
+	vulnerabilities: JiraVulnerability[];
+}
+
+export interface JiraVulnerability {
+	id: string;
+	schemaVersion: string;
+	updateSequenceNumber: number;
+	containerId: string;
+	displayName: string;
+	description: string;
+	url: string;
+	type: string;
+	introducedDate: string;
+	lastUpdated: string;
+	severity: JiraVulnerabilitySeverity;
+	identifiers: JiraVulnerabilityIdentifier[];
+	status: JiraVulnerabilityStatusEnum;
+	additionalInfo: JiraVulnerabilityAdditionalInfo;
+	associations: JiraAssociation[];
+}
+
+export interface JiraVulnerabilitySeverity {
+	level: string;
+}
+
+export interface JiraVulnerabilityIdentifier {
+	displayName: string;
+	url: string;
+}
+
+export enum JiraVulnerabilityStatusEnum {
+	OPEN = "open",
+	CLOSED = "closed",
+	IGNORED = "ignored",
+	UNKNOWN = "unknown"
+}
+
+export interface JiraVulnerabilityAdditionalInfo {
+	content: string;
+	url: string;
+}
+
 // These align with Atlaskit's lozenge values:
 // https://atlassian.design/components/lozenge/examples
 export type JiraRemoteLinkStatusAppearance = "default" | "inprogress" | "moved" | "new" | "removed" | "prototype" | "success";

--- a/src/jira/client/jira-client.ts
+++ b/src/jira/client/jira-client.ts
@@ -373,6 +373,19 @@ export const getJiraClient = async (
 				logger.info("Sending remoteLinks payload to jira.");
 				await instance.post("/rest/remotelinks/1.0/bulk", payload);
 			}
+		},
+		security: {
+			submit: async (data, options?: JiraSubmitOptions) => {
+				const	payload = {
+					vulnerabilities: data.vulnerabilities,
+					properties: {
+						gitHubInstallationId
+					},
+					operationType: options?.operationType || "NORMAL"
+				};
+				logger.info("Sending vulnerabilities payload to jira.");
+				await instance.post("/rest/security/1.0/bulk", payload);
+			}
 		}
 	};
 

--- a/src/routes/api/installation/api-installation-delete-pollinator.ts
+++ b/src/routes/api/installation/api-installation-delete-pollinator.ts
@@ -37,6 +37,12 @@ export const ApiInstallationDeleteForPollinator = async (req: Request, res: Resp
 
 	try {
 		const jiraClient = await getJiraClient(jiraHost, Number(gitHubInstallationId), gitHubAppId, req.log);
+
+		if (!jiraClient) {
+			req.log.info("Halting further execution for delete DevInfo as JiraClient is empty for this installation");
+			throw new Error("Unable to get Jira client for undefined githubAppId");
+		}
+
 		req.log.info({ jiraHost, gitHubInstallationId }, "Deleting DevInfo");
 		await jiraClient.devinfo.installation.delete(gitHubInstallationId);
 		await subscription.update({

--- a/src/routes/api/installation/api-installation-delete.ts
+++ b/src/routes/api/installation/api-installation-delete.ts
@@ -29,6 +29,10 @@ export const ApiInstallationDelete = async (req: Request, res: Response): Promis
 
 	try {
 		const jiraClient = await getJiraClient(jiraHost, Number(gitHubInstallationId), gitHubAppId, req.log);
+		if (!jiraClient) {
+			req.log.info("Halting further execution for delete DevInfo as JiraClient is empty for this installation");
+			throw new Error("Unable to get Jira client for undefined githubAppId");
+		}
 		req.log.info({ jiraHost, gitHubInstallationId }, `Deleting DevInfo`);
 		await jiraClient.devinfo.installation.delete(gitHubInstallationId);
 		await RepoSyncState.resetSyncFromSubscription(subscription);

--- a/src/routes/github/configuration/github-configuration-get.ts
+++ b/src/routes/github/configuration/github-configuration-get.ts
@@ -83,7 +83,8 @@ const getInstallationsWithAdmin = async (
 		});
 
 		// See if we can get the membership for this user
-		// TODO: instead of calling each installation org to see if the current user is admin, you could just ask for all orgs the user is a member of and cross reference with the installation org
+		// TODO: instead of calling each installation org to see if the current user is admin, you could just ask for
+		//  all orgs the user is a member of and cross reference with the installation org
 		const checkAdmin = isUserAdminOfOrganization(
 			gitHubUserClient,
 			installation.account.login,

--- a/src/routes/github/webhook/webhook-receiver-post.ts
+++ b/src/routes/github/webhook/webhook-receiver-post.ts
@@ -77,7 +77,6 @@ export const WebhookReceiverPost = async (request: Request, response: Response):
 		});
 		await webhookRouter(webhookContext);
 		logger.info("Webhook was successfully processed");
-		logger.info(webhookContext);
 		response.sendStatus(204);
 
 	} catch (err) {

--- a/src/routes/github/webhook/webhook-receiver-post.ts
+++ b/src/routes/github/webhook/webhook-receiver-post.ts
@@ -17,6 +17,7 @@ import { deploymentWebhookHandler } from "~/src/github/deployment";
 import { codeScanningAlertWebhookHandler } from "~/src/github/code-scanning-alert";
 import { getLogger } from "config/logger";
 import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL } from "~/src/github/client/github-client-constants";
+import { dependabotAlertWebhookHandler } from "~/src/github/dependabot-alert";
 
 export const WebhookReceiverPost = async (request: Request, response: Response): Promise<void> => {
 	const eventName = request.headers["x-github-event"] as string;
@@ -76,6 +77,7 @@ export const WebhookReceiverPost = async (request: Request, response: Response):
 		});
 		await webhookRouter(webhookContext);
 		logger.info("Webhook was successfully processed");
+		logger.info(webhookContext);
 		response.sendStatus(204);
 
 	} catch (err) {
@@ -125,6 +127,9 @@ const webhookRouter = async (context: WebhookContext) => {
 			break;
 		case "code_scanning_alert":
 			await GithubWebhookMiddleware(codeScanningAlertWebhookHandler)(context);
+			break;
+		case "dependabot_alert":
+			await GithubWebhookMiddleware(dependabotAlertWebhookHandler)(context);
 			break;
 	}
 };

--- a/src/routes/jira/jira-delete.ts
+++ b/src/routes/jira/jira-delete.ts
@@ -47,6 +47,12 @@ export const JiraDelete = async (req: Request, res: Response): Promise<void> => 
 	}
 
 	const jiraClient = await getJiraClient(jiraHost, gitHubInstallationId, gitHubAppId, req.log);
+	if (!jiraClient) {
+		req.log.info("Halting further execution for delete DevInfo as JiraClient is empty for this installation");
+		res.status(500).send("Cannot find JiraClient for null gitHubAppId");
+		return;
+	}
+
 	await jiraClient.devinfo.installation.delete(gitHubInstallationId);
 	await subscription.destroy();
 

--- a/src/transforms/push.ts
+++ b/src/transforms/push.ts
@@ -131,6 +131,10 @@ export const processPush = async (github: GitHubInstallationClient, payload: Pus
 			gitHubAppId,
 			log
 		);
+		if (!jiraClient) {
+			log.info("Halting further execution for push as JiraClient is empty for this installation");
+			return;
+		}
 
 		const recentShas = shas.slice(0, MAX_COMMIT_HISTORY);
 		const commits: JiraCommit[] = await Promise.all(
@@ -196,7 +200,6 @@ export const processPush = async (github: GitHubInstallationClient, payload: Pus
 			log.info("Sending data to Jira");
 			try {
 				const jiraResponse = await jiraClient.devinfo.repository.update(jiraPayload);
-
 				webhookReceived && emitWebhookProcessedMetrics(
 					webhookReceived,
 					"push",

--- a/src/transforms/transform-dependabot-alert.test.ts
+++ b/src/transforms/transform-dependabot-alert.test.ts
@@ -1,0 +1,83 @@
+import Logger from "bunyan";
+import {
+	JiraVulnerabilityStatusEnum
+} from "../interfaces/jira";
+import { WebhookContext } from "../routes/github/webhook/webhook-context";
+import { transformDependabotAlert } from "./transform-dependabot-alert";
+import { envVars } from "config/env";
+import {
+	GITHUB_CLOUD_API_BASEURL,
+	GITHUB_CLOUD_BASEURL
+} from "~/src/github/client/github-client-constants";
+
+
+const getContext = (state): WebhookContext => ({
+	id: "1",
+	name: "dependabot_alert",
+	payload: {
+		alert: {
+			security_advisory: {
+				summary: "Test summary",
+				description: "Test description",
+				identifiers: [{ value: "CVE-123" }],
+				references: [{ url: "https://example.com/CVE-123" }]
+			},
+			security_vulnerability: {
+				severity: "high"
+			},
+			dependency: {
+				manifest_path: "path/to/manifest"
+			},
+			html_url: "https://example.com/alert/1",
+			created_at: "2021-01-01T00:00:00Z",
+			updated_at: "2021-01-02T00:00:00Z",
+			state: state,
+			number: 1
+		},
+		repository: {
+			id: 1
+		}
+	},
+	log: { info: jest.fn() } as unknown as Logger,
+
+	gitHubAppConfig: {
+		uuid: undefined,
+		gitHubAppId: undefined,
+		appId: parseInt(envVars.APP_ID),
+		clientId: envVars.GITHUB_CLIENT_ID,
+		gitHubBaseUrl: GITHUB_CLOUD_BASEURL,
+		gitHubApiUrl: GITHUB_CLOUD_API_BASEURL
+	}
+});
+
+describe("transformDependabotAlert", () => {
+	const gitHubInstallationId = 1;
+	const jiraHost = "https://jira.example.com";
+
+	it.each([
+		["open", JiraVulnerabilityStatusEnum.OPEN],
+		["fixed", JiraVulnerabilityStatusEnum.CLOSED],
+		["dismissed", JiraVulnerabilityStatusEnum.IGNORED],
+		["auto_dismissed", JiraVulnerabilityStatusEnum.IGNORED],
+		["unmapped_state", JiraVulnerabilityStatusEnum.UNKNOWN]
+	])("should correctly transform dependabot alert with state %s", async (state, expectedStatus) => {
+		const context = getContext(state);
+		const result = await transformDependabotAlert(context, gitHubInstallationId, jiraHost);
+		expect(result.vulnerabilities[0].status).toEqual(expectedStatus);
+	});
+
+	it("should log unmapped state", async () => {
+		const context = getContext("unmapped_state");
+		await transformDependabotAlert(context, gitHubInstallationId, jiraHost);
+		expect(context.log.info).toHaveBeenCalledWith("Received unmapped state from dependabot_alert webhook: unmapped_state");
+	});
+
+	it("should correctly map vulnerability identifiers", async () => {
+		const context = getContext("open");
+		const result = await transformDependabotAlert(context, gitHubInstallationId, jiraHost);
+		expect(result.vulnerabilities[0].identifiers).toEqual([
+			{ displayName: "CVE-123", url: "https://example.com/CVE-123" }
+		]);
+	});
+});
+

--- a/src/transforms/transform-dependabot-alert.ts
+++ b/src/transforms/transform-dependabot-alert.ts
@@ -1,0 +1,65 @@
+import { JiraVulnerabilityBulkSubmitData, JiraVulnerabilityStatusEnum } from "interfaces/jira";
+import { createInstallationClient } from "utils/get-github-client-config";
+import { WebhookContext } from "routes/github/webhook/webhook-context";
+import { transformRepositoryId } from "~/src/transforms/transform-repository-id";
+
+// From GitHub: Status can be one of: open, fixed, dismissed, auto_dismissed
+// To Jira: Status can be one of: : open, closed, ignored, unknown
+const transformGitHubStateToJiraStatus = (state: string, context: WebhookContext): JiraVulnerabilityStatusEnum => {
+	switch (state) {
+		case "open":
+			return JiraVulnerabilityStatusEnum.OPEN;
+		case "fixed":
+			return JiraVulnerabilityStatusEnum.CLOSED;
+		case "dismissed":
+			return JiraVulnerabilityStatusEnum.IGNORED;
+		case "auto_dismissed":
+			return JiraVulnerabilityStatusEnum.IGNORED;
+		default:
+			context.log.info(`Received unmapped state from dependabot_alert webhook: ${state}`);
+			return JiraVulnerabilityStatusEnum.UNKNOWN;
+	}
+};
+
+export const transformDependabotAlert = async (context: WebhookContext, githubInstallationId: number, jiraHost: string): Promise<JiraVulnerabilityBulkSubmitData | undefined> => {
+	const { alert, repository } = context.payload;
+
+	const metrics = {
+		trigger: "webhook",
+		subTrigger: "dependabot_alert"
+	};
+	const gitHubInstallationClient = await createInstallationClient(githubInstallationId, jiraHost, metrics, context.log, context.gitHubAppConfig?.gitHubAppId);
+
+	return {
+		vulnerabilities: [{
+			schemaVersion: "1.0",
+			id: `d-${transformRepositoryId(repository.id, gitHubInstallationClient.baseUrl)}-${alert.number}`,
+			updateSequenceNumber: Date.now(),
+			containerId: transformRepositoryId(repository.id),
+			displayName: alert.security_advisory.summary,
+			description: alert.security_advisory.description,
+			url: alert.html_url,
+			type: "sca",
+			introducedDate: alert.created_at,
+			lastUpdated: alert.updated_at || alert.created_at,
+			severity: {
+				level: alert.security_vulnerability.severity
+			},
+			identifiers: [ // todo mapping
+				{
+					displayName: "CWE-123",
+					url: "https://cwe.mitre.org/data/definitions/123.html"
+				}
+			],
+			status: transformGitHubStateToJiraStatus(alert.state, context),
+			additionalInfo: { //todo mapping
+				content: "More information on the vulnerability, as a string",
+				url: "https://example.com/project/CWE-123/additionalInfo"
+			},
+			associations: [{
+				associationType: "issueKeys",
+				values: ["placeholder"]//// todo create relationship manually, tbd longer term
+			}]
+		}]
+	};
+};

--- a/src/transforms/transform-dependabot-alert.ts
+++ b/src/transforms/transform-dependabot-alert.ts
@@ -27,12 +27,12 @@ const transformGitHubStateToJiraStatus = (state: string, context: WebhookContext
 };
 
 const mapVulnIdentifiers = (identifiers: GitHubVulnIdentifier[], references: GitHubVulnReference[]): JiraVulnerabilityIdentifier[] => {
-	const mappedIdentifiers:JiraVulnerabilityIdentifier[] = [];
+	const mappedIdentifiers: JiraVulnerabilityIdentifier[] = [];
 
 	identifiers.forEach((identifier) => {
 		const foundUrl = references.find((reference) => reference.url.includes(identifier.value))?.url;
 
-		const mappedIdentifier:JiraVulnerabilityIdentifier = {
+		const mappedIdentifier: JiraVulnerabilityIdentifier = {
 			displayName: identifier.value,
 			url: foundUrl ? foundUrl : identifier.value
 		};
@@ -43,7 +43,7 @@ const mapVulnIdentifiers = (identifiers: GitHubVulnIdentifier[], references: Git
 	return mappedIdentifiers;
 };
 
-export const transformDependabotAlert = async (context: WebhookContext, githubInstallationId: number, jiraHost: string): Promise<JiraVulnerabilityBulkSubmitData | undefined> => {
+export const transformDependabotAlert = async (context: WebhookContext, githubInstallationId: number, jiraHost: string): Promise<JiraVulnerabilityBulkSubmitData> => {
 	const { alert, repository } = context.payload;
 
 	const metrics = {
@@ -75,7 +75,7 @@ export const transformDependabotAlert = async (context: WebhookContext, githubIn
 			},
 			associations: [{
 				associationType: "issueKeys",
-				values: ["placeholder"]//// todo create relationship manually, tbd longer term
+				values: ["placeholder"] //// todo create relationship manually, tbd longer term
 			}]
 		}]
 	};

--- a/test/snapshots/jira/client/jira-client.test.ts.snap
+++ b/test/snapshots/jira/client/jira-client.test.ts.snap
@@ -42,6 +42,9 @@ Object {
   "remoteLink": Object {
     "submit": [Function],
   },
+  "security": Object {
+    "submit": [Function],
+  },
   "workflow": Object {
     "submit": [Function],
   },


### PR DESCRIPTION
**What's in this PR?**
We are adding a webhook listener to the `dependabot_alert` webhook. Which is posted to Jira as a security vulnerability.
I also added types for the JiraClient. This helped me catch some bugs, but also required me to handle some null cases in other parts of the code - as they _could_ be null. 


**Added feature flags**
I did not feature flag this, as we shouldn't receive the webhook events as we don't hav permissions for it right now. 

