### PR TITLE
ISOC-3776 Installation webhook handler

### DIFF
--- a/db/migrations/20230731063755-add-security-permission-col.js
+++ b/db/migrations/20230731063755-add-security-permission-col.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn("Subscriptions", "isSecurityPermissionsAccepted", {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn("Subscriptions", "isSecurityPermissionsAccepted");
+  }
+};

--- a/src/github/installation.test.ts
+++ b/src/github/installation.test.ts
@@ -1,0 +1,225 @@
+import { when } from "jest-when";
+import { envVars } from "../config/env";
+import { getLogger } from "../config/logger";
+import { Installation } from "../models/installation";
+import { Subscription } from "../models/subscription";
+import { WebhookContext } from "../routes/github/webhook/webhook-context";
+import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL } from "./client/github-client-constants";
+import { installationWebhookHandler } from "./installation";
+import { BooleanFlags, booleanFlag } from "../config/feature-flags";
+import { submitSecurityWorkspaceToLink } from "../services/subscription-installation-service";
+import { GitHubServerApp } from "../models/github-server-app";
+import { v4 as uuid } from "uuid";
+
+jest.mock("utils/webhook-utils");
+jest.mock("config/feature-flags");
+jest.mock("services/subscription-installation-service");
+
+const GITHUB_INSTALLATION_ID = 1234;
+const GHES_GITHUB_APP_ID = 111;
+const GHES_GITHUB_UUID = "xxx-xxx-xxx-xxx";
+const GHES_GITHUB_APP_CLIENT_ID = "client-id";
+
+describe("InstallationWebhookHandler", () => {
+	let jiraClient: any;
+	let util: any;
+	let gitHubServerApp;
+	let ghesGitHubAppId;
+
+	describe("GitHub Cloud", () => {
+
+		beforeEach(async () => {
+			jiraClient = { baseURL: jiraHost };
+			util = null;
+
+			await Subscription.create({
+				gitHubInstallationId: GITHUB_INSTALLATION_ID,
+				jiraHost
+			});
+
+			await Installation.create({
+				jiraHost,
+				clientKey: "client-key",
+				encryptedSharedSecret: "shared-secret"
+			});
+
+			when(booleanFlag).calledWith(BooleanFlags.ENABLE_GITHUB_SECURITY_IN_JIRA, expect.anything()).mockResolvedValue(true);
+
+		});
+
+		describe.each(
+			["created", "new_permissions_accepted"]
+		)("should not set security permissions accepted field in subscriptions when FF is disabled", (action) => {
+			it(`${action} action`, async () => {
+				when(booleanFlag).calledWith(BooleanFlags.ENABLE_GITHUB_SECURITY_IN_JIRA, expect.anything()).mockResolvedValue(false);
+				await installationWebhookHandler(getWebhookContext({ cloud: true, action }), jiraClient, util, GITHUB_INSTALLATION_ID);
+				const subscription = await Subscription.findOneForGitHubInstallationId(GITHUB_INSTALLATION_ID, undefined);
+				expect(subscription?.isSecurityPermissionsAccepted).toBeFalsy();
+
+			});
+		});
+		describe.each(
+			["created", "new_permissions_accepted"]
+		)("should set security permissions accepted field in subscriptions", (action) => {
+			it(`${action} action`, async () => {
+				await installationWebhookHandler(getWebhookContext({ cloud: true, action }), jiraClient, util, GITHUB_INSTALLATION_ID);
+				const subscription = await Subscription.findOneForGitHubInstallationId(GITHUB_INSTALLATION_ID, undefined);
+				expect(subscription?.isSecurityPermissionsAccepted).toBeTruthy();
+
+			});
+		});
+
+		it("should not set security permissions accepted field if the payload doesn't contain secret_scanning_alerts permission", async () => {
+			const webhookContext = getWebhookContext({ cloud: true });
+			delete webhookContext.payload.installation.permissions["secret_scanning_alerts"];
+			await installationWebhookHandler(webhookContext, jiraClient, util, GITHUB_INSTALLATION_ID);
+			const subscription = await Subscription.findOneForGitHubInstallationId(GITHUB_INSTALLATION_ID, undefined);
+			expect(subscription?.isSecurityPermissionsAccepted).toBeFalsy();
+
+		});
+
+		it("should not set security permissions accepted field if the payload doesn't contain security_events permission", async () => {
+			const webhookContext = getWebhookContext({ cloud: true });
+			delete webhookContext.payload.installation.permissions["security_events"];
+			await installationWebhookHandler(webhookContext, jiraClient, util, GITHUB_INSTALLATION_ID);
+			const subscription = await Subscription.findOneForGitHubInstallationId(GITHUB_INSTALLATION_ID, undefined);
+			expect(subscription?.isSecurityPermissionsAccepted).toBeFalsy();
+
+		});
+
+		it("should not set security permissions accepted field if the payload doesn't contain vulnerability_alerts permission", async () => {
+			const webhookContext = getWebhookContext({ cloud: true });
+			delete webhookContext.payload.installation.permissions["vulnerability_alerts"];
+			await installationWebhookHandler(webhookContext, jiraClient, util, GITHUB_INSTALLATION_ID);
+			const subscription = await Subscription.findOneForGitHubInstallationId(GITHUB_INSTALLATION_ID, undefined);
+			expect(subscription?.isSecurityPermissionsAccepted).toBeFalsy();
+
+		});
+
+		it("should submit workspace to link for new_permissions_accepted action", async () => {
+			const webhookContext = getWebhookContext({ cloud: true });
+			await installationWebhookHandler(webhookContext, jiraClient, util, GITHUB_INSTALLATION_ID);
+			const subscription = await Subscription.findOneForGitHubInstallationId(GITHUB_INSTALLATION_ID, undefined);
+			const installation = await Installation.getForHost(jiraHost);
+			expect(submitSecurityWorkspaceToLink).toBeCalledTimes(1);
+			expect(submitSecurityWorkspaceToLink).toBeCalledWith(installation, subscription, expect.anything());
+
+		});
+
+		it("should not submit workspace to link for created action", async () => {
+			const webhookContext = getWebhookContext({ cloud: true, action: "created" });
+			await installationWebhookHandler(webhookContext, jiraClient, util, GITHUB_INSTALLATION_ID);
+			expect(submitSecurityWorkspaceToLink).toBeCalledTimes(0);
+
+		});
+		it("should throw error if subscription is not found", async () => {
+			const webhookContext = getWebhookContext({ cloud: true });
+			await expect(installationWebhookHandler(webhookContext, jiraClient, util, 0)).rejects.toThrow("Subscription not found");
+		});
+
+	});
+	describe("GitHub Enterprise Server", () => {
+
+		beforeEach(async () => {
+			jiraClient = { baseURL: jiraHost };
+			util = null;
+
+			await Installation.create({
+				jiraHost,
+				clientKey: "client-key",
+				encryptedSharedSecret: "shared-secret"
+			});
+
+			gitHubServerApp = await GitHubServerApp.install({
+				uuid: uuid(),
+				appId: GHES_GITHUB_APP_ID,
+				installationId: 456,
+				gitHubAppName: "test-github-server-app",
+				gitHubBaseUrl: gheUrl,
+				gitHubClientId: "client-id",
+				gitHubClientSecret: "client-secret",
+				privateKey: "private-key",
+				webhookSecret: "webhook-secret"
+			}, jiraHost);
+			ghesGitHubAppId =  gitHubServerApp.id;
+			await Subscription.create({
+				gitHubInstallationId: GITHUB_INSTALLATION_ID,
+				jiraHost,
+				jiraClientKey: "client-key",
+				gitHubAppId: gitHubServerApp.id
+			});
+
+			when(booleanFlag).calledWith(BooleanFlags.ENABLE_GITHUB_SECURITY_IN_JIRA, expect.anything()).mockResolvedValue(true);
+
+		});
+		describe.each(
+			["created", "new_permissions_accepted"]
+		)("should not set security permissions accepted field in subscriptions when FF is disabled", (action) => {
+			it(`${action} action`, async () => {
+				when(booleanFlag).calledWith(BooleanFlags.ENABLE_GITHUB_SECURITY_IN_JIRA, expect.anything()).mockResolvedValue(false);
+				await installationWebhookHandler(getWebhookContext({ cloud: false, action }), jiraClient, util, GITHUB_INSTALLATION_ID);
+				const subscription = await Subscription.findOneForGitHubInstallationId(GITHUB_INSTALLATION_ID, undefined);
+				expect(subscription?.isSecurityPermissionsAccepted).toBeFalsy();
+
+			});
+		});
+
+		describe.each(
+			["created", "new_permissions_accepted"]
+		)("should set security permissions accepted field in subscriptions", (action) => {
+			it(`${action} action`, async () => {
+				await installationWebhookHandler(getWebhookContext({ cloud: false, action }), jiraClient, util, GITHUB_INSTALLATION_ID);
+				const subscription = await Subscription.findOneForGitHubInstallationId(GITHUB_INSTALLATION_ID, ghesGitHubAppId);
+				expect(subscription?.isSecurityPermissionsAccepted).toBeTruthy();
+
+			});
+		});
+
+	});
+
+	const getWebhookContext = ({ cloud, action = "new_permissions_accepted" }: { cloud: boolean, action?: string }) => {
+		return new WebhookContext<any>({
+			id: "1",
+			name: "installation",
+			log: getLogger("test"),
+			action,
+			payload: getPayload(),
+			gitHubAppConfig: cloud ? {
+				uuid: undefined,
+				gitHubAppId: undefined,
+				appId: parseInt(envVars.APP_ID),
+				clientId: envVars.GITHUB_CLIENT_ID,
+				gitHubBaseUrl: GITHUB_CLOUD_BASEURL,
+				gitHubApiUrl: GITHUB_CLOUD_API_BASEURL
+			} : {
+				uuid: GHES_GITHUB_UUID,
+				gitHubAppId: ghesGitHubAppId,
+				appId: GHES_GITHUB_APP_ID,
+				clientId: GHES_GITHUB_APP_CLIENT_ID,
+				gitHubBaseUrl: gheUrl,
+				gitHubApiUrl: gheUrl
+			}
+		});
+	};
+
+	const getPayload = () => {
+		return {
+			"installation": {
+				"id": GITHUB_INSTALLATION_ID,
+				"permissions": {
+					"issues": "write",
+					"actions": "write",
+					"contents": "write",
+					"metadata": "read",
+					"workflows": "write",
+					"deployments": "write",
+					"pull_requests": "write",
+					"security_events": "read",
+					"vulnerability_alerts": "read",
+					"secret_scanning_alerts": "read"
+				}
+			}
+		};
+	};
+
+});

--- a/src/github/installation.ts
+++ b/src/github/installation.ts
@@ -1,0 +1,101 @@
+import { WebhookContext } from "routes/github/webhook/webhook-context";
+import { JiraClient } from "../jira/client/jira-client";
+import { BooleanFlags, booleanFlag } from "../config/feature-flags";
+import { InstallationEvent } from "@octokit/webhooks-types";
+import { Subscription } from "../models/subscription";
+import { submitSecurityWorkspaceToLink } from "../services/subscription-installation-service";
+import { Installation } from "../models/installation";
+import { emitWebhookProcessedMetrics } from "../util/webhook-utils";
+import Logger from "bunyan";
+
+const SECURITY_PERMISSIONS = ["secret_scanning_alerts", "security_events", "vulnerability_alerts"];
+
+export const installationWebhookHandler = async (
+	context: WebhookContext<InstallationEvent>,
+	jiraClient: JiraClient,
+	_util,
+	gitHubInstallationId: number
+): Promise<void> => {
+
+	if (!await booleanFlag(BooleanFlags.ENABLE_GITHUB_SECURITY_IN_JIRA, jiraClient.baseURL)) {
+		return;
+	}
+	const {
+		action,
+		payload: {
+			installation: {
+				permissions
+			}
+		},
+		gitHubAppConfig: {
+			gitHubAppId
+		}
+	} = context;
+
+	const jiraHost = jiraClient.baseURL;
+
+	const logger = context.log.child({
+		gitHubInstallationId,
+		jiraHost
+	});
+
+	const installation = await Installation.getForHost(jiraHost);
+	if (!installation) {
+		throw new Error(`Installation not found`);
+	}
+
+	const subscription = await Subscription.getSingleInstallation(jiraHost, gitHubInstallationId, gitHubAppId);
+	if (!subscription) {
+		throw new Error(`Subscription not found`);
+	}
+
+	let jiraResponse;
+
+	try {
+		if (action === "created" && hasSecurityPermissions(permissions)) {
+			return await setSecurityPermissionAccepted(subscription, logger);
+
+		} else if (action === "new_permissions_accepted" && hasSecurityPermissions(permissions) && !subscription.isSecurityPermissionsAccepted) {
+			await setSecurityPermissionAccepted(subscription, logger);
+
+			jiraResponse = await submitSecurityWorkspaceToLink(installation, subscription, logger);
+			logger.info({ subscriptionId: subscription.id }, "Linked security workspace");
+		}
+
+		const webhookReceived = context.webhookReceived;
+		webhookReceived && emitWebhookProcessedMetrics(
+			new Date(webhookReceived).getTime(),
+			`installation-${action}`,
+			jiraClient.baseURL,
+			logger,
+			jiraResponse?.status,
+			gitHubAppId
+		);
+
+	} catch (err) {
+		logger.warn({ err }, "Failed to submit security workspace to Jira");
+		const webhookReceived = context.webhookReceived;
+		webhookReceived && emitWebhookProcessedMetrics(
+			new Date(webhookReceived).getTime(),
+			"installation",
+			jiraClient.baseURL,
+			logger,
+			500,
+			gitHubAppId
+		);
+	}
+};
+
+const hasSecurityPermissions = (permissions: InstallationEvent["installation"]["permissions"]) => {
+	return SECURITY_PERMISSIONS.every(securityPermission => securityPermission in permissions);
+};
+
+const setSecurityPermissionAccepted = async (subscription: Subscription, logger: Logger) => {
+	try {
+		if (subscription) {
+			await subscription.update({ isSecurityPermissionsAccepted: true });
+		}
+	} catch (err) {
+		logger.warn({ err }, "Failed to set security permissions accepted field in Subscriptions");
+	}
+};

--- a/src/github/installation.ts
+++ b/src/github/installation.ts
@@ -55,7 +55,7 @@ export const installationWebhookHandler = async (
 			await setSecurityPermissionAccepted(subscription, logger);
 
 			jiraResponse = await submitSecurityWorkspaceToLink(installation, subscription, logger);
-			logger.info({ subscriptionId: subscription.id }, "Linked security workspace");
+			logger.info({ subscriptionId: subscription.id }, "Linked security workspace via backfill");
 		}
 
 		const webhookReceived = context.webhookReceived;
@@ -69,7 +69,7 @@ export const installationWebhookHandler = async (
 		);
 
 	} catch (err) {
-		logger.warn({ err }, "Failed to submit security workspace to Jira");
+		logger.warn({ err }, "Failed to submit security workspace to Jira via backfill");
 		const webhookReceived = context.webhookReceived;
 		webhookReceived && emitWebhookProcessedMetrics(
 			new Date(webhookReceived).getTime(),

--- a/src/github/installation.ts
+++ b/src/github/installation.ts
@@ -22,6 +22,7 @@ export const installationWebhookHandler = async (
 	}
 	const {
 		action,
+		log: logger,
 		payload: {
 			installation: {
 				permissions
@@ -33,11 +34,6 @@ export const installationWebhookHandler = async (
 	} = context;
 
 	const jiraHost = jiraClient.baseURL;
-
-	const logger = context.log.child({
-		gitHubInstallationId,
-		jiraHost
-	});
 
 	const installation = await Installation.getForHost(jiraHost);
 	if (!installation) {
@@ -92,9 +88,7 @@ const hasSecurityPermissions = (permissions: InstallationEvent["installation"]["
 
 const setSecurityPermissionAccepted = async (subscription: Subscription, logger: Logger) => {
 	try {
-		if (subscription) {
-			await subscription.update({ isSecurityPermissionsAccepted: true });
-		}
+		await subscription.update({ isSecurityPermissionsAccepted: true });
 	} catch (err) {
 		logger.warn({ err }, "Failed to set security permissions accepted field in Subscriptions");
 	}

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -43,6 +43,7 @@ export class Subscription extends Model {
 	repositoryStatus?: TaskStatus;
 	gitHubAppId: number | undefined;
 	avatarUrl: string | undefined;
+	isSecurityPermissionsAccepted: boolean;
 
 	static async getAllForHost(jiraHost: string, gitHubAppId?: number): Promise<Subscription[]> {
 		return this.findAll({
@@ -273,7 +274,8 @@ Subscription.init({
 	avatarUrl: {
 		type: DataTypes.STRING,
 		allowNull: true
-	}
+	},
+	isSecurityPermissionsAccepted: DataTypes.BOOLEAN
 }, { sequelize });
 
 export interface SubscriptionPayload {

--- a/src/routes/github/webhook/webhook-receiver-post.test.ts
+++ b/src/routes/github/webhook/webhook-receiver-post.test.ts
@@ -14,8 +14,9 @@ import { envVars } from "config/env";
 import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL } from "~/src/github/client/github-client-constants";
 import { dependabotAlertWebhookHandler } from "~/src/github/dependabot-alert";
 import { Subscription } from "~/src/models/subscription";
-import { DependabotAlertEvent, Schema, SecretScanningAlertEvent } from "@octokit/webhooks-types";
+import { DependabotAlertEvent, InstallationEvent, Schema, SecretScanningAlertEvent } from "@octokit/webhooks-types";
 import { secretScanningAlertWebhookHandler } from "~/src/github/secret-scanning-alert";
+import { installationWebhookHandler } from "~/src/github/installation";
 
 jest.mock("~/src/middleware/github-webhook-middleware");
 jest.mock("~/src/config/feature-flags");
@@ -333,6 +334,33 @@ describe("webhook-receiver-post", () => {
 			name: "secret_scanning_alert",
 			gitHubAppConfig: gitHubAppConfigForGHES()
 		}));
+	});
+	describe.each(
+		["created", "new_permissions_accepted"]
+	)("should call installation handler", (action) => {
+		it(`${action} action`, async() => {
+			req = createGHESReqForEvent("installation", action, EXIST_GHES_UUID, { installation: { id: 123 } } as unknown as InstallationEvent);
+			const spy = jest.fn();
+			jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
+			jest.mocked(Subscription.findOneForGitHubInstallationId).mockReturnValue(Promise.resolve({ jiraHost: "https://test-instnace.atlassian.net" } as unknown as Subscription));
+			await WebhookReceiverPost(injectRawBodyToReq(req), res);
+			expect(GithubWebhookMiddleware).toBeCalledWith(installationWebhookHandler);
+			expect(spy).toBeCalledWith(expect.objectContaining({
+				id: "100",
+				name: "installation",
+				gitHubAppConfig: gitHubAppConfigForGHES()
+			}));
+		});
+
+	});
+
+	it("should not call installation handler for other than created/new_permissions_accepted action", async () => {
+		req = createGHESReqForEvent("installation", "suspend", EXIST_GHES_UUID, { installation: { id: 123 } } as unknown as InstallationEvent);
+		const spy = jest.fn();
+		jest.mocked(GithubWebhookMiddleware).mockImplementation(() => spy);
+		jest.mocked(Subscription.findOneForGitHubInstallationId).mockReturnValue(Promise.resolve({ jiraHost: "https://test-instnace.atlassian.net" } as unknown as Subscription));
+		await WebhookReceiverPost(injectRawBodyToReq(req), res);
+		expect(GithubWebhookMiddleware).toBeCalledTimes(0);
 	});
 
 });

--- a/src/routes/github/webhook/webhook-receiver-post.ts
+++ b/src/routes/github/webhook/webhook-receiver-post.ts
@@ -20,6 +20,7 @@ import { GITHUB_CLOUD_API_BASEURL, GITHUB_CLOUD_BASEURL } from "~/src/github/cli
 import { dependabotAlertWebhookHandler } from "~/src/github/dependabot-alert";
 import { extraLoggerInfo } from "./webhook-logging-extra";
 import { secretScanningAlertWebhookHandler } from "~/src/github/secret-scanning-alert";
+import { installationWebhookHandler } from "~/src/github/installation";
 
 export const WebhookReceiverPost = async (request: Request, response: Response): Promise<void> => {
 	const eventName = request.headers["x-github-event"] as string;
@@ -137,6 +138,12 @@ const webhookRouter = async (context: WebhookContext) => {
 			break;
 		case "secret_scanning_alert":
 			await GithubWebhookMiddleware(secretScanningAlertWebhookHandler)(context);
+			break;
+		case "installation":
+			if (context.action === "created" || context.action === "new_permissions_accepted") {
+				await GithubWebhookMiddleware(installationWebhookHandler)(context);
+			}
+			break;
 	}
 };
 
@@ -164,7 +171,7 @@ const getWebhookSecrets = async (uuid?: string): Promise<{ webhookSecrets: Array
 		 * If we ever need to rotate the webhook secrets for Enterprise Customers,
 		 * we can add it in the array: ` [ webhookSecret ]`
 		 */
-		return { webhookSecrets: [ webhookSecret ], gitHubServerApp };
+		return { webhookSecrets: [webhookSecret], gitHubServerApp };
 	}
 
 	return {

--- a/src/services/subscription-installation-service.ts
+++ b/src/services/subscription-installation-service.ts
@@ -107,8 +107,12 @@ export const verifyAdminPermsAndFinishInstallation =
 			log.info({ subscriptionId: subscription.id }, "Subscription was created");
 
 			if (await booleanFlag(BooleanFlags.ENABLE_GITHUB_SECURITY_IN_JIRA, installation.jiraHost)) {
-				await submitSecurityWorkspaceToLink(installation, subscription, log);
-				log.info({ subscriptionId: subscription.id }, "Linked security workspace");
+				try {
+					await submitSecurityWorkspaceToLink(installation, subscription, log);
+					log.info({ subscriptionId: subscription.id }, "Linked security workspace");
+				} catch (err) {
+					log.warn({ err }, "Failed to submit security workspace to Jira");
+				}
 			}
 
 			await Promise.all(
@@ -146,18 +150,11 @@ export const verifyAdminPermsAndFinishInstallation =
 		}
 	};
 
-const submitSecurityWorkspaceToLink = async (
+export const submitSecurityWorkspaceToLink = async (
 	installation: Installation,
 	subscription: Subscription,
 	logger: Logger
 ) => {
-
-	try {
-		const jiraClient = await JiraClient.getNewClient(installation, logger);
-		await jiraClient.linkedWorkspace(subscription.id);
-
-	} catch (err) {
-		logger.warn({ err }, "Failed to submit security workspace to Jira");
-	}
-
+	const jiraClient = await JiraClient.getNewClient(installation, logger);
+	return await jiraClient.linkedWorkspace(subscription.id);
 };


### PR DESCRIPTION
**What's in this PR?**
Implemented `installation` webhook handler to check whether security permissions has been accepted or not. If yes, then
 - update`isSecurityPermissionsAccepted` column in `Subscriptions` table to true
 -  Submit request to Jira to link security workspace

**Why**
We are introducing new permissions to access `dependabot_alerts` and `secret_scanning`. Once these permissions are made available in the GH app, the GH Admin will need to accept them. We will use this data to track customers whose permission requests are still pending. Backfill for security VULNS will also be triggered on permission acceptance 

**Added feature flags**
ENABLE_GITHUB_SECURITY_IN_JIRA

**Affected issues**  
[ISOC-3776]

**How has this been tested?**  
Unit test
Local


[ISOC-3776]: https://softwareteams.atlassian.net/browse/ISOC-3776