### PR TITLE
None redirect to new exp on empty sub

### DIFF
--- a/src/routes/jira/jira-get.test.ts
+++ b/src/routes/jira/jira-get.test.ts
@@ -10,6 +10,8 @@ import express from "express";
 import supertest from "supertest";
 import { encodeSymmetric } from "atlassian-jwt";
 import { getFrontendApp } from "~/src/app";
+import { when } from "jest-when";
+import { booleanFlag, BooleanFlags } from "config/feature-flags";
 
 jest.mock("config/feature-flags");
 jest.mock("utils/app-properties-utils");
@@ -304,5 +306,16 @@ describe.each([
 			.then(response => {
 				expect(response.text).toContain("<h1 class=\"jiraConfiguration__header__title\">GitHub configuration</h1>");
 			});
+	});
+
+	describe("5ku new experience", () => {
+		it("should redirect to new spa entry page on empty state", async () => {
+			when(booleanFlag).calledWith(BooleanFlags.USE_NEW_5KU_SPA_EXPERIENCE, jiraHost)
+				.mockResolvedValue(true);
+			await supertest(frontendApp)
+				.get(url)
+				.expect(302)
+				.expect("location", "/spa?from=homepage");
+		});
 	});
 });

--- a/src/routes/jira/jira-get.test.ts
+++ b/src/routes/jira/jira-get.test.ts
@@ -309,13 +309,23 @@ describe.each([
 	});
 
 	describe("5ku new experience", () => {
-		it("should redirect to new spa entry page on empty state", async () => {
+		it("should redirect to new spa entry page on empty state if ff on", async () => {
 			when(booleanFlag).calledWith(BooleanFlags.USE_NEW_5KU_SPA_EXPERIENCE, jiraHost)
 				.mockResolvedValue(true);
 			await supertest(frontendApp)
 				.get(url)
 				.expect(302)
 				.expect("location", "/spa?from=homepage");
+		});
+		it("should show existing page on empty state if ff off", async () => {
+			when(booleanFlag).calledWith(BooleanFlags.USE_NEW_5KU_SPA_EXPERIENCE, jiraHost)
+				.mockResolvedValue(false);
+			await supertest(frontendApp)
+				.get(url)
+				.expect(200)
+				.then(response => {
+					expect(response.text).toContain("<h1 class=\"jiraConfiguration__header__title\">GitHub configuration</h1>");
+				});
 		});
 	});
 });

--- a/src/routes/jira/jira-get.ts
+++ b/src/routes/jira/jira-get.ts
@@ -162,6 +162,11 @@ const renderJiraCloudAndEnterpriseServer = async (res: Response, req: Request): 
 	const hasConnections =  !!(installations.total || gheServers?.length);
 
 	const useNewSPAExperience = await booleanFlag(BooleanFlags.USE_NEW_5KU_SPA_EXPERIENCE, jiraHost);
+	if (useNewSPAExperience && !hasConnections) {
+		res.redirect("/spa?from=homepage");
+		return;
+	}
+
 	res.render("jira-configuration.hbs", {
 		host: jiraHost,
 		gheServers: groupedGheServers,


### PR DESCRIPTION
**What's in this PR?**
1. Add a redirect for new 5ku experience that on empty state, go directly to the new page.

**Why**
1. One less step for the user.

**Added feature flags**
enable-5ku-experience--cloud-connect

**Affected issues**  
None

**How has this been tested?**  
Unit test + local

**Whats Next?**
N/A
