### PR TITLE
5KU - Removing the path redirection in atlassian-connect.json

### DIFF
--- a/src/routes/jira/atlassian-connect/jira-atlassian-connect-get.ts
+++ b/src/routes/jira/atlassian-connect/jira-atlassian-connect-get.ts
@@ -264,11 +264,6 @@ export const JiraAtlassianConnectGet = async (_: Request, res: Response): Promis
 	modules.jiraDevelopmentTool.actions = await defineJiraDevelopmentToolModuleActions(jiraHost);
 	const isGitHubSecurityInJiraEnabled = await booleanFlag(BooleanFlags.ENABLE_GITHUB_SECURITY_IN_JIRA, jiraHost);
 
-	const useNewSPAExperience = await booleanFlag(BooleanFlags.USE_NEW_5KU_SPA_EXPERIENCE, jiraHost);
-	if (useNewSPAExperience) {
-		modules.postInstallPage.url = "/spa?from=postInstallPage";
-	}
-
 	res.status(200).json({
 		apiMigrations: {
 			gdpr: false,


### PR DESCRIPTION
**What's in this PR?**
- Removing the path  redirection in atlassian-connect.json because the redirect logic is already in `jira-get`.
