### PR TITLE
ARC-2429 - Help Jira admin track down "who is the GH org owner"

### DIFF
--- a/spa/src/analytics/types.ts
+++ b/spa/src/analytics/types.ts
@@ -4,7 +4,8 @@ type UIEventActionSubject =
   | "startOAuthAuthorisation" | "switchGitHubAccount"
 	| "connectOrganisation" | "installToNewOrganisation"
 	| "checkBackfillStatus"
-	| "dropExperienceViaBackButton";
+	| "dropExperienceViaBackButton"
+	| "checkOrgAdmin";
 
 export type UIEventProps = {
 	actionSubject: UIEventActionSubject,

--- a/spa/src/components/Error/KnownErrors/index.tsx
+++ b/spa/src/components/Error/KnownErrors/index.tsx
@@ -1,7 +1,8 @@
 import styled from "@emotion/styled";
 import { token } from "@atlaskit/tokens";
-import { popup } from "../../../utils";
 import Button from "@atlaskit/button";
+import analyticsClient from "../../../analytics";
+import { popup } from "../../../utils";
 
 const Paragraph = styled.div`
 	color: ${token("color.text.subtle")};
@@ -28,8 +29,13 @@ export const ErrorForSSO = ({ orgName, accessUrl, resetCallback }: { orgName?: s
 	</Paragraph>
 </>;
 
-export const ErrorForNonAdmins = ({ orgName }: { orgName?: string; }) => <Paragraph>
-	Can't connect, you're not the organization owner{orgName && <span> of <b>{orgName}</b></span>}.<br />Ask an owner to complete this step.
+export const ErrorForNonAdmins = ({ orgName, adminOrgsUrl }: { orgName?: string; adminOrgsUrl: string; }) => <Paragraph>
+	Can't connect, you're not the organization owner{orgName && <span> of <b>{orgName}</b></span>}.<br />
+	Ask an <StyledLink onClick={() => {
+	// TODO: Need to get this URL for Enterprise users too, this is only for Cloud users
+		popup(adminOrgsUrl);
+		analyticsClient.sendUIEvent({ actionSubject: "checkOrgAdmin", action: "clicked"}, { type: "cloud" });
+	}}>organization owner</StyledLink> to complete this step.
 </Paragraph>;
 
 export const ErrorForIPBlocked = ({ orgName, resetCallback }: { orgName?: string; resetCallback: () => void }) => <>

--- a/spa/src/pages/ConfigSteps/OrgsContainer/index.tsx
+++ b/spa/src/pages/ConfigSteps/OrgsContainer/index.tsx
@@ -73,7 +73,10 @@ const OrganizationsList = ({
 		}
 
 		if (!org.isAdmin) {
-			return <ErrorForNonAdmins />;
+			// TODO: Update this to support GHE
+			const adminOrgsUrl = `https://github.com/orgs/${org.account.login}/people?query=role%3Aowner`;
+
+			return <ErrorForNonAdmins adminOrgsUrl={adminOrgsUrl} />;
 		}
 	};
 

--- a/spa/src/utils/modifyError.tsx
+++ b/spa/src/utils/modifyError.tsx
@@ -59,10 +59,13 @@ export const modifyError = (
 			</>
 		};
 	} else if (errorCode === "INSUFFICIENT_PERMISSION") {
+		// TODO: Update this to support GHE
+		const adminOrgsUrl = `https://github.com/orgs/${context.orgLogin}/people?query=role%3Aowner`;
+
 		return {
 			...warningObj,
 			errorCode,
-			message: <ErrorForNonAdmins orgName={context.orgLogin} />
+			message: <ErrorForNonAdmins orgName={context.orgLogin} adminOrgsUrl={adminOrgsUrl} />
 		};
 	} else if (errorCode === "TIMEOUT") {
 		return { ...errorObj, errorCode, message: "Request timeout. Please try again later." };


### PR DESCRIPTION
**What's in this PR?**
- Added URL for list of admin orgs in non-admin errors.
- Added analytics when the link is clicked.

**Why**
- Improving UX for non-admins


**How has this been tested?**  
- Local

**Video**
- When listing the orgs

https://github.com/atlassian/github-for-jira/assets/13076255/9299e97e-38dd-4d8a-924c-54fed6676920

- When trying to connect to an org

https://github.com/atlassian/github-for-jira/assets/13076255/dd41f6d1-57a6-41e6-ad1b-18fd186c9850




**Whats Next?**
- test and merge