### PR TITLE
ARC-1913 and SPOT-197: Remove admins permissions to call /deleteInstallation

### DIFF
--- a/etc/poco/bundle/main-test.json
+++ b/etc/poco/bundle/main-test.json
@@ -152,7 +152,6 @@
 			"principals": [],
 			"allowed": true
 		},
-
 		{
 			"name": "Allow external users to disconnect github account",
 			"path": "/jira/configuration",
@@ -184,6 +183,14 @@
 			"mechanism": "group",
 			"principals": ["micros-sv--github-for-jira-dl-admins"],
 			"allowed": true
+		},
+		{
+			"name": "Block service team members to access Admin DELETE API endpoints",
+			"path": "/api/deleteInstallation/12345/https%3A%2F%2Fsome-jira-instance.atlassian.net",
+			"method": "DELETE",
+			"mechanism": "group",
+			"principals": ["micros-sv--github-for-jira-dl-admins"],
+			"allowed": false
 		},
 		{
 			"name": "Allow micros manager-service to microscope endpoints",

--- a/etc/poco/bundle/main.json
+++ b/etc/poco/bundle/main.json
@@ -51,7 +51,8 @@
         "/api/**"
       ],
       "methods": [
-        "*"
+        "GET",
+				"POST"
       ],
       "principals": {
         "staff": {


### PR DESCRIPTION
**What's in this PR?**
Just removing the permissions for us to call the `deleteInstallation` endpoint manually via the cli. It's currently being called by Pollinator only, so they will continue to do so (policies are already defined in the `extras-stg` and `extras-prod` policies).

**Why**
[Spotlight](https://hello.atlassian.net/wiki/spaces/JST/pages/2101826308/Spotlight+Agile+and+Open+Toolchain+dangerous+operations+audit) project (response to last year's sev 0).
Removing operations that can be considered dangerous.

**Added feature flags**
None.

**Affected issues**  
ARC-1913
SPOT-197

**How has this been tested?**  
Added a new test on `mais-test.json`
