### PR TITLE
NONE - update response for associate repository if no repo is found

### DIFF
--- a/src/config/errors.ts
+++ b/src/config/errors.ts
@@ -6,7 +6,8 @@ export enum Errors {
 	MISSING_GITHUB_APP_CONFIG = "No gitHubAppConfig found",
 	IP_ALLOWLIST_MISCONFIGURED = "IP Allowlist Misconfigured",
 	MISSING_GITHUB_APP_NAME = "Github App name is missing",
-	MISSING_REPOSITORY_ID = "Missing repository ID"
+	MISSING_REPOSITORY_ID = "Missing repository ID",
+	REPOSITORY_NOT_FOUND = "Repository not found"
 }
 
 export class UIDisplayableError extends Error {

--- a/src/routes/jira/workspaces/repositories/jira-workspaces-repositories-associate.test.ts
+++ b/src/routes/jira/workspaces/repositories/jira-workspaces-repositories-associate.test.ts
@@ -107,7 +107,7 @@ describe("Workspaces Associate Repository", () => {
 			});
 	});
 
-	it("Should return empty object when no repo is found", async () => {
+	it("Should return 404 not found status when no repo is found", async () => {
 		app = express();
 		app.use((req, _, next) => {
 			req.log = getLogger("test");
@@ -118,11 +118,6 @@ describe("Workspaces Associate Repository", () => {
 
 		Date.now = jest.fn(() => 1487076708000);
 
-		const response = {
-			success: true,
-			associatedRepository: {}
-		};
-
 		await supertest(app)
 			.post("/jira/workspaces/repositories/associate")
 			.set({
@@ -132,8 +127,8 @@ describe("Workspaces Associate Repository", () => {
 				id: "1"
 			})
 			.expect(res => {
-				expect(res.status).toBe(200);
-				expect(res.text).toContain(JSON.stringify(response));
+				expect(res.status).toBe(404);
+				expect(res.text).toContain(Errors.REPOSITORY_NOT_FOUND);
 			});
 	});
 });

--- a/src/routes/jira/workspaces/repositories/jira-workspaces-repositories-associate.ts
+++ b/src/routes/jira/workspaces/repositories/jira-workspaces-repositories-associate.ts
@@ -39,7 +39,10 @@ export const JiraWorkspacesRepositoriesAssociate = async (req: Request, res: Res
 
 	const repo = await findMatchingRepository(Number(sanitizeHtml(repoId)), jiraHost);
 	const transformedRepository = repo && transformedRepo(repo);
-	const payload = repo ? transformedRepository : {};
 
-	res.status(200).json({ success: true, associatedRepository: payload });
+	if (repo) {
+		res.status(200).json({ success: true, associatedRepository: transformedRepository });
+	} else {
+		res.status(404).send(Errors.REPOSITORY_NOT_FOUND);
+	}
 };


### PR DESCRIPTION
**What's in this PR?**
Change to the response for associate repository

**Why**
Because the spec changes for GC are never ending?

**How has this been tested?**  
Unit tests

**Whats Next?**
If there's another spec request :tableflipp:
If not, :nothingtodo: