### PR TITLE
ISOC-3691 add DB columns for Dependabot alerts backfill

### DIFF
--- a/db/migrations/20230717232437-add-dependabot-alert-cols.js
+++ b/db/migrations/20230717232437-add-dependabot-alert-cols.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn("RepoSyncStates", "dependabotAlertFrom", { type: Sequelize.DATE, allowNull: true });
+    await queryInterface.addColumn("RepoSyncStates", "dependabotAlertStatus", { type: Sequelize.ENUM("pending", "complete", "failed"), allowNull: true });
+    await queryInterface.addColumn("RepoSyncStates", "dependabotAlertCursor", { type: Sequelize.STRING, allowNull: true });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn("RepoSyncStates", "dependabotAlertFrom");
+    await queryInterface.removeColumn("RepoSyncStates", "dependabotAlertStatus");
+    await queryInterface.removeColumn("RepoSyncStates", "dependabotAlertCursor");
+  }
+};


### PR DESCRIPTION
**What's in this PR?**
Adding script to add columns for dependabot alerts backfill in `RepoSyncStates` table 

**Why**
Need these columns to track the status of dependabot alerts backfill

**Added feature flags**
N/A

**Affected issues**  
[ISOC-3691]

**How has this been tested?**  
Local

**Whats Next?**
Dependabot alerts backfill


[ISOC-3691]: https://softwareteams.atlassian.net/browse/ISOC-3691