### PR TITLE
Use host.docker.internal to visit yarn dev server on host network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,11 @@ services:
   ngrok:
     image: wernight/ngrok
     container_name: ngrok
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "4040:4040"
-    command: ngrok http -log stdout --authtoken $NGROK_AUTHTOKEN app:8080
+    command: ngrok http -log stdout --authtoken $NGROK_AUTHTOKEN host.docker.internal:8080
 
   localstack:
     image: localstack/localstack:1.0.4


### PR DESCRIPTION
**What's in this PR?**
Use host.docker.internal to visit yarn dev server on host network

**Why**
So that ngrok works

**Added feature flags**
N/A

**Affected issues**  
N/A

**How has this been tested?**  
Locally

**Whats Next?**
N/A
