### PR TITLE
DISTURBED: add healtcheck endpoint to troubleshoot GHEs webhooks

### DIFF
--- a/etc/poco/bundle/main-test.json
+++ b/etc/poco/bundle/main-test.json
@@ -16,6 +16,14 @@
       "principals": [],
       "allowed": true
     },
+		{
+			"name": "allow request with no asap to retrieve healthcheck via POST for GHE",
+			"path": "/healthcheck/my-uuid",
+			"method": "POST",
+			"mechanism": "open",
+			"principals": [],
+			"allowed": true
+		},
     {
       "name": "allow request with no asap to retrieve deepcheck",
       "path": "/deepcheck",

--- a/etc/poco/bundle/main.json
+++ b/etc/poco/bundle/main.json
@@ -4,7 +4,7 @@
       "description": "Open version and healthcheck endpoints",
       "paths": [
         "/version",
-        "/healthcheck",
+        "/healthcheck/*",
         "/deepcheck"
       ],
       "methods": [

--- a/etc/poco/bundle/main.json
+++ b/etc/poco/bundle/main.json
@@ -8,7 +8,7 @@
         "/deepcheck"
       ],
       "methods": [
-        "GET"
+        "GET", "POST"
       ],
       "principals": {
         "open": {

--- a/etc/poco/bundle/main.json
+++ b/etc/poco/bundle/main.json
@@ -1,14 +1,13 @@
 {
   "allow": [
     {
-      "description": "Open version and healthcheck endpoints",
+      "description": "Open version and deepcheck endpoints",
       "paths": [
         "/version",
-        "/healthcheck/*",
         "/deepcheck"
       ],
       "methods": [
-        "GET", "POST"
+        "GET"
       ],
       "principals": {
         "open": {
@@ -16,6 +15,21 @@
         }
       }
     },
+		{
+			"description": "Healthcheck endpoints",
+			"paths": [
+				"/healthcheck",
+				"/healthcheck/**"
+			],
+			"methods": [
+				"GET", "POST"
+			],
+			"principals": {
+				"open": {
+					"reason": "Allow requests for healthcheck endpoints"
+				}
+			}
+		},
     {
       "description": "Open all endpoints used in the App logic",
       "paths": [

--- a/src/routes/healthcheck/healthcheck-get-post.ts
+++ b/src/routes/healthcheck/healthcheck-get-post.ts
@@ -3,9 +3,12 @@ import { getLogger } from "config/logger";
 import { EncryptionClient } from "utils/encryption-client";
 
 const logger = getLogger("healthcheck");
-export const HealthcheckGet = async (_: Request, res: Response): Promise<void> => {
+export const HealthcheckGetPost = async (req: Request, res: Response): Promise<void> => {
 
 	try {
+		if (req.params["uuid"]) {
+			logger.info({ uuid: req.params["uuid"] }, "healthcheck call from GHEs");
+		}
 		await EncryptionClient.healthcheck();
 		await EncryptionClient.deepcheck();
 	} catch (err) {

--- a/src/routes/healthcheck/healthcheck-router.test.ts
+++ b/src/routes/healthcheck/healthcheck-router.test.ts
@@ -18,6 +18,12 @@ describe("Healthcheck Router", () => {
 			.expect(200);
 	});
 
+	it("should POST /healthcheck/:uuid", async () => {
+		await supertest(app)
+			.post	(`/healthcheck/blah`)
+			.expect(200);
+	});
+
 	it("should GET /deepcheck", async () => {
 		await supertest(app)
 			.get(`/deepcheck`)

--- a/src/routes/healthcheck/healthcheck-router.ts
+++ b/src/routes/healthcheck/healthcheck-router.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { DeepcheckGet } from "./deepcheck-get";
-import { HealthcheckGet } from "./healthcheck-get";
+import { HealthcheckGetPost } from "./healthcheck-get-post";
 
 export const HealthcheckRouter = Router();
 
@@ -14,4 +14,6 @@ HealthcheckRouter.get("/deepcheck", DeepcheckGet);
 /**
  * healthcheck endpoint to check that the app started properly
  */
-HealthcheckRouter.get("/healthcheck", HealthcheckGet);
+HealthcheckRouter.get("/healthcheck", HealthcheckGetPost);
+// To troubleshoot connectivity between GHEs and the app
+HealthcheckRouter.post("/healthcheck/:uuid", HealthcheckGetPost);

--- a/test/snapshots/app.test.ts.snap
+++ b/test/snapshots/app.test.ts.snap
@@ -30,7 +30,9 @@ exports[`app getFrontendApp please review routes and update snapshot when adding
 :GET ^/?(?=/|$)^/?(?=/|$)^/deepcheck/?$
 	query,expressInit,elapsedTimeMetrics,sentryRequestMiddleware,urlencodedParser,jsonParser,cookieParser,LogMiddleware,DeepcheckGet
 :GET ^/?(?=/|$)^/?(?=/|$)^/healthcheck/?$
-	query,expressInit,elapsedTimeMetrics,sentryRequestMiddleware,urlencodedParser,jsonParser,cookieParser,LogMiddleware,HealthcheckGet
+	query,expressInit,elapsedTimeMetrics,sentryRequestMiddleware,urlencodedParser,jsonParser,cookieParser,LogMiddleware,HealthcheckGetPost
+:POST ^/?(?=/|$)^/?(?=/|$)^/healthcheck/(?:([^/]+?))/?$
+	query,expressInit,elapsedTimeMetrics,sentryRequestMiddleware,urlencodedParser,jsonParser,cookieParser,LogMiddleware,HealthcheckGetPost
 :GET ^/?(?=/|$)^/version/?$
 	query,expressInit,elapsedTimeMetrics,sentryRequestMiddleware,urlencodedParser,jsonParser,cookieParser,LogMiddleware,VersionGet
 :GET ^/?(?=/|$)^/api/?(?=/|$)^/?$


### PR DESCRIPTION
**What's in this PR?**
- Adding a new public endpoint
 
**Why**
Writing a runbook how to troubleshoot connectivity issues between GHEs and the app. This endpoint is to make sure a webhook can be delivered to the app, thus ruling out network issues.

**Added feature flags**
Yeah nah
