### PR TITLE
None refactor spa service app manager

### DIFF
--- a/spa/src/api/orgs/index.ts
+++ b/spa/src/api/orgs/index.ts
@@ -3,5 +3,5 @@ import { axiosRestWithGitHubToken } from "../axiosInstance";
 
 export default {
 	getOrganizations: () => axiosRestWithGitHubToken.get<OrganizationsResponse>("/rest/app/cloud/org"),
-	connectOrganization: (orgId: number) => axiosRestWithGitHubToken.post<OrganizationsResponse>("/rest/app/cloud/org", { installationId: orgId }),
+	connectOrganization: (orgId: number) => axiosRestWithGitHubToken.post<void>("/rest/app/cloud/org", { installationId: orgId }),
 };

--- a/spa/src/services/app-manager/index.test.ts
+++ b/spa/src/services/app-manager/index.test.ts
@@ -1,0 +1,64 @@
+import Api from "../../api";
+import AppManager from "./index";
+import { AxiosResponse, AxiosError } from "axios";
+import { OrganizationsResponse, ErrorCode } from "rest-interfaces";
+
+jest.mock("../../api");
+
+const successAxioResponse = <T>(data: T) => { return { status: 200, data } as AxiosResponse<T>; };
+const failAxioResponse = (status: number, errorCode: ErrorCode): AxiosError => {
+	return new AxiosError("error", "blah", undefined, undefined, {
+		status: status,
+		data: { errorCode }
+	} as AxiosResponse);
+};
+
+describe("app-manager", () => {
+	describe("fetchOrgs", () => {
+		it("should return empty orgs when token is empty", async () => {
+			jest.mocked(Api.token.hasGitHubToken).mockReturnValue(false);
+			const result = await AppManager.fetchOrgs();
+			expect(result).toEqual({ orgs: [] });
+		});
+		it("should return error code as result", async () => {
+			jest.mocked(Api.token.hasGitHubToken).mockReturnValue(true);
+			jest.mocked(Api.orgs.getOrganizations).mockRejectedValue(failAxioResponse(400, "INVALID_OR_MISSING_ARG"));
+			await expect(AppManager.fetchOrgs()).rejects.toThrow(failAxioResponse(400, "INVALID_OR_MISSING_ARG"));
+		});
+		it("should successfully return orgs", async () => {
+			jest.mocked(Api.token.hasGitHubToken).mockReturnValue(true);
+			jest.mocked(Api.orgs.getOrganizations).mockResolvedValue(successAxioResponse({
+				orgs: [{ id: 123 }]
+			} as OrganizationsResponse));
+			const result = await AppManager.fetchOrgs();
+			expect(result).toEqual({ orgs: [expect.objectContaining({ id: 123 }) ] });
+		});
+	});
+	describe("connecOrg", () => {
+		it("should fail on empty github token", async () => {
+			jest.mocked(Api.token.hasGitHubToken).mockReturnValue(false);
+			try {
+				await AppManager.connectOrg(1234);
+				expect(true).toBe(false);
+			} catch (e) {
+				expect(e).toEqual({ errorCode: "INVALID_TOKEN" });
+			}
+		});
+		it("should return error code as result", async () => {
+			jest.mocked(Api.token.hasGitHubToken).mockReturnValue(true);
+			jest.mocked(Api.orgs.connectOrganization).mockRejectedValue(failAxioResponse(401, "INSUFFICIENT_PERMISSION"));
+			try {
+				await AppManager.connectOrg(1234);
+				expect(true).toBe(false);
+			} catch (e) {
+				expect(e).toEqual(failAxioResponse(401, "INSUFFICIENT_PERMISSION"));
+			}
+		});
+		it("should successfully connect org", async () => {
+			jest.mocked(Api.token.hasGitHubToken).mockReturnValue(true);
+			jest.mocked(Api.orgs.connectOrganization).mockResolvedValue(successAxioResponse(undefined));
+			const result = await AppManager.connectOrg(1234);
+			expect(result).toEqual(undefined);
+		});
+	});
+});

--- a/spa/src/services/app-manager/index.ts
+++ b/spa/src/services/app-manager/index.ts
@@ -1,9 +1,9 @@
 import Api from "../../api";
 import { OrganizationsResponse } from "rest-interfaces";
-import { AxiosError } from "axios";
 import { popup, reportError } from "../../utils";
 
-async function fetchOrgs(): Promise<OrganizationsResponse | AxiosError> {
+async function fetchOrgs(): Promise<OrganizationsResponse> {
+
 	if (!Api.token.hasGitHubToken()) return { orgs: [] };
 
 	try {
@@ -11,19 +11,19 @@ async function fetchOrgs(): Promise<OrganizationsResponse | AxiosError> {
 		return response.data;
 	} catch (e) {
 		reportError(e);
-		return e as AxiosError;
+		throw e;
 	}
 }
 
-async function connectOrg(orgId: number): Promise<boolean | AxiosError> {
-	if (!Api.token.hasGitHubToken()) return false;
+async function connectOrg(orgId: number): Promise<void> {
+
+	if (!Api.token.hasGitHubToken()) throw { errorCode: "INVALID_TOKEN" };
 
 	try {
-		const response = await Api.orgs.connectOrganization(orgId);
-		return response.status === 200;
+		await Api.orgs.connectOrganization(orgId);
 	} catch (e) {
 		reportError(e);
-		return e as AxiosError;
+		throw e;
 	}
 }
 

--- a/spa/src/utils/modifyError.tsx
+++ b/spa/src/utils/modifyError.tsx
@@ -1,5 +1,5 @@
 import { AxiosError } from "axios";
-import { ErrorType, ApiError, ErrorCode } from "rest-interfaces";
+import { ErrorType, ErrorCode } from "rest-interfaces";
 import React, { MouseEvent } from "react";
 import { ErrorForIPBlocked, ErrorForNonAdmins, ErrorForSSO } from "../components/Error/KnownErrors";
 
@@ -25,7 +25,7 @@ export const GENERIC_MESSAGE_WITH_LINK = <>
 </>;
 
 export const modifyError = (
-  error: AxiosError<ApiError> | SimpleError | ErrorWithErrorCode,
+  error: AxiosError | SimpleError | ErrorWithErrorCode | unknown,
   context: { orgLogin?: string; },
   callbacks: { onClearGitHubToken: (e: MouseEvent<HTMLAnchorElement>) => void; onRelogin: () => void }
 ): ErrorObjType => {

--- a/src/rest/routes/github-orgs/index.ts
+++ b/src/rest/routes/github-orgs/index.ts
@@ -10,11 +10,9 @@ export const GitHubOrgsRouter = Router({ mergeParams: true });
 GitHubOrgsRouter.get("/", errorWrapper("GitHubOrgsFetchOrgs", async (req: Request, res: Response<OrganizationsResponse>) => {
 	const { githubToken, jiraHost, installation } = res.locals;
 	const organizations = await fetchGitHubOrganizations(githubToken, jiraHost, installation, req.log);
-	if (organizations) {
-		res.status(200).send({
-			orgs: organizations
-		});
-	}
+	res.status(200).send({
+		orgs: organizations
+	});
 }));
 
 GitHubOrgsRouter.post("/", errorWrapper("GitHubOrgsConnectJira", async (req: Request, res: Response) => {

--- a/src/rest/routes/github-orgs/service.ts
+++ b/src/rest/routes/github-orgs/service.ts
@@ -12,7 +12,7 @@ const fetchGitHubOrganizations = async (
 	jiraHost: string,
 	installation: Installation,
 	log: Logger
-): Promise<Array<GitHubInstallationType> | void> => {
+): Promise<Array<GitHubInstallationType>> => {
 	const gitHubUserClient = await createUserClient(githubToken, jiraHost, { trigger: "getOrganizations" }, log, undefined);
 	const { data: { login } } = await gitHubUserClient.getUser();
 


### PR DESCRIPTION
**What's in this PR?**
1. Refactor the code between UI and service manager.

**Why**
1. Mixing `throw error` and return `false` in the service manager code make code complicated.

**Added feature flags**
N/A

**Affected issues**  
N/A

**How has this been tested?**  
Local + unit test.

**Whats Next?**
N/A
