### PR TITLE
Use popup instead of new tab for oauth/install/and sign out

### DIFF
--- a/spa/src/pages/ConfigSteps/index.tsx
+++ b/spa/src/pages/ConfigSteps/index.tsx
@@ -248,7 +248,7 @@ const ConfigSteps = () => {
 	};
 
 	const logout = () => {
-		window.open("https://github.com/logout");
+		window.open("https://github.com/logout", "_blank", "popup,width=400,height=600");
 		OAuthManager.clear();
 		setIsLoggedIn(false);
 		setCompletedStep1(false);

--- a/spa/src/services/app-manager/index.ts
+++ b/spa/src/services/app-manager/index.ts
@@ -41,7 +41,7 @@ async function installNewApp(onFinish: (gitHubInstallationId: number | undefined
 	};
 	window.addEventListener("message", handler);
 
-	const winInstall = window.open(app.data.appInstallationUrl, "_blank");
+	const winInstall = window.open(app.data.appInstallationUrl, "_blank", "popup,width=1024,height=760");
 
 	// Still need below interval for window close
 	// As user might not finish the app install flow, there's no guarantee that above message

--- a/spa/src/services/oauth-manager/index.ts
+++ b/spa/src/services/oauth-manager/index.ts
@@ -25,7 +25,7 @@ async function authenticateInGitHub(): Promise<void> {
 	const res = await Api.auth.generateOAuthUrl();
 	if (res.data.redirectUrl && res.data.state) {
 		window.localStorage.setItem(STATE_KEY, res.data.state);
-		window.open(res.data.redirectUrl);
+		window.open(res.data.redirectUrl, "_blank", "popup,width=400,height=600");
 	}
 }
 


### PR DESCRIPTION
**What's in this PR?**
Use popup instead of new tab

**Why**
It gave user more in-context experience

https://github.com/atlassian/github-for-jira/assets/105693507/1cfa31f2-0ff5-4078-bced-407136152da4



