### PR TITLE
None resolve 504

### DIFF
--- a/src/routes/github/create-branch/github-create-branch-get.ts
+++ b/src/routes/github/create-branch/github-create-branch-get.ts
@@ -16,7 +16,10 @@ export const GithubCreateBranchGet = async (req: Request, res: Response, next: N
 		jiraHost
 	} = res.locals;
 	const logger = getLogger("github-create-branch-get", {
-		fields: req.log?.fields
+		fields: {
+			...req.log?.fields,
+			jiraHost
+		}
 	});
 
 	if (!jiraHost) {

--- a/src/routes/github/create-branch/github-create-branch-options-get.test.ts
+++ b/src/routes/github/create-branch/github-create-branch-options-get.test.ts
@@ -58,7 +58,7 @@ describe("GitHub Create Branch Options Get", () => {
 				}))
 			.expect(res => {
 				expect(res.status).toBe(307);
-				expect(res.text).toBe("Found. Redirecting to /github/create-branch?issueKey=TEST-123");
+				expect(res.text).toBe("Temporary Redirect. Redirecting to /github/create-branch?issueKey=TEST-123");
 			});
 	});
 
@@ -90,7 +90,7 @@ describe("GitHub Create Branch Options Get", () => {
 				}))
 			.expect(res => {
 				expect(res.status).toBe(307);
-				expect(res.text).toBe(`Found. Redirecting to /github/${uuid}/create-branch?issueKey=TEST-123`);
+				expect(res.text).toBe(`Temporary Redirect. Redirecting to /github/${uuid}/create-branch?issueKey=TEST-123`);
 			});
 	});
 

--- a/src/routes/github/create-branch/github-create-branch-options-get.test.ts
+++ b/src/routes/github/create-branch/github-create-branch-options-get.test.ts
@@ -57,7 +57,7 @@ describe("GitHub Create Branch Options Get", () => {
 					githubToken: "random-token"
 				}))
 			.expect(res => {
-				expect(res.status).toBe(302);
+				expect(res.status).toBe(307);
 				expect(res.text).toBe("Found. Redirecting to /github/create-branch?issueKey=TEST-123");
 			});
 	});
@@ -89,7 +89,7 @@ describe("GitHub Create Branch Options Get", () => {
 					githubToken: "random-token"
 				}))
 			.expect(res => {
-				expect(res.status).toBe(302);
+				expect(res.status).toBe(307);
 				expect(res.text).toBe(`Found. Redirecting to /github/${uuid}/create-branch?issueKey=TEST-123`);
 			});
 	});

--- a/src/routes/github/create-branch/github-create-branch-options-get.ts
+++ b/src/routes/github/create-branch/github-create-branch-options-get.ts
@@ -5,6 +5,7 @@ import { GitHubServerApp } from "~/src/models/github-server-app";
 import { sendAnalytics } from "utils/analytics-client";
 import { AnalyticsEventTypes, AnalyticsScreenEventsEnum } from "interfaces/common";
 import { envVars } from "config/env";
+import { getLogger } from "config/logger";
 
 // TODO - this entire route could be abstracted out into a generic get instance route on github/instance
 export const GithubCreateBranchOptionsGet = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
@@ -15,6 +16,13 @@ export const GithubCreateBranchOptionsGet = async (req: Request, res: Response, 
 	}
 
 	const jiraHost = res.locals.jiraHost;
+
+	const logger = getLogger("github-create-branch-get-options", {
+		fields: {
+			...req.log?.fields,
+			jiraHost
+		}
+	});
 
 	// TODO move to middleware or shared for create-branch-get
 	const servers = await getGitHubServers(jiraHost);
@@ -36,13 +44,14 @@ export const GithubCreateBranchOptionsGet = async (req: Request, res: Response, 
 	const url = new URL(`${req.protocol}://${req.get("host")}${req.originalUrl}`);
 	// Only has cloud instance
 	if (servers.hasCloudServer && servers.gheServerInfos.length == 0) {
+		logger.info("redirecting to cloud.");
 		res.set("Authorization", req.headers.authorization);
 		res.redirect(307, `/github/create-branch${url.search}`);
-		return;
 		return;
 	}
 	// Only single GitHub Enterprise connected
 	if (!servers.hasCloudServer && servers.gheServerInfos.length == 1) {
+		logger.info("redirecting to server.");
 		res.set("Authorization", req.headers.authorization);
 		res.redirect(307, `/github/${servers.gheServerInfos[0].uuid}/create-branch${url.search}`);
 		return;

--- a/src/routes/github/create-branch/github-create-branch-options-get.ts
+++ b/src/routes/github/create-branch/github-create-branch-options-get.ts
@@ -45,14 +45,12 @@ export const GithubCreateBranchOptionsGet = async (req: Request, res: Response, 
 	// Only has cloud instance
 	if (servers.hasCloudServer && servers.gheServerInfos.length == 0) {
 		logger.info("redirecting to cloud.");
-		res.set("Authorization", req.headers.authorization);
 		res.redirect(307, `/github/create-branch${url.search}`);
 		return;
 	}
 	// Only single GitHub Enterprise connected
 	if (!servers.hasCloudServer && servers.gheServerInfos.length == 1) {
 		logger.info("redirecting to server.");
-		res.set("Authorization", req.headers.authorization);
 		res.redirect(307, `/github/${servers.gheServerInfos[0].uuid}/create-branch${url.search}`);
 		return;
 	}

--- a/src/routes/github/create-branch/github-create-branch-options-get.ts
+++ b/src/routes/github/create-branch/github-create-branch-options-get.ts
@@ -36,12 +36,15 @@ export const GithubCreateBranchOptionsGet = async (req: Request, res: Response, 
 	const url = new URL(`${req.protocol}://${req.get("host")}${req.originalUrl}`);
 	// Only has cloud instance
 	if (servers.hasCloudServer && servers.gheServerInfos.length == 0) {
-		res.redirect(`/github/create-branch${url.search}`);
+		res.set("Authorization", req.headers.authorization);
+		res.redirect(307, `/github/create-branch${url.search}`);
+		return;
 		return;
 	}
 	// Only single GitHub Enterprise connected
 	if (!servers.hasCloudServer && servers.gheServerInfos.length == 1) {
-		res.redirect(`/github/${servers.gheServerInfos[0].uuid}/create-branch${url.search}`);
+		res.set("Authorization", req.headers.authorization);
+		res.redirect(307, `/github/${servers.gheServerInfos[0].uuid}/create-branch${url.search}`);
 		return;
 	}
 


### PR DESCRIPTION
tested in stage

**What's in this PR?**
Apparently 301/302 redirects can strip header data usually **Authorization**, in the logs we have some calls getting 401s at the create-branch route, but successfully making through the create-branch-options route, which means that they were authorized for the first call but not the second, we have that backed up by some error messaging saying header data is incomplete... Hopefully this resolves that!
