### PR TITLE
Fixing the opening of 2 tabs after logging in

### DIFF
--- a/spa/src/pages/ConfigSteps/index.tsx
+++ b/spa/src/pages/ConfigSteps/index.tsx
@@ -240,14 +240,12 @@ const ConfigSteps = () => {
 					analyticsClient.sendTrackEvent({ actionSubject: "finishOAuthFlow", action: "success" });
 				}
 				setIsLoggedIn(true);
-				await getOrganizations();
 			}
 		};
 		window.addEventListener("message", handler);
 		return () => {
 			window.removeEventListener("message", handler);
 		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ originalUrl ]);
 
 	useEffect(() => {


### PR DESCRIPTION
**What's in this PR?**
- After successful login, setIsLogged is set to true, which triggers the `useEffect` with `recheckValidity` and calls `getOrganization`. So, no need to call `getOrganization` again in the other `useEffect`.

