### PR TITLE
ISOC-3690 Secret scanning webhook handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
 	},
 	"devDependencies": {
 		"@octokit/rest": "16.43.2",
-		"@octokit/webhooks-types": "^6.11.0",
+		"@octokit/webhooks-types": "^7.1.0",
 		"@playwright/test": "^1.33.0",
 		"@types/bunyan": "^1.8.6",
 		"@types/bunyan-format": "^0.2.4",

--- a/src/github/dependabot-alert.test.ts
+++ b/src/github/dependabot-alert.test.ts
@@ -13,6 +13,8 @@ import {
 } from "../interfaces/jira";
 import { JiraClient } from "../jira/client/jira-client";
 import { emitWebhookProcessedMetrics } from "utils/webhook-utils";
+import { BooleanFlags, booleanFlag } from "../config/feature-flags";
+import { when } from "jest-when";
 
 const GITHUB_INSTALLATION_ID = 1234;
 const GHES_GITHUB_APP_ID = 111;
@@ -36,6 +38,8 @@ const SAMPLE_SECURITY_CREATED_DATE = "2022-01-01T00:00:00Z";
 const SAMPLE_SECURITY_UPDATED_DATE = "2022-01-02T00:00:00Z";
 const WEBHOOK_RECIEVED_ISO = 1688951387;
 jest.mock("utils/webhook-utils");
+jest.mock("config/feature-flags");
+
 
 describe("DependabotAlertWebhookHandler", () => {
 	const RealDate = Date.now;
@@ -53,8 +57,9 @@ describe("DependabotAlertWebhookHandler", () => {
 			baseURL: jiraHost,
 			security: { submitVulnerabilities: jest.fn(() =>({ status: 200 })) }
 		} as unknown as JiraClient;
+		when(booleanFlag).calledWith(BooleanFlags.ENABLE_GITHUB_SECURITY_IN_JIRA, expect.anything()).mockResolvedValue(true);
 	});
-	it("should call jira client with tarnsformed vulnerability", async () => {
+	it("should call jira client with transformed vulnerability", async () => {
 		await dependabotAlertWebhookHandler(
 			getWebhookContext({ cloud: true }),
 			jiraClient,
@@ -82,6 +87,16 @@ describe("DependabotAlertWebhookHandler", () => {
 		);
 	});
 
+	it("should not call jira client with transformed vulnerability if FF is OFF", async () => {
+		when(booleanFlag).calledWith(BooleanFlags.ENABLE_GITHUB_SECURITY_IN_JIRA, expect.anything()).mockResolvedValue(false);
+		await dependabotAlertWebhookHandler(
+			getWebhookContext({ cloud: true }),
+			jiraClient,
+			undefined,
+			GITHUB_INSTALLATION_ID
+		);
+		expect(jiraClient.security.submitVulnerabilities).toBeCalledTimes(0);
+	});
 
 	const getWebhookContext = <T>({ cloud }: { cloud: boolean }): WebhookContext<T> => {
 		return {

--- a/src/github/dependabot-alert.ts
+++ b/src/github/dependabot-alert.ts
@@ -3,8 +3,12 @@ import { WebhookContext } from "routes/github/webhook/webhook-context";
 import { transformDependabotAlert } from "~/src/transforms/transform-dependabot-alert";
 import { JiraClient } from "../jira/client/jira-client";
 import { DependabotAlertEvent } from "@octokit/webhooks-types";
+import { BooleanFlags, booleanFlag } from "../config/feature-flags";
 
 export const dependabotAlertWebhookHandler = async (context: WebhookContext<DependabotAlertEvent>, jiraClient: JiraClient, _util, gitHubInstallationId: number): Promise<void> => {
+	if (!await booleanFlag(BooleanFlags.ENABLE_GITHUB_SECURITY_IN_JIRA, jiraClient.baseURL)) {
+		return;
+	}
 	context.log = context.log.child({
 		gitHubInstallationId,
 		jiraHost: jiraClient.baseURL

--- a/src/github/secret-scanning-alert.ts
+++ b/src/github/secret-scanning-alert.ts
@@ -4,8 +4,12 @@ import { JiraClient } from "../jira/client/jira-client";
 import { InstallationLite, SecretScanningAlert, SecretScanningAlertCreatedEvent, SecretScanningAlertResolvedEvent, SecretScanningAlertRevokedEvent, Repository, Organization } from "@octokit/webhooks-types";
 import { transformSecretScanningAlert } from "../transforms/transform-secret-scanning-alert";
 import { User } from "@sentry/node";
+import { BooleanFlags, booleanFlag } from "../config/feature-flags";
 
 export const secretScanningAlertWebhookHandler = async (context: WebhookContext<SecretScanningAlertEvent>, jiraClient: JiraClient, _util, gitHubInstallationId: number): Promise<void> => {
+	if (!await booleanFlag(BooleanFlags.ENABLE_GITHUB_SECURITY_IN_JIRA, jiraClient.baseURL)) {
+		return;
+	}
 	context.log = context.log.child({
 		gitHubInstallationId,
 		jiraHost: jiraClient.baseURL

--- a/src/github/secret-scanning-alert.ts
+++ b/src/github/secret-scanning-alert.ts
@@ -1,0 +1,57 @@
+import { emitWebhookProcessedMetrics } from "utils/webhook-utils";
+import { WebhookContext } from "routes/github/webhook/webhook-context";
+import { JiraClient } from "../jira/client/jira-client";
+import { InstallationLite, SecretScanningAlert, SecretScanningAlertCreatedEvent, SecretScanningAlertResolvedEvent, SecretScanningAlertRevokedEvent, Repository, Organization } from "@octokit/webhooks-types";
+import { transformSecretScanningAlert } from "../transforms/transform-secret-scanning-alert";
+import { User } from "@sentry/node";
+
+export const secretScanningAlertWebhookHandler = async (context: WebhookContext<SecretScanningAlertEvent>, jiraClient: JiraClient, _util, gitHubInstallationId: number): Promise<void> => {
+	context.log = context.log.child({
+		gitHubInstallationId,
+		jiraHost: jiraClient.baseURL
+	});
+
+	const jiraPayload = await transformSecretScanningAlert(context, jiraClient.baseURL);
+
+	if (!jiraPayload) {
+		context.log.info({ noop: "no_jira_payload_secret_scanning_alert" }, "Halting further execution for secret scanning alert since jiraPayload is empty");
+		return;
+	}
+
+	context.log.info(`Sending secret scanning alert event as Vulnerability data to Jira's Security endpoint: ${jiraClient.baseURL}`);
+	const result = await jiraClient.security.submitVulnerabilities(jiraPayload);
+	const gitHubAppId = context.gitHubAppConfig?.gitHubAppId;
+
+	const webhookReceived = context.webhookReceived;
+	webhookReceived && emitWebhookProcessedMetrics(
+		new Date(webhookReceived).getTime(),
+		"secret_scanning_alert",
+		jiraClient.baseURL,
+		context.log,
+		result.status,
+		gitHubAppId
+	);
+};
+
+// Due to missing SecretScanningAlert for alert property in SecretScanningAlertReopenedEvent in @octokit/webhooks-types.
+// If fixed in future realease, remove the following type
+export interface SecretScanningAlertReopenedEvent {
+	action: "reopened";
+	alert: SecretScanningAlert & {
+		number: number;
+		secret_type: string;
+		resolution: null;
+		resolved_by: null;
+		resolved_at: null;
+	};
+	repository: Repository;
+	organization?: Organization;
+	installation?: InstallationLite;
+	sender: User;
+}
+
+export type SecretScanningAlertEvent =
+	| SecretScanningAlertCreatedEvent
+	| SecretScanningAlertReopenedEvent
+	| SecretScanningAlertResolvedEvent
+	| SecretScanningAlertRevokedEvent;

--- a/src/routes/github/webhook/webhook-receiver-post.test.ts
+++ b/src/routes/github/webhook/webhook-receiver-post.test.ts
@@ -15,7 +15,6 @@ import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL } from "~/src/github/cli
 import { dependabotAlertWebhookHandler } from "~/src/github/dependabot-alert";
 import { Subscription } from "~/src/models/subscription";
 import { DependabotAlertEvent, Schema, SecretScanningAlertEvent } from "@octokit/webhooks-types";
-import { booleanFlag } from "~/src/config/feature-flags";
 import { secretScanningAlertWebhookHandler } from "~/src/github/secret-scanning-alert";
 
 jest.mock("~/src/middleware/github-webhook-middleware");
@@ -309,20 +308,10 @@ describe("webhook-receiver-post", () => {
 			gitHubAppConfig: gitHubAppConfigForGHES()
 		}));
 	});
-	it("should not call dependabot handler when ENABLE_GITHUB_SECURITY_IN_JIRA is disabled", async () => {
-		req = createGHESReqForEvent("dependabot_alert", "", EXIST_GHES_UUID, { installation: { id: 123 } } as unknown as DependabotAlertEvent);
-		const spy = jest.fn();
-		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		jest.mocked(booleanFlag).mockReturnValue(Promise.resolve(false));
-		jest.mocked(Subscription.findOneForGitHubInstallationId).mockReturnValue(Promise.resolve({ jiraHost: "https://test-instnace.atlassian.net" } as unknown as Subscription));
-		await WebhookReceiverPost(injectRawBodyToReq(req), res);
-		expect(GithubWebhookMiddleware).not.toBeCalledWith(dependabotAlertWebhookHandler);
-	});
 	it("should call dependabot handler", async () => {
 		req = createGHESReqForEvent("dependabot_alert", "", EXIST_GHES_UUID, { installation: { id: 123 } } as unknown as DependabotAlertEvent);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		jest.mocked(booleanFlag).mockReturnValue(Promise.resolve(true));
 		jest.mocked(Subscription.findOneForGitHubInstallationId).mockReturnValue(Promise.resolve({ jiraHost: "https://test-instnace.atlassian.net" } as unknown as Subscription));
 		await WebhookReceiverPost(injectRawBodyToReq(req), res);
 		expect(GithubWebhookMiddleware).toBeCalledWith(dependabotAlertWebhookHandler);
@@ -332,20 +321,10 @@ describe("webhook-receiver-post", () => {
 			gitHubAppConfig: gitHubAppConfigForGHES()
 		}));
 	});
-	it("should not call secret scanning handler when ENABLE_GITHUB_SECURITY_IN_JIRA is disabled", async () => {
-		req = createGHESReqForEvent("secret_scanning_alert", "", EXIST_GHES_UUID, { installation: { id: 123 } } as unknown as SecretScanningAlertEvent);
-		const spy = jest.fn();
-		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		jest.mocked(booleanFlag).mockReturnValue(Promise.resolve(false));
-		jest.mocked(Subscription.findOneForGitHubInstallationId).mockReturnValue(Promise.resolve({ jiraHost: "https://test-instnace.atlassian.net" } as unknown as Subscription));
-		await WebhookReceiverPost(injectRawBodyToReq(req), res);
-		expect(GithubWebhookMiddleware).not.toBeCalledWith(secretScanningAlertWebhookHandler);
-	});
 	it("should call secret scanning handler", async () => {
 		req = createGHESReqForEvent("secret_scanning_alert", "", EXIST_GHES_UUID, { installation: { id: 123 } } as unknown as SecretScanningAlertEvent);
 		const spy = jest.fn();
 		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
-		jest.mocked(booleanFlag).mockReturnValue(Promise.resolve(true));
 		jest.mocked(Subscription.findOneForGitHubInstallationId).mockReturnValue(Promise.resolve({ jiraHost: "https://test-instnace.atlassian.net" } as unknown as Subscription));
 		await WebhookReceiverPost(injectRawBodyToReq(req), res);
 		expect(GithubWebhookMiddleware).toBeCalledWith(secretScanningAlertWebhookHandler);

--- a/src/routes/github/webhook/webhook-receiver-post.test.ts
+++ b/src/routes/github/webhook/webhook-receiver-post.test.ts
@@ -14,8 +14,9 @@ import { envVars } from "config/env";
 import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL } from "~/src/github/client/github-client-constants";
 import { dependabotAlertWebhookHandler } from "~/src/github/dependabot-alert";
 import { Subscription } from "~/src/models/subscription";
-import { DependabotAlertEvent, Schema } from "@octokit/webhooks-types";
+import { DependabotAlertEvent, Schema, SecretScanningAlertEvent } from "@octokit/webhooks-types";
 import { booleanFlag } from "~/src/config/feature-flags";
+import { secretScanningAlertWebhookHandler } from "~/src/github/secret-scanning-alert";
 
 jest.mock("~/src/middleware/github-webhook-middleware");
 jest.mock("~/src/config/feature-flags");
@@ -328,6 +329,29 @@ describe("webhook-receiver-post", () => {
 		expect(spy).toBeCalledWith(expect.objectContaining({
 			id: "100",
 			name: "dependabot_alert",
+			gitHubAppConfig: gitHubAppConfigForGHES()
+		}));
+	});
+	it("should not call secret scanning handler when ENABLE_GITHUB_SECURITY_IN_JIRA is disabled", async () => {
+		req = createGHESReqForEvent("secret_scanning_alert", "", EXIST_GHES_UUID, { installation: { id: 123 } } as unknown as SecretScanningAlertEvent);
+		const spy = jest.fn();
+		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
+		jest.mocked(booleanFlag).mockReturnValue(Promise.resolve(false));
+		jest.mocked(Subscription.findOneForGitHubInstallationId).mockReturnValue(Promise.resolve({ jiraHost: "https://test-instnace.atlassian.net" } as unknown as Subscription));
+		await WebhookReceiverPost(injectRawBodyToReq(req), res);
+		expect(GithubWebhookMiddleware).not.toBeCalledWith(secretScanningAlertWebhookHandler);
+	});
+	it("should call secret scanning handler", async () => {
+		req = createGHESReqForEvent("secret_scanning_alert", "", EXIST_GHES_UUID, { installation: { id: 123 } } as unknown as SecretScanningAlertEvent);
+		const spy = jest.fn();
+		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
+		jest.mocked(booleanFlag).mockReturnValue(Promise.resolve(true));
+		jest.mocked(Subscription.findOneForGitHubInstallationId).mockReturnValue(Promise.resolve({ jiraHost: "https://test-instnace.atlassian.net" } as unknown as Subscription));
+		await WebhookReceiverPost(injectRawBodyToReq(req), res);
+		expect(GithubWebhookMiddleware).toBeCalledWith(secretScanningAlertWebhookHandler);
+		expect(spy).toBeCalledWith(expect.objectContaining({
+			id: "100",
+			name: "secret_scanning_alert",
 			gitHubAppConfig: gitHubAppConfigForGHES()
 		}));
 	});

--- a/src/transforms/transform-secret-scanning-alert.test.ts
+++ b/src/transforms/transform-secret-scanning-alert.test.ts
@@ -88,7 +88,7 @@ describe("transformSecretScanningAlert", () => {
 					"level": "critical"
 				},
 				"status": "open",
-				"type": "sca",
+				"type": "sast",
 				"updateSequenceNumber":  Date.now(),
 				"url": "https://sample/123",
 				"additionalInfo": {

--- a/src/transforms/transform-secret-scanning-alert.test.ts
+++ b/src/transforms/transform-secret-scanning-alert.test.ts
@@ -1,0 +1,101 @@
+import Logger from "bunyan";
+import {
+	JiraVulnerabilityStatusEnum
+} from "../interfaces/jira";
+import { WebhookContext } from "../routes/github/webhook/webhook-context";
+import { envVars } from "config/env";
+import {
+	GITHUB_CLOUD_API_BASEURL,
+	GITHUB_CLOUD_BASEURL
+} from "~/src/github/client/github-client-constants";
+import { transformSecretScanningAlert } from "./transform-secret-scanning-alert";
+
+jest.mock("utils/webhook-utils");
+
+const getContext = (state): WebhookContext => ({
+	id: "1",
+	name: "secret_scanning_alert",
+	action: state,
+	payload: {
+		alert: {
+			number: 123,
+			html_url: "https://sample/123",
+			created_at: "2022-01-01T00:00:00Z",
+			updated_at: "2022-01-01T00:00:00Z",
+			secret_type: "personal_access_token"
+		},
+
+		repository: {
+			id: 1
+		}
+	},
+	log: { info: jest.fn() } as unknown as Logger,
+
+	gitHubAppConfig: {
+		uuid: undefined,
+		gitHubAppId: undefined,
+		appId: parseInt(envVars.APP_ID),
+		clientId: envVars.GITHUB_CLIENT_ID,
+		gitHubBaseUrl: GITHUB_CLOUD_BASEURL,
+		gitHubApiUrl: GITHUB_CLOUD_API_BASEURL
+	}
+});
+
+describe("transformSecretScanningAlert", () => {
+	const jiraHost = "https://jira.example.com";
+	const RealDate = Date.now;
+
+	beforeAll(() => {
+		global.Date.now = jest.fn(() => new Date("2019-04-07T10:20:30Z").getTime());
+	});
+
+	afterAll(() => {
+		global.Date.now = RealDate;
+	});
+
+	it.each([
+		["created", JiraVulnerabilityStatusEnum.OPEN],
+		["reopened", JiraVulnerabilityStatusEnum.OPEN],
+		["resolved", JiraVulnerabilityStatusEnum.CLOSED],
+		["revoked", JiraVulnerabilityStatusEnum.CLOSED],
+		["unmapped_state", JiraVulnerabilityStatusEnum.UNKNOWN]
+	])("should correctly transform secret scanning alert with state %s", async (state, expectedStatus) => {
+		const context = getContext(state);
+		const result = await transformSecretScanningAlert(context, jiraHost);
+		expect(result.vulnerabilities[0].status).toEqual(expectedStatus);
+	});
+
+	it("should log unmapped state", async () => {
+		const context = getContext("unmapped_state");
+		await transformSecretScanningAlert(context, jiraHost);
+		expect(context.log.info).toHaveBeenCalledWith("Received unmapped state from secret_scanning_alert webhook: unmapped_state");
+	});
+
+	it("should correctly map display name identifiers", async () => {
+		const context = getContext("created");
+		const result = await transformSecretScanningAlert(context, jiraHost);
+		expect(result.vulnerabilities).toEqual([
+			{
+				"containerId": "1",
+				"description": "Secret scanning alert",
+				"displayName": "personal_access_token secret exposed",
+				"id": "d-1-123",
+				"identifiers": [],
+				"introducedDate": "2022-01-01T00:00:00Z",
+				"lastUpdated": "2022-01-01T00:00:00Z",
+				"schemaVersion": "1.0",
+				"severity": {
+					"level": "critical"
+				},
+				"status": "open",
+				"type": "sca",
+				"updateSequenceNumber":  Date.now(),
+				"url": "https://sample/123",
+				"additionalInfo": {
+					"content": "personal_access_token"
+				}
+			}
+		]);
+	});
+});
+

--- a/src/transforms/transform-secret-scanning-alert.ts
+++ b/src/transforms/transform-secret-scanning-alert.ts
@@ -1,0 +1,57 @@
+import {
+	JiraVulnerabilityBulkSubmitData, JiraVulnerabilitySeverityEnum, JiraVulnerabilityStatusEnum
+} from "interfaces/jira";
+import { getGitHubClientConfigFromAppId } from "utils/get-github-client-config";
+import { WebhookContext } from "routes/github/webhook/webhook-context";
+import { transformRepositoryId } from "~/src/transforms/transform-repository-id";
+import { SecretScanningAlertEvent } from "../github/secret-scanning-alert";
+import Logger from "bunyan";
+
+export const transformSecretScanningAlert = async (context: WebhookContext<SecretScanningAlertEvent>, jiraHost: string): Promise<JiraVulnerabilityBulkSubmitData> => {
+	const { alert, repository } = context.payload;
+
+	const githubClientConfig = await getGitHubClientConfigFromAppId(context.gitHubAppConfig?.gitHubAppId, jiraHost);
+	return {
+		vulnerabilities: [{
+			schemaVersion: "1.0",
+			id: `d-${transformRepositoryId(repository.id, githubClientConfig.baseUrl)}-${alert.number}`,
+			updateSequenceNumber: Date.now(),
+			containerId: transformRepositoryId(repository.id, githubClientConfig.baseUrl),
+			displayName: alert.secret_type_display_name || `${alert.secret_type} secret exposed`,
+			description:  "Secret scanning alert",
+			url: alert.html_url,
+			type: "sca",
+			introducedDate: alert.created_at,
+			lastUpdated: alert.updated_at || alert.created_at,
+			severity: {
+				level: JiraVulnerabilitySeverityEnum.CRITICAL
+			},
+			identifiers: [],
+			status: transformGitHubStateToJiraStatus(context.action, context.log),
+			additionalInfo: {
+				content: alert.secret_type
+			}
+		}]
+	};
+};
+
+
+// From GitHub: Status can be one of: created, reopened, resolved, revoked
+// To Jira: Status can be one of: : open, closed
+export const transformGitHubStateToJiraStatus = (state: string | undefined, logger: Logger): JiraVulnerabilityStatusEnum => {
+	if (!state) {
+		logger.info(`Received unmapped state from secret_scanning_alert webhook: ${state}`);
+		return JiraVulnerabilityStatusEnum.UNKNOWN;
+	}
+	switch (state) {
+		case "created":
+		case "reopened":
+			return JiraVulnerabilityStatusEnum.OPEN;
+		case "resolved":
+		case "revoked":
+			return JiraVulnerabilityStatusEnum.CLOSED;
+		default:
+			logger.info(`Received unmapped state from secret_scanning_alert webhook: ${state}`);
+			return JiraVulnerabilityStatusEnum.UNKNOWN;
+	}
+};

--- a/src/transforms/transform-secret-scanning-alert.ts
+++ b/src/transforms/transform-secret-scanning-alert.ts
@@ -20,14 +20,14 @@ export const transformSecretScanningAlert = async (context: WebhookContext<Secre
 			displayName: alert.secret_type_display_name || `${alert.secret_type} secret exposed`,
 			description:  "Secret scanning alert",
 			url: alert.html_url,
-			type: "sca",
+			type: "sast",
 			introducedDate: alert.created_at,
 			lastUpdated: alert.updated_at || alert.created_at,
 			severity: {
 				level: JiraVulnerabilitySeverityEnum.CRITICAL
 			},
 			identifiers: [],
-			status: transformGitHubStateToJiraStatus(context.action, context.log),
+			status: transformGitHubStateToJiraStatus(alert.state || context.action, context.log),
 			additionalInfo: {
 				content: alert.secret_type
 			}

--- a/yarn.lock
+++ b/yarn.lock
@@ -831,10 +831,10 @@
   dependencies:
     "@octokit/openapi-types" "^7.2.3"
 
-"@octokit/webhooks-types@^6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks-types/-/webhooks-types-6.11.0.tgz#1fb903bff3f2883490d6ba88d8cb8f8a55f68176"
-  integrity sha512-AanzbulOHljrku1NGfafxdpTCfw2ENaWzH01N2vqQM+cUFbk868Cgh0xylz0JIM9BoKbfI++bdD6EYX0Q/UTEw==
+"@octokit/webhooks-types@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks-types/-/webhooks-types-7.1.0.tgz#d533dea253416e02dd6c2bfab25e533295bd5d3f"
+  integrity sha512-y92CpG4kFFtBBjni8LHoV12IegJ+KFxLgKRengrVjKmGE5XMeCuGvlfRe75lTRrgXaG6XIWJlFpIDTlkoJsU8w==
 
 "@playwright/test@^1.33.0":
   version "1.33.0"


### PR DESCRIPTION
**What's in this PR?**
Adding support to listen to `secret_scanning_alert` webhook event, transform the payload to Jira vulnerability and submit to Jira.
Updated `@octokit/webhooks-types` to latest version as support for secret scanning added in version `7.x`

**Why**
Part of the work to integrate GitHub with Security in Jira
https://hello.atlassian.net/wiki/spaces/CDX/pages/2673460294/RFC+GitHub+for+Jira+Security

**Added feature flags**
ENABLE_GITHUB_SECURITY_IN_JIRA

**Affected issues**  
[ISOC-3690]

**How has this been tested?**  
Unit test
Local testing


[ISOC-3690]: https://softwareteams.atlassian.net/browse/ISOC-3690