### PR TITLE
Reset auth button when auth window close regardless of flow state

### DIFF
--- a/spa/src/pages/ConfigSteps/index.tsx
+++ b/spa/src/pages/ConfigSteps/index.tsx
@@ -214,7 +214,9 @@ const ConfigSteps = () => {
 				setLoaderForLogin(true);
 				try {
 					analyticsClient.sendUIEvent({ actionSubject: "startOAuthAuthorisation", action: "clicked", attributes: { type: "cloud" } });
-					await OAuthManager.authenticateInGitHub();
+					await OAuthManager.authenticateInGitHub(() => {
+						setLoaderForLogin(false);
+					});
 				} catch (e) {
 					setLoaderForLogin(false);
 					setError(modifyError(e as AxiosError, {}, { onClearGitHubToken: clearGitHubToken }));


### PR DESCRIPTION
**What's in this PR?**
Reset auth button when auth window close regardless of flow state

**Why**
Otherwise, the auth button stays spinning, forbid user to try to auth again.

**Added feature flags**
N/A

**Affected issues**  
None

**How has this been tested?**  
Local

**Whats Next?**
