### PR TITLE
add 'draft' state for pull-requests

### DIFF
--- a/docs/DevInfoAPI.json
+++ b/docs/DevInfoAPI.json
@@ -434,7 +434,7 @@
           "type" : "string",
           "description" : "The status of the pull request. Priority applies between these states with preference given in the order OPEN, MERGED, DECLINED, UNKNOWN",
           "readOnly" : true,
-          "enum" : [ "OPEN", "MERGED", "DECLINED", "UNKNOWN" ]
+          "enum" : [ "OPEN", "DRAFT", "MERGED", "DECLINED", "UNKNOWN" ]
         },
         "title" : {
           "type" : "string",

--- a/docs/jira-dev-info-0.10-swagger.yaml
+++ b/docs/jira-dev-info-0.10-swagger.yaml
@@ -773,6 +773,7 @@ definitions:
           readOnly: true
           enum:
           - "OPEN"
+          - "DRAFT"
           - "MERGED"
           - "DECLINED"
           - "UNKNOWN"

--- a/src/github/client/github-queries.ts
+++ b/src/github/client/github-queries.ts
@@ -77,6 +77,7 @@ export type pullRequestNode = {
 	title: string;
 	body: string;
 	url: string;
+  draft: boolean;
 	baseRef?: {
 		name: string;
 		repository: {
@@ -184,6 +185,7 @@ export const getPullRequests = `query ($owner: String!, $repo: String!, $per_pag
 					title
 					body
 					url
+          draft
 					baseRef {
 						name
 						repository {

--- a/src/transforms/transform-pull-request.test.ts
+++ b/src/transforms/transform-pull-request.test.ts
@@ -195,7 +195,7 @@ describe("pull_request transform", () => {
 					sourceBranch: "use-the-force",
 					sourceBranchUrl:
 						"https://github.com/integrations/test/tree/use-the-force",
-					status: "OPEN",
+					status: "DRAFT",
 					timestamp: updated_at,
 					title: title,
 					url: "https://github.com/integrations/test/pull/51",

--- a/test/fixtures/api/transform-pull-request-list.json
+++ b/test/fixtures/api/transform-pull-request-list.json
@@ -9,6 +9,7 @@
     "issue_url": "https://api.github.com/repos/integrations/test/issues/51",
     "number": 51,
     "state": "merged",
+    "draft": false,
     "locked": false,
     "title": "[TES-123] Branch payload Test",
     "user": {
@@ -322,6 +323,7 @@
     "issue_url": "https://api.github.com/repos/integrations/test/issues/51",
     "number": 51,
     "state": "open",
+    "draft": false,
     "locked": false,
     "title": "Testing force pushes",
     "user": {
@@ -636,6 +638,7 @@
 		"issue_url": "https://api.github.com/repos/integrations/test/issues/51",
 		"number": 51,
 		"state": "open",
+    "draft": true,
 		"locked": false,
 		"title": "Testing force pushes",
 		"user": {


### PR DESCRIPTION
**What's in this PR?**
I'm adding a new state of Pull-Requests: DRAFT

**Why**
this would close this community issue: [Differentiate between a draft pull request and a normal pull request in workflow triggers](https://jira.atlassian.com/browse/JRACLOUD-72888)

**How has this been tested?**  
I've added a unit test