### PR TITLE
ISOC-3776 Add DB col in Subscriptions table

### DIFF
--- a/db/migrations/20230731063755-add-security-permission-col.js
+++ b/db/migrations/20230731063755-add-security-permission-col.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn("Subscriptions", "isSecurityPermissionsAccepted", {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn("Subscriptions", "isSecurityPermissionsAccepted");
+  }
+};


### PR DESCRIPTION
**What's in this PR?**
Adding `isSecurityPermissionsAccepted` column in `Subscriptions` table to track whether the new permissions are accepted by the GH Admin.

**Why**
We are introducing new permissions to access `dependabot_alerts` and `secret_scanning`. Once these permissions are made available in the GH app, the GH Admin will need to accept them. We will use this data to track customers whose permission requests are still pending.

We are currently considering various proposals how to push customers to accept the permissions using this data -

- Sending an email to customers to accept the new permissions.
- Implementing changes in GH4J UI to prompt customers to accept the permissions.

**Affected issues**  
[ISOC-3776]

**How has this been tested?**  
Local

**Whats Next?**
Listen to `installation` webhook and populate the `isSecurityPermissionsAccepted` col in `Subscriptions` table


[ISOC-3776]: https://softwareteams.atlassian.net/browse/ISOC-3776