### PR TITLE
None fix multi org install popup

### DIFF
--- a/spa/src/pages/ConfigSteps/index.tsx
+++ b/spa/src/pages/ConfigSteps/index.tsx
@@ -255,7 +255,7 @@ const ConfigSteps = () => {
 			setLoggedInUser(OAuthManager.getUserDetails().username);
 			setLoaderForLogin(false);
 			setOrganizations([]);
-			if (status === true) {
+			if (status) {
 				const result = await getOrganizations();
 				if (result.success) {
 					if (result.orgs.length === 0) {

--- a/spa/src/pages/ConfigSteps/index.tsx
+++ b/spa/src/pages/ConfigSteps/index.tsx
@@ -255,7 +255,7 @@ const ConfigSteps = () => {
 			setLoggedInUser(OAuthManager.getUserDetails().username);
 			setLoaderForLogin(false);
 			setOrganizations([]);
-			if (status) {
+			if (status === true) {
 				const result = await getOrganizations();
 				if (result.success) {
 					if (result.orgs.length === 0) {

--- a/spa/src/pages/ConfigSteps/index.tsx
+++ b/spa/src/pages/ConfigSteps/index.tsx
@@ -132,19 +132,16 @@ const ConfigSteps = () => {
 		});
 	};
 
-	const getOrganizations = async (autoRedirectToInstall = true) => {
+	const getOrganizations = async () => {
 		setLoaderForOrgFetching(true);
 		const response = await AppManager.fetchOrgs();
 		setLoaderForOrgFetching(false);
 		if (response instanceof AxiosError) {
 			setError(modifyError(response, {}, { onClearGitHubToken: clearGitHubToken }));
+			return { success: false, orgs: [] };
 		} else {
 			setOrganizations(response.orgs);
-			/**
-			 * If there are no orgs and auto-redirect is not disabled,
-			 * then redirect them to the Install New Org screen
-			 */
-			autoRedirectToInstall && response.orgs.length === 0 && installNewOrg();
+			return { success: true, orgs: response.orgs };
 		}
 	};
 
@@ -203,13 +200,13 @@ const ConfigSteps = () => {
 		}
 	};
 
-	const installNewOrg = async () => {
+	const installNewOrg = async (mode: "auto" | "manual") => {
 		try {
-			analyticsClient.sendUIEvent({ actionSubject: "installToNewOrganisation", action: "clicked" });
+			analyticsClient.sendUIEvent({ actionSubject: "installToNewOrganisation", action: "clicked", attributes: { mode } });
 			await AppManager.installNewApp({
 				onFinish: async (gitHubInstallationId: number | undefined) => {
-					analyticsClient.sendTrackEvent({ actionSubject: "installNewOrgInGithubResponse", action: "success" });
-					getOrganizations(false);
+					analyticsClient.sendTrackEvent({ actionSubject: "installNewOrgInGithubResponse", action: "success", attributes: { mode } });
+					getOrganizations();
 					if(gitHubInstallationId) {
 						await doCreateConnection(gitHubInstallationId, "auto");
 					}
@@ -249,6 +246,7 @@ const ConfigSteps = () => {
 	}, [ originalUrl ]);
 
 	useEffect(() => {
+		console.log("---------- effect fire ------------", { isLoggedIn });
 		const recheckValidity = async () => {
 			const status: boolean | AxiosError = await OAuthManager.checkValidity();
 			if (status instanceof AxiosError) {
@@ -257,7 +255,18 @@ const ConfigSteps = () => {
 			}
 			setLoggedInUser(OAuthManager.getUserDetails().username);
 			setLoaderForLogin(false);
-			await getOrganizations();
+			setOrganizations([]);
+			if (status === true) {
+				console.log("========== start loading orgs ===========");
+				console.log("========== start loading orgs ===========", { isLoggedIn });
+				console.log("========== start loading orgs ===========");
+				const result = await getOrganizations();
+				if (result.success) {
+					if (result.orgs.length === 0) {
+						await installNewOrg("auto");
+					}
+				}
+			}
 		};
 		isLoggedIn && recheckValidity();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -325,7 +334,7 @@ const ConfigSteps = () => {
 														isDisabled={loaderForOrgClicked}
 														appearance="primary"
 														aria-label="Install new Org"
-														onClick={installNewOrg}
+														onClick={() => installNewOrg("manual")}
 													>
 														Install Jira in a new organization
 													</Button>

--- a/spa/src/pages/ConfigSteps/index.tsx
+++ b/spa/src/pages/ConfigSteps/index.tsx
@@ -246,7 +246,6 @@ const ConfigSteps = () => {
 	}, [ originalUrl ]);
 
 	useEffect(() => {
-		console.log("---------- effect fire ------------", { isLoggedIn });
 		const recheckValidity = async () => {
 			const status: boolean | AxiosError = await OAuthManager.checkValidity();
 			if (status instanceof AxiosError) {
@@ -257,9 +256,6 @@ const ConfigSteps = () => {
 			setLoaderForLogin(false);
 			setOrganizations([]);
 			if (status === true) {
-				console.log("========== start loading orgs ===========");
-				console.log("========== start loading orgs ===========", { isLoggedIn });
-				console.log("========== start loading orgs ===========");
 				const result = await getOrganizations();
 				if (result.success) {
 					if (result.orgs.length === 0) {

--- a/spa/src/pages/ConfigSteps/index.tsx
+++ b/spa/src/pages/ConfigSteps/index.tsx
@@ -257,7 +257,7 @@ const ConfigSteps = () => {
 			setOrganizations([]);
 			if (status === true) {
 				const result = await getOrganizations();
-				if (result.success) {
+				if (result.success && result.orgs.length === 0) {
 					if (result.orgs.length === 0) {
 						await installNewOrg("auto");
 					}

--- a/spa/src/services/app-manager/index.ts
+++ b/spa/src/services/app-manager/index.ts
@@ -27,13 +27,23 @@ async function connectOrg(orgId: number): Promise<boolean | AxiosError> {
 	}
 }
 
+let lastOpenWin: WindowProxy | null = null;
 async function installNewApp(callbacks: {
 	onFinish: (gitHubInstallationId: number | undefined) => void,
 	onRequested: (setupAction: string) => void
 }): Promise<void> {
+
 	const app = await Api.app.getAppNewInstallationUrl();
 
+	if(lastOpenWin) {
+		//do nothing, as there's already an win opened.
+		return;
+	}
+
+	const winInstall = lastOpenWin = popup(app.data.appInstallationUrl);
+
 	const handler = async (event: MessageEvent) => {
+		lastOpenWin = null;
 		if (event.data?.type === "install-callback" && event.data?.gitHubInstallationId) {
 			const id = parseInt(event.data?.gitHubInstallationId);
 			callbacks.onFinish(isNaN(id) ? undefined : id);
@@ -45,14 +55,13 @@ async function installNewApp(callbacks: {
 	};
 	window.addEventListener("message", handler);
 
-	const winInstall = popup(app.data.appInstallationUrl);
-
 	// Still need below interval for window close
 	// As user might not finish the app install flow, there's no guarantee that above message
 	// event will happen.
 	const hdlWinInstall = setInterval(() => {
 		if (winInstall?.closed) {
 			try {
+				lastOpenWin = null;
 				setTimeout(() => window.removeEventListener("message", handler), 1000); //give time for above message handler to kick off
 			} catch (e) {
 				reportError(e);

--- a/src/github/code-scanning-alert.ts
+++ b/src/github/code-scanning-alert.ts
@@ -19,7 +19,7 @@ export const codeScanningAlertWebhookHandler = async (context: WebhookContext, j
 	const result = await jiraClient.remoteLink.submit(jiraPayload);
 	const gitHubAppId = context.gitHubAppConfig?.gitHubAppId;
 
-	const webhookReceived = context.payload.webhookReceived;
+	const webhookReceived = context.webhookReceived;
 	webhookReceived && emitWebhookProcessedMetrics(
 		new Date(webhookReceived).getTime(),
 		"code_scanning_alert",


### PR DESCRIPTION
**What's in this PR?**
1. Remove the cycle reference on getOrgs <--> installNewOrgs
2. Add lock to forbid open tabs multi times. 


**Why**
1. Cycle reference is always bad
2. From some reference page https://upmostly.com/tutorials/why-is-my-useeffect-hook-running-twice-in-react , it is better to model our api (in useEffect) to be idempotent (as much as we can)

**Added feature flags**

**Affected issues**  


**How has this been tested?**  
Local

**Whats Next?**
