### PR TITLE
ARC-2316: start sending analytic events to SQS

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -30,6 +30,7 @@ export enum BooleanFlags {
 	ENABLE_GITHUB_SECURITY_IN_JIRA = "enable-github-security-in-jira",
 	DELETE_MESSAGE_ON_BACKFILL_WHEN_OTHERS_WORKING_ON_IT = "delete-message-on-backfill-when-others-working-on-it",
 	USE_NEW_5KU_SPA_EXPERIENCE = "enable-5ku-experience--cloud-connect",
+	SEND_ANALYTICS_TO_SQS = "send-analytics-to-sqs"
 }
 
 export enum StringFlags {

--- a/src/github/push.ts
+++ b/src/github/push.ts
@@ -33,7 +33,7 @@ export const pushWebhookHandler = async (context: WebhookContext, jiraClient, _u
 	const jiraHost = jiraClient.baseURL;
 	const gitHubAppId = context.gitHubAppConfig?.gitHubAppId;
 	const gitHubProduct = getCloudOrServerFromGitHubAppId(context.gitHubAppConfig?.gitHubAppId);
-	sendAnalytics(jiraHost, AnalyticsEventTypes.TrackEvent, {
+	await sendAnalytics(jiraHost, AnalyticsEventTypes.TrackEvent, {
 		action: AnalyticsTrackEventsEnum.CommitsPushedTrackEventName,
 		actionSubject: AnalyticsTrackEventsEnum.CommitsPushedTrackEventName,
 		source: !gitHubAppId ? AnalyticsTrackSource.Cloud : AnalyticsTrackSource.GitHubEnterprise

--- a/src/routes/api/api-router.ts
+++ b/src/routes/api/api-router.ts
@@ -1,4 +1,3 @@
-import AWS from "aws-sdk";
 import { NextFunction, Request, Response, Router } from "express";
 import { body, param } from "express-validator";
 import rateLimit from "express-rate-limit";
@@ -25,8 +24,6 @@ import { ApiResetSubscriptionFailedTasks } from "./api-reset-subscription-failed
 import { RecoverCommitsFromDatePost } from "./commits-from-date/recover-commits-from-dates";
 import { ResetFailedAndPendingDeploymentCursorPost } from "./commits-from-date/reset-failed-and-pending-deployment-cursors";
 import { ApiRecryptPost } from "./api-recrypt-post";
-import { envVars } from "config/env";
-import { SendMessageRequest } from "aws-sdk/clients/sqs";
 export const ApiRouter = Router();
 
 // TODO: remove this duplication because of the horrible way to do logs through requests
@@ -145,26 +142,6 @@ const cryptorDebugEndpoint = async (_req: Request, resp: Response) => {
 	}
 };
 ApiRouter.use("/cryptor", cryptorDebugEndpoint);
-
-// Temp code, TODO: :killwithfire:
-const analyticsQueueConnectivityTest = async (req: Request, resp: Response) => {
-	req.log.info("starting connectivity test");
-	const sqs = new AWS.SQS({ apiVersion: "2012-11-05", region: envVars.SQS_INCOMINGANALYTICEVENTS_QUEUE_REGION });
-	const params: SendMessageRequest = {
-		MessageBody: JSON.stringify({ hello: "world" }),
-		QueueUrl: envVars.SQS_INCOMINGANALYTICEVENTS_QUEUE_URL,
-		DelaySeconds: 0
-	};
-	try {
-		const sendMessageResult = await sqs.sendMessage(params)
-			.promise();
-		req.log.info({ sendMessageResult }, "connectivity test succeeded!");
-		resp.sendStatus(200);
-	} catch (err) {
-		req.log.error({ err }, "connectivity test failed!");
-	}
-};
-ApiRouter.use("/analytics-queue-connectivity-test", analyticsQueueConnectivityTest);
 
 ApiRouter.use("/db-migration", DBMigrationsRouter);
 ApiRouter.post("/recover-client-key", RecoverClientKeyPost);

--- a/src/routes/github/configuration/github-configuration-get.ts
+++ b/src/routes/github/configuration/github-configuration-get.ts
@@ -164,7 +164,7 @@ export const GithubConfigurationGet = async (req: Request, res: Response, next: 
 
 	req.log.info({ method: req.method, requestUrl: req.originalUrl }, `Request for type ${gitHubProduct}`);
 
-	sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
+	await sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
 		name: AnalyticsScreenEventsEnum.ConnectAnOrgScreenEventName
 	},
 	{

--- a/src/routes/github/create-branch/github-create-branch-get.ts
+++ b/src/routes/github/create-branch/github-create-branch-get.ts
@@ -47,7 +47,7 @@ export const GithubCreateBranchGet = async (req: Request, res: Response, next: N
 			configurationUrl: `${jiraHost}/plugins/servlet/ac/${envVars.APP_KEY}/github-select-product-page`
 		});
 
-		sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
+		await sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
 			name: AnalyticsScreenEventsEnum.NotConfiguredScreenEventName
 		}, {
 			jiraHost
@@ -74,7 +74,7 @@ export const GithubCreateBranchGet = async (req: Request, res: Response, next: N
 
 	req.log.debug(`Github Create Branch Page rendered page`);
 
-	sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
+	await sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
 		name: AnalyticsScreenEventsEnum.CreateBranchScreenEventName
 	}, {
 		jiraHost

--- a/src/routes/github/create-branch/github-create-branch-options-get.ts
+++ b/src/routes/github/create-branch/github-create-branch-options-get.ts
@@ -33,7 +33,7 @@ export const GithubCreateBranchOptionsGet = async (req: Request, res: Response, 
 			configurationUrl: `${jiraHost}/plugins/servlet/ac/${envVars.APP_KEY}/github-select-product-page`
 		});
 
-		sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
+		await sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
 			name: AnalyticsScreenEventsEnum.NotConfiguredScreenEventName
 		}, {
 			jiraHost
@@ -62,7 +62,7 @@ export const GithubCreateBranchOptionsGet = async (req: Request, res: Response, 
 		servers
 	});
 
-	sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
+	await sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
 		name: AnalyticsScreenEventsEnum.CreateBranchOptionsScreenEventName
 	}, {
 		jiraHost

--- a/src/routes/github/create-branch/github-create-branch-post.ts
+++ b/src/routes/github/create-branch/github-create-branch-post.ts
@@ -65,7 +65,7 @@ export const GithubCreateBranchPost = async (req: Request, res: Response): Promi
 		res.sendStatus(200);
 
 		logger.info("Branch create successful.");
-		sendTrackEventAnalytics(AnalyticsTrackEventsEnum.CreateBranchSuccessTrackEventName, jiraHost);
+		await sendTrackEventAnalytics(AnalyticsTrackEventsEnum.CreateBranchSuccessTrackEventName, jiraHost);
 		const tags = {
 			name: newBranchName,
 			gitHubProduct: getCloudOrServerFromGitHubAppId(gitHubAppConfig.githubAppId)
@@ -74,15 +74,15 @@ export const GithubCreateBranchPost = async (req: Request, res: Response): Promi
 	} catch (err) {
 		logger.error({ err }, getErrorMessages(err.status));
 		res.status(err.status).json({ error: getErrorMessages(err.status) });
-		sendTrackEventAnalytics(AnalyticsTrackEventsEnum.CreateBranchErrorTrackEventName, jiraHost);
+		await sendTrackEventAnalytics(AnalyticsTrackEventsEnum.CreateBranchErrorTrackEventName, jiraHost);
 		statsd.increment(metricCreateBranch.failed, {
 			name: newBranchName
 		}, { jiraHost });
 	}
 };
 
-const sendTrackEventAnalytics = (name: string, jiraHost: string) => {
-	sendAnalytics(jiraHost, AnalyticsEventTypes.TrackEvent, {
+const sendTrackEventAnalytics = async (name: string, jiraHost: string) => {
+	await sendAnalytics(jiraHost, AnalyticsEventTypes.TrackEvent, {
 		action: name,
 		actionSubject: name,
 		source: AnalyticsTrackSource.CreateBranch

--- a/src/routes/github/manifest/github-manifest-complete-get.ts
+++ b/src/routes/github/manifest/github-manifest-complete-get.ts
@@ -60,7 +60,7 @@ export const GithubManifestCompleteGet = async (req: Request, res: Response) => 
 
 		await tempStorage.delete(uuid, res.locals.installation.id);
 
-		sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
+		await sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
 			action: AnalyticsTrackEventsEnum.AutoCreateGitHubServerAppTrackEventName,
 			actionSubject: AnalyticsTrackEventsEnum.AutoCreateGitHubServerAppTrackEventName,
 			source: AnalyticsTrackSource.GitHubEnterprise
@@ -79,7 +79,7 @@ export const GithubManifestCompleteGet = async (req: Request, res: Response) => 
 		 * And the rest of the queryParameters are simply forwarded to the new `retryUrl`
 		 */
 
-		sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
+		await sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
 			action: AnalyticsTrackEventsEnum.AutoCreateGitHubServerAppTrackEventName,
 			actionSubject: AnalyticsTrackEventsEnum.AutoCreateGitHubServerAppTrackEventName,
 			source: AnalyticsTrackSource.GitHubEnterprise

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-create-or-edit-get.ts
@@ -68,7 +68,7 @@ export const JiraConnectEnterpriseAppCreateOrEditGet = async (
 			};
 		}
 
-		sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
+		await sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
 			name: AnalyticsScreenEventsEnum.CreateOrEditGitHubServerAppScreenEventName
 		}, {
 			isNew

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-delete.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-delete.ts
@@ -19,7 +19,7 @@ export const JiraConnectEnterpriseAppDelete = async (
 
 		await GitHubServerApp.uninstallApp(gitHubAppConfig.uuid);
 
-		sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
+		await sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
 			action: AnalyticsTrackEventsEnum.DeleteGitHubServerAppTrackEventName,
 			actionSubject: AnalyticsTrackEventsEnum.DeleteGitHubServerAppTrackEventName,
 			source: AnalyticsTrackSource.GitHubEnterprise
@@ -31,7 +31,7 @@ export const JiraConnectEnterpriseAppDelete = async (
 		req.log.debug("Jira Connect Enterprise App deleted successfully.");
 	} catch (error) {
 
-		sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
+		await sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
 			action: AnalyticsTrackEventsEnum.DeleteGitHubServerAppTrackEventName,
 			actionSubject: AnalyticsTrackEventsEnum.DeleteGitHubServerAppTrackEventName,
 			source: AnalyticsTrackSource.GitHubEnterprise

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-post.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-post.ts
@@ -59,7 +59,7 @@ export const JiraConnectEnterpriseAppPost = async (
 
 		await new GheConnectConfigTempStorage().delete(uuid, installation.id);
 
-		sendAnalytics(jiraHost, AnalyticsEventTypes.TrackEvent, {
+		await sendAnalytics(jiraHost, AnalyticsEventTypes.TrackEvent, {
 			action: AnalyticsTrackEventsEnum.CreateGitHubServerAppTrackEventName,
 			actionSubject: AnalyticsTrackEventsEnum.CreateGitHubServerAppTrackEventName,
 			source: AnalyticsTrackSource.GitHubEnterprise
@@ -73,7 +73,7 @@ export const JiraConnectEnterpriseAppPost = async (
 		req.log.debug("Jira Connect Enterprise App added successfully.");
 	} catch (err) {
 
-		sendAnalytics(jiraHost, AnalyticsEventTypes.TrackEvent, {
+		await sendAnalytics(jiraHost, AnalyticsEventTypes.TrackEvent, {
 			action: AnalyticsTrackEventsEnum.CreateGitHubServerAppTrackEventName,
 			actionSubject: AnalyticsTrackEventsEnum.CreateGitHubServerAppTrackEventName,
 			source: AnalyticsTrackSource.GitHubEnterprise

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-put.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-app-put.ts
@@ -37,7 +37,7 @@ export const JiraConnectEnterpriseAppPut = async (
 				: null
 		}, jiraHost);
 
-		sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
+		await sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
 			action: AnalyticsTrackEventsEnum.UpdateGitHubServerAppTrackEventName,
 			actionSubject: AnalyticsTrackEventsEnum.UpdateGitHubServerAppTrackEventName,
 			source: AnalyticsTrackSource.GitHubEnterprise
@@ -49,7 +49,7 @@ export const JiraConnectEnterpriseAppPut = async (
 		req.log.debug("Jira Connect Enterprise App updated successfully.");
 	} catch (error) {
 
-		sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
+		await sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
 			action: AnalyticsTrackEventsEnum.UpdateGitHubServerAppTrackEventName,
 			actionSubject: AnalyticsTrackEventsEnum.UpdateGitHubServerAppTrackEventName,
 			source: AnalyticsTrackSource.GitHubEnterprise

--- a/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-apps-get.ts
+++ b/src/routes/jira/connect/enterprise/app/jira-connect-enterprise-apps-get.ts
@@ -32,7 +32,7 @@ export const JiraConnectEnterpriseAppsGet = async (
 			// `identifier` is the githubAppName for the GH server app
 			const serverApps = gheServers.map(server => ({ identifier: server.gitHubAppName, uuid: server.uuid }));
 
-			sendScreenAnalytics({ jiraHost: res.locals.jiraHost, isNew, gheServers, name: AnalyticsScreenEventsEnum.SelectGitHubAppsListScreenEventName });
+			await sendScreenAnalytics({ jiraHost: res.locals.jiraHost, isNew, gheServers, name: AnalyticsScreenEventsEnum.SelectGitHubAppsListScreenEventName });
 			res.render("jira-select-server-app.hbs", {
 				list: serverApps,
 				pathNameForAddNew: "github-app-creation-page", // lol, this actually references the same endpoint, but with new flag :mindpop:
@@ -44,7 +44,7 @@ export const JiraConnectEnterpriseAppsGet = async (
 				serverUrl: baseUrl
 			});
 		} else {
-			sendScreenAnalytics({ jiraHost: res.locals.jiraHost, isNew, gheServers, name: AnalyticsScreenEventsEnum.SelectGitHubAppsCreationScreenEventName });
+			await sendScreenAnalytics({ jiraHost: res.locals.jiraHost, isNew, gheServers, name: AnalyticsScreenEventsEnum.SelectGitHubAppsCreationScreenEventName });
 			res.render("jira-select-app-creation.hbs", {
 				connectConfigUuid: tempConnectConfigUuidOrServerUuid
 			});
@@ -56,8 +56,8 @@ export const JiraConnectEnterpriseAppsGet = async (
 	}
 };
 
-const sendScreenAnalytics = ({ jiraHost, isNew, gheServers, name }) => {
-	sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
+const sendScreenAnalytics = async ({ jiraHost, isNew, gheServers, name }) => {
+	await sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
 		name
 	}, {
 		createNew: isNew,

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-delete.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-delete.ts
@@ -15,7 +15,7 @@ export const JiraConnectEnterpriseDelete = async (
 
 		await GitHubServerApp.uninstallServer(req.body.serverUrl, installation.id);
 
-		sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
+		await sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
 			action: AnalyticsTrackEventsEnum.RemoveGitHubServerTrackEventName,
 			actionSubject: AnalyticsTrackEventsEnum.RemoveGitHubServerTrackEventName,
 			source: AnalyticsTrackSource.GitHubEnterprise
@@ -27,7 +27,7 @@ export const JiraConnectEnterpriseDelete = async (
 		req.log.debug("Jira Connect Enterprise Server successfully deleted.");
 	} catch (error) {
 
-		sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
+		await sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
 			action: AnalyticsTrackEventsEnum.RemoveGitHubServerTrackEventName,
 			actionSubject: AnalyticsTrackEventsEnum.RemoveGitHubServerTrackEventName,
 			source: AnalyticsTrackSource.GitHubEnterprise

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-get.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-get.ts
@@ -23,7 +23,7 @@ export const JiraConnectEnterpriseGet = async (
 				uuid: servers[0].uuid
 			})).value();
 
-			sendScreenAnalytics({ jiraHost: res.locals.jiraHost, isNew, gheServers, name: AnalyticsScreenEventsEnum.SelectGitHubServerListScreenEventName });
+			await sendScreenAnalytics({ jiraHost: res.locals.jiraHost, isNew, gheServers, name: AnalyticsScreenEventsEnum.SelectGitHubServerListScreenEventName });
 			res.render("jira-select-server.hbs", {
 				list: servers,
 				// Passing these query parameters for the route when clicking `Connect a new server`
@@ -31,7 +31,7 @@ export const JiraConnectEnterpriseGet = async (
 				queryStringForPathNew: JSON.stringify({ new: 1 })
 			});
 		} else {
-			sendScreenAnalytics({ jiraHost: res.locals.jiraHost, isNew, gheServers, name: AnalyticsScreenEventsEnum.SelectGitHubServerUrlScreenEventName });
+			await sendScreenAnalytics({ jiraHost: res.locals.jiraHost, isNew, gheServers, name: AnalyticsScreenEventsEnum.SelectGitHubServerUrlScreenEventName });
 			res.render("jira-server-url.hbs", {
 				csrfToken: req.csrfToken(),
 				installationId: res.locals.installation.id,
@@ -45,8 +45,8 @@ export const JiraConnectEnterpriseGet = async (
 	}
 };
 
-const sendScreenAnalytics = ({ jiraHost, isNew, gheServers, name }) => {
-	sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
+const sendScreenAnalytics = async ({ jiraHost, isNew, gheServers, name }) => {
+	await sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
 		name
 	}, {
 		createNew: isNew,

--- a/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.ts
+++ b/src/routes/jira/connect/enterprise/jira-connect-enterprise-post.ts
@@ -152,7 +152,7 @@ export const JiraConnectEnterprisePost = async (
 
 		await saveTempConfigAndRespond200(res, gitHubConnectConfig, installationId);
 
-		sendAnalytics(jiraHost, AnalyticsEventTypes.TrackEvent, {
+		await sendAnalytics(jiraHost, AnalyticsEventTypes.TrackEvent, {
 			action: AnalyticsTrackEventsEnum.GitHubServerUrlTrackEventName,
 			actionSubject: AnalyticsTrackEventsEnum.GitHubServerUrlTrackEventName,
 			source: AnalyticsTrackSource.GitHubEnterprise
@@ -166,7 +166,7 @@ export const JiraConnectEnterprisePost = async (
 		if (isResponseFromGhe(req.log, axiosError.response)) {
 			req.log.info({ err }, "Server is reachable, but responded with a status different from 200/202");
 			await saveTempConfigAndRespond200(res, gitHubConnectConfig, installationId);
-			sendAnalytics(jiraHost, AnalyticsEventTypes.TrackEvent, {
+			await sendAnalytics(jiraHost, AnalyticsEventTypes.TrackEvent, {
 				action: AnalyticsTrackEventsEnum.GitHubServerUrlTrackEventName,
 				actionSubject: AnalyticsTrackEventsEnum.GitHubServerUrlTrackEventName,
 				source: AnalyticsTrackSource.GitHubEnterprise

--- a/src/routes/jira/connect/jira-connect-get.ts
+++ b/src/routes/jira/connect/jira-connect-get.ts
@@ -10,7 +10,7 @@ export const JiraConnectGet = async (
 	try {
 		req.log.info("Received Jira Connect page request");
 
-		sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.ScreenEvent, {
+		await sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.ScreenEvent, {
 			name: AnalyticsScreenEventsEnum.SelectGitHubProductEventName
 		}, {
 			jiraHost: res.locals.jiraHost

--- a/src/routes/jira/jira-delete.ts
+++ b/src/routes/jira/jira-delete.ts
@@ -58,7 +58,7 @@ export const JiraDelete = async (req: Request, res: Response): Promise<void> => 
 	}
 	await subscription.destroy();
 
-	sendAnalytics(jiraHost, AnalyticsEventTypes.TrackEvent, {
+	await sendAnalytics(jiraHost, AnalyticsEventTypes.TrackEvent, {
 		action: AnalyticsTrackEventsEnum.DisconnectToOrgTrackEventName,
 		actionSubject: AnalyticsTrackEventsEnum.DisconnectToOrgTrackEventName,
 		source: !gitHubAppId ? AnalyticsTrackSource.Cloud : AnalyticsTrackSource.GitHubEnterprise

--- a/src/routes/jira/jira-get.ts
+++ b/src/routes/jira/jira-get.ts
@@ -181,7 +181,7 @@ const renderJiraCloudAndEnterpriseServer = async (res: Response, req: Request): 
 	const allSuccessfulConnections = [...successfulCloudConnections, ...gheServersWithConnections];
 	const completeConnections = allSuccessfulConnections.filter(connection => connection.syncStatus === "FINISHED");
 
-	sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
+	await sendAnalytics(jiraHost, AnalyticsEventTypes.ScreenEvent, {
 		name: AnalyticsScreenEventsEnum.GitHubConfigScreenEventName
 	}, {
 		jiraHost,

--- a/src/routes/jira/sync/jira-sync-post.ts
+++ b/src/routes/jira/sync/jira-sync-post.ts
@@ -38,7 +38,7 @@ export const JiraSyncPost = async (req: Request, res: Response, next: NextFuncti
 		const { syncType, targetTasks } = await determineSyncTypeAndTargetTasks(syncTypeFromReq, subscription);
 		await findOrStartSync(subscription, req.log, syncType, commitsFromDate || subscription.backfillSince, targetTasks, { source });
 
-		sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
+		await sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
 			action: AnalyticsTrackEventsEnum.ManualRestartBackfillTrackEventName,
 			actionSubject: AnalyticsTrackEventsEnum.ManualRestartBackfillTrackEventName,
 			source: !gitHubAppId ? AnalyticsTrackSource.Cloud : AnalyticsTrackSource.GitHubEnterprise
@@ -51,7 +51,7 @@ export const JiraSyncPost = async (req: Request, res: Response, next: NextFuncti
 		res.sendStatus(202);
 	} catch (error) {
 
-		sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
+		await sendAnalytics(res.locals.jiraHost, AnalyticsEventTypes.TrackEvent, {
 			action: AnalyticsTrackEventsEnum.ManualRestartBackfillTrackEventName,
 			actionSubject: AnalyticsTrackEventsEnum.ManualRestartBackfillTrackEventName,
 			source: !gitHubAppId ? AnalyticsTrackSource.Cloud : AnalyticsTrackSource.GitHubEnterprise

--- a/src/services/subscription-installation-service.ts
+++ b/src/services/subscription-installation-service.ts
@@ -124,7 +124,7 @@ export const verifyAdminPermsAndFinishInstallation =
 				]
 			);
 
-			sendAnalytics(installation.jiraHost, AnalyticsEventTypes.TrackEvent, {
+			await sendAnalytics(installation.jiraHost, AnalyticsEventTypes.TrackEvent, {
 				action: AnalyticsTrackEventsEnum.ConnectToOrgTrackEventName,
 				actionSubject: AnalyticsTrackEventsEnum.ConnectToOrgTrackEventName,
 				source: !gitHubServerAppIdPk ? AnalyticsTrackSource.Cloud : AnalyticsTrackSource.GitHubEnterprise
@@ -138,7 +138,7 @@ export const verifyAdminPermsAndFinishInstallation =
 			return {};
 		} catch (err) {
 
-			sendAnalytics(installation.jiraHost, AnalyticsEventTypes.TrackEvent, {
+			await sendAnalytics(installation.jiraHost, AnalyticsEventTypes.TrackEvent, {
 				action: AnalyticsTrackEventsEnum.ConnectToOrgTrackEventName,
 				actionSubject: AnalyticsTrackEventsEnum.ConnectToOrgTrackEventName,
 				source: !gitHubServerAppIdPk ? AnalyticsTrackSource.Cloud : AnalyticsTrackSource.GitHubEnterprise

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -204,7 +204,7 @@ const markSyncAsCompleteAndStop = async (data: BackfillMessagePayload, subscript
 			gitHubProduct,
 			repos: repoCountToBucket(subscription.totalNumberOfRepos)
 		}, { jiraHost: subscription.jiraHost });
-		sendAnalytics(subscription.jiraHost, AnalyticsEventTypes.TrackEvent, {
+		await sendAnalytics(subscription.jiraHost, AnalyticsEventTypes.TrackEvent, {
 			actionSubject: AnalyticsTrackEventsEnum.BackfullSyncOperationEventName,
 			action: "complete",
 			source: data.metricTags?.source || "worker"

--- a/src/util/analytics-client.test.ts
+++ b/src/util/analytics-client.test.ts
@@ -1,0 +1,72 @@
+import { booleanFlag, BooleanFlags } from "config/feature-flags";
+import { when } from "jest-when";
+import { ScreenEventProps, sendAnalytics } from "utils/analytics-client";
+import { SQS } from "aws-sdk";
+
+jest.mock("config/feature-flags");
+
+jest.mock("aws-sdk");
+
+describe("analytics-client", () => {
+	let oldMicrosEnvType: string | undefined;
+
+	beforeEach(() => {
+		when(booleanFlag).calledWith(BooleanFlags.SEND_ANALYTICS_TO_SQS, jiraHost).mockResolvedValue(true);
+		oldMicrosEnvType = process.env.MICROS_ENVTYPE;
+		process.env.MICROS_ENVTYPE = "prod";
+
+		(SQS as unknown as jest.Mock).mockImplementation(() => {
+			return {
+				sendMessage: jest.fn().mockReturnValue({
+					promise: jest.fn().mockResolvedValue(true)
+				})
+			};
+		});
+	});
+
+	afterEach(() => {
+		process.env.MICROS_ENVTYPE = oldMicrosEnvType;
+	});
+
+	it("hashes jiraHost attribute before sending", async () => {
+		await sendAnalytics(jiraHost, "screen", {} as unknown as ScreenEventProps & Record<string, unknown>, { jiraHost });
+
+		const sendMessageCalls = (SQS as unknown as jest.Mock).mock.results[0].value.sendMessage.mock.calls;
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		expect(JSON.parse(sendMessageCalls[0][0].MessageBody).eventPayload.eventAttributes.jiraHost).toStrictEqual("553291b03783c4875ed1b0ae4d1c8dde93070e028bc064137980c99e3e7df1da");
+	});
+
+	it("sends analytic event to SQS", async () => {
+		await sendAnalytics(jiraHost, "screen", { foo: "bar" } as unknown as ScreenEventProps & Record<string, unknown>, { jiraHost, blah: "baz" }, "myAccountId");
+
+		const sendMessageCalls = (SQS as unknown as jest.Mock).mock.results[0].value.sendMessage.mock.calls;
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		const capturedPayload = JSON.parse(sendMessageCalls[0][0].MessageBody);
+		expect(capturedPayload).toStrictEqual(
+			{
+				eventPayload:  {
+					accountId: "myAccountId",
+					eventAttributes:  {
+						appKey: "com.github.integration.test-atlassian-instance",
+						blah: "baz",
+						jiraHost: "553291b03783c4875ed1b0ae4d1c8dde93070e028bc064137980c99e3e7df1da"
+					},
+					eventProps:  {
+						foo: "bar"
+					},
+					eventType: "screen"
+				},
+				jiraHost: "https://test-atlassian-instance.atlassian.net"
+			}
+		);
+	});
+
+	it("does not send analytics for test instances", async () => {
+		await sendAnalytics("https://site-1.some-test.atlassian.net", "screen", {} as unknown as ScreenEventProps & Record<string, unknown>, {});
+		expect(booleanFlag).not.toHaveBeenCalled();
+	});
+});

--- a/src/util/analytics-client.ts
+++ b/src/util/analytics-client.ts
@@ -6,6 +6,9 @@ import { createHashWithoutSharedSecret } from "utils/encryption";
 import _, { omit } from "lodash";
 import { MicrosEnvTypeEnum } from "interfaces/common";
 import { isTestJiraHost } from "config/jira-test-site-check";
+import { booleanFlag, BooleanFlags } from "config/feature-flags";
+import AWS from "aws-sdk";
+import { SendMessageRequest } from "aws-sdk/clients/sqs";
 
 const { analyticsClient } = optionalRequire("@atlassiansox/analytics-node-client", true) || {};
 const logger = getLogger("analytics");
@@ -34,6 +37,50 @@ const calculateClientEnv = () => {
 	return "dev";
 };
 
+interface SQSEventPayload {
+	accountId?: string;
+	eventType: "screen" | "ui" | "operational" | "track";
+	eventProps: ScreenEventProps | TrackOpUiEventProps;
+	eventAttributes?: Record<string, unknown>;
+}
+
+export interface SQSAnalyticsMessagePayload {
+	jiraHost: string;
+	eventPayload: SQSEventPayload;
+}
+
+export const sendAnalyticsWithSqs = async (
+	jiraHost: string,
+	eventType: "screen" | "ui" | "operational" | "track",
+	eventProps: (ScreenEventProps | TrackOpUiEventProps)  & Record<string, unknown>,
+	attributes: Record<string, unknown> = {},
+	accountId?: string
+): Promise<void> => {
+
+	const payload: SQSAnalyticsMessagePayload = {
+		jiraHost,
+		eventPayload: {
+			accountId,
+			eventType,
+			eventProps,
+			eventAttributes: attributes
+		}
+	};
+	const sqs = new AWS.SQS({ apiVersion: "2012-11-05", region: envVars.SQS_INCOMINGANALYTICEVENTS_QUEUE_REGION });
+	const params: SendMessageRequest = {
+		MessageBody: JSON.stringify(payload),
+		QueueUrl: envVars.SQS_INCOMINGANALYTICEVENTS_QUEUE_URL,
+		DelaySeconds: 0
+	};
+	try {
+		const sendMessageResult = await sqs.sendMessage(params)
+			.promise();
+		logger.info({ sendMessageResult }, "Publishing an analytic event to SQS");
+	} catch (err) {
+		logger.error({ err }, "Cannot publish the event to SQS");
+	}
+};
+
 /**
  *
  * @param jiraHost
@@ -45,7 +92,24 @@ const calculateClientEnv = () => {
 export const sendAnalytics: {
 	(jiraHost: string, eventType: "screen", eventProps: ScreenEventProps & Record<string, unknown>, attributes: Record<string, unknown>, accountId?: string);
 	(jiraHost: string, eventType: "ui" | "operational" | "track", eventProps: TrackOpUiEventProps  & Record<string, unknown>, attributes: Record<string, unknown>, accountId?: string);
-} = (jiraHost: string, eventType: string, eventProps: (ScreenEventProps | TrackOpUiEventProps)  & Record<string, unknown>, unsafeAttributes: Record<string, unknown> = {}, accountId?: string): void => {
+} = async (jiraHost: string, eventType: "screen" | "ui" | "operational" | "track", eventProps: (ScreenEventProps | TrackOpUiEventProps)  & Record<string, unknown>, unsafeAttributes: Record<string, unknown> = {}, accountId?: string): Promise<void> => {
+
+	if (isTestJiraHost(jiraHost) && envVars.MICROS_ENVTYPE === MicrosEnvTypeEnum.prod) {
+		logger.warn("Skip analytics for test jira in prod");
+		return;
+	}
+
+	const attributes = _.cloneDeep(unsafeAttributes);
+	if (attributes.jiraHost && (typeof attributes.jiraHost === "string")) {
+		attributes.jiraHost = createHashWithoutSharedSecret(attributes.jiraHost);
+	}
+
+	attributes.appKey = envVars.APP_KEY;
+
+	if (await booleanFlag(BooleanFlags.SEND_ANALYTICS_TO_SQS, jiraHost)) {
+		await sendAnalyticsWithSqs(jiraHost, eventType, eventProps, attributes, accountId);
+		return;
+	}
 
 	logger.debug({ jiraHost }, analyticsClient ? "Found analytics client." : `No analytics client found.`);
 
@@ -56,11 +120,6 @@ export const sendAnalytics: {
 
 	if (isNodeTest()) {
 		logger.warn("Analytics is disabled in tests");
-		return;
-	}
-
-	if (isTestJiraHost(jiraHost) && envVars.MICROS_ENVTYPE === MicrosEnvTypeEnum.prod) {
-		logger.warn("Skip analytics for test jira in prod");
 		return;
 	}
 
@@ -78,13 +137,6 @@ export const sendAnalytics: {
 		tenantIdType: "cloudId",
 		tenantId: "NONE" // TODO: determine from jiraHost
 	};
-
-	const attributes = _.cloneDeep(unsafeAttributes);
-	if (attributes.jiraHost && (typeof attributes.jiraHost === "string")) {
-		attributes.jiraHost = createHashWithoutSharedSecret(attributes.jiraHost);
-	}
-
-	attributes.appKey = envVars.APP_KEY;
 
 	logger.debug({ eventType }, "Sending analytics");
 

--- a/src/util/analytics-client.ts
+++ b/src/util/analytics-client.ts
@@ -7,7 +7,7 @@ import _, { omit } from "lodash";
 import { MicrosEnvTypeEnum } from "interfaces/common";
 import { isTestJiraHost } from "config/jira-test-site-check";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
-import AWS from "aws-sdk";
+import { SQS } from "aws-sdk";
 import { SendMessageRequest } from "aws-sdk/clients/sqs";
 
 const { analyticsClient } = optionalRequire("@atlassiansox/analytics-node-client", true) || {};
@@ -66,7 +66,7 @@ export const sendAnalyticsWithSqs = async (
 			eventAttributes: attributes
 		}
 	};
-	const sqs = new AWS.SQS({ apiVersion: "2012-11-05", region: envVars.SQS_INCOMINGANALYTICEVENTS_QUEUE_REGION });
+	const sqs = new SQS({ apiVersion: "2012-11-05", region: envVars.SQS_INCOMINGANALYTICEVENTS_QUEUE_REGION });
 	const params: SendMessageRequest = {
 		MessageBody: JSON.stringify(payload),
 		QueueUrl: envVars.SQS_INCOMINGANALYTICEVENTS_QUEUE_URL,
@@ -75,7 +75,7 @@ export const sendAnalyticsWithSqs = async (
 	try {
 		const sendMessageResult = await sqs.sendMessage(params)
 			.promise();
-		logger.info({ sendMessageResult }, "Publishing an analytic event to SQS");
+		logger.debug({ sendMessageResult }, "Published an analytic event to SQS");
 	} catch (err) {
 		logger.error({ err }, "Cannot publish the event to SQS");
 	}


### PR DESCRIPTION
**What's in this PR?**
Sending analytics event to SQS instead of via analytics client

**Why**

**Added feature flags**
Yes

**Affected issues**  
in title

**How has this been tested?**  
in ddev

<img width="300" alt="image" src="https://github.com/atlassian/github-for-jira/assets/20631664/d6125baf-ec7b-483e-a86e-f467c05e967a">
<img width="300" alt="image" src="https://github.com/atlassian/github-for-jira/assets/20631664/a6cd99c2-a72d-447a-b320-88a5469245ca">


**Whats Next?**
