### PR TITLE
ARC-2459 use app client to check user permission

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -30,6 +30,7 @@ export enum BooleanFlags {
 	ENABLE_GITHUB_SECURITY_IN_JIRA = "enable-github-security-in-jira",
 	DELETE_MESSAGE_ON_BACKFILL_WHEN_OTHERS_WORKING_ON_IT = "delete-message-on-backfill-when-others-working-on-it",
 	USE_NEW_5KU_SPA_EXPERIENCE = "enable-5ku-experience--cloud-connect",
+	USE_APP_CLIENT_CHECK_PERMISSION = "use-app-client-to-check-permission",
 	USE_CUSTOM_ROOT_CA_BUNDLE = "use-custom-root-ca-bundle"
 }
 

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -30,7 +30,7 @@ export enum BooleanFlags {
 	ENABLE_GITHUB_SECURITY_IN_JIRA = "enable-github-security-in-jira",
 	DELETE_MESSAGE_ON_BACKFILL_WHEN_OTHERS_WORKING_ON_IT = "delete-message-on-backfill-when-others-working-on-it",
 	USE_NEW_5KU_SPA_EXPERIENCE = "enable-5ku-experience--cloud-connect",
-	USE_APP_CLIENT_CHECK_PERMISSION = "use-app-client-to-check-permission",
+	USE_INSTALLATION_CLIENT_CHECK_PERMISSION = "use-installation-client-to-check-permission",
 	USE_CUSTOM_ROOT_CA_BUNDLE = "use-custom-root-ca-bundle"
 }
 

--- a/src/github/client/github-installation-client.ts
+++ b/src/github/client/github-installation-client.ts
@@ -77,6 +77,12 @@ export class GitHubInstallationClient extends GitHubClient {
 		this.gitHubServerAppId = gshaId;
 	}
 
+	public getUserMembershipForOrg = async (username: string, org: string): Promise<AxiosResponse<Octokit.OrgsGetMembershipResponse>> => {
+		return await this.get<Octokit.OrgsGetMembershipResponse>(`/orgs/{org}/memberships/{username}`, {}, {
+			username,
+			org
+		});
+	};
 
 	public async getSecretScanningAlerts(owner: string, repo: string, secretScanningAlertRequestParams: GetSecretScanningAlertRequestParams): Promise<AxiosResponse<SecretScanningAlertResponseItem[]>> {
 		return await this.get<SecretScanningAlertResponseItem[]>(`/repos/{owner}/{repo}/secret-scanning/alerts`, secretScanningAlertRequestParams, {

--- a/src/routes/github/configuration/github-configuration-get.ts
+++ b/src/routes/github/configuration/github-configuration-get.ts
@@ -9,7 +9,7 @@ import { envVars } from "config/env";
 import { GitHubUserClient } from "~/src/github/client/github-user-client";
 import { isUserAdminOfOrganization } from "utils/github-utils";
 import { GithubClientBlockedIpError, GithubClientSSOLoginError } from "~/src/github/client/github-client-errors";
-import { createInstallationClient, createUserClient } from "~/src/util/get-github-client-config";
+import { createInstallationClient, createUserClient, createAppClient } from "~/src/util/get-github-client-config";
 import { GitHubServerApp } from "models/github-server-app";
 import { sendAnalytics } from "utils/analytics-client";
 import { AnalyticsEventTypes, AnalyticsScreenEventsEnum } from "interfaces/common";
@@ -77,6 +77,7 @@ export const getInstallationsWithAdmin = async (
 	return await Promise.all(installations.map(async (installation) => {
 		const errors: Error[] = [];
 		const gitHubClient = await createInstallationClient(installation.id, jiraHost, { trigger: "github-configuration-get" }, log, gitHubAppId);
+		const gitHubAppClient = await createAppClient(log, jiraHost, gitHubAppId, { trigger: "github-configuration-get" });
 
 		const numberOfReposPromise = await gitHubClient.getNumberOfReposForInstallation().catch((err) => {
 			errors.push(err);
@@ -88,6 +89,8 @@ export const getInstallationsWithAdmin = async (
 		//  all orgs the user is a member of and cross reference with the installation org
 		const checkAdmin = isUserAdminOfOrganization(
 			gitHubUserClient,
+			jiraHost,
+			gitHubAppClient,
 			installation.account.login,
 			login,
 			installation.target_type,

--- a/src/routes/github/configuration/github-configuration-get.ts
+++ b/src/routes/github/configuration/github-configuration-get.ts
@@ -9,7 +9,7 @@ import { envVars } from "config/env";
 import { GitHubUserClient } from "~/src/github/client/github-user-client";
 import { isUserAdminOfOrganization } from "utils/github-utils";
 import { GithubClientBlockedIpError, GithubClientSSOLoginError } from "~/src/github/client/github-client-errors";
-import { createInstallationClient, createUserClient, createAppClient } from "~/src/util/get-github-client-config";
+import { createInstallationClient, createUserClient } from "~/src/util/get-github-client-config";
 import { GitHubServerApp } from "models/github-server-app";
 import { sendAnalytics } from "utils/analytics-client";
 import { AnalyticsEventTypes, AnalyticsScreenEventsEnum } from "interfaces/common";
@@ -77,7 +77,6 @@ export const getInstallationsWithAdmin = async (
 	return await Promise.all(installations.map(async (installation) => {
 		const errors: Error[] = [];
 		const gitHubClient = await createInstallationClient(installation.id, jiraHost, { trigger: "github-configuration-get" }, log, gitHubAppId);
-		const gitHubAppClient = await createAppClient(log, jiraHost, gitHubAppId, { trigger: "github-configuration-get" });
 
 		const numberOfReposPromise = await gitHubClient.getNumberOfReposForInstallation().catch((err) => {
 			errors.push(err);
@@ -90,7 +89,7 @@ export const getInstallationsWithAdmin = async (
 		const checkAdmin = isUserAdminOfOrganization(
 			gitHubUserClient,
 			jiraHost,
-			gitHubAppClient,
+			gitHubClient,
 			installation.account.login,
 			login,
 			installation.target_type,

--- a/src/routes/github/subscription/github-subscription-delete.ts
+++ b/src/routes/github/subscription/github-subscription-delete.ts
@@ -39,6 +39,8 @@ export const GithubSubscriptionDelete = async (req: Request, res: Response): Pro
 		// Only show the page if the logged in user is an admin of this installation
 		if (!await isUserAdminOfOrganization(
 			gitHubUserClient,
+			jiraHost,
+			gitHubAppClient,
 			installation.account.login,
 			login,
 			installation.target_type,

--- a/src/routes/github/subscription/github-subscription-delete.ts
+++ b/src/routes/github/subscription/github-subscription-delete.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { Subscription } from "models/subscription";
 import { isUserAdminOfOrganization } from "~/src/util/github-utils";
-import { createAppClient, createUserClient } from "~/src/util/get-github-client-config";
+import { createAppClient, createInstallationClient, createUserClient } from "~/src/util/get-github-client-config";
 import { getCloudOrServerFromGitHubAppId } from "utils/get-cloud-or-server";
 
 export const GithubSubscriptionDelete = async (req: Request, res: Response): Promise<void> => {
@@ -16,6 +16,7 @@ export const GithubSubscriptionDelete = async (req: Request, res: Response): Pro
 		trigger: "github-subscription-delete"
 	};
 	const gitHubAppClient = await createAppClient(logger, jiraHost, gitHubAppId, metrics);
+	const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraHost, { trigger: "github-subscription-delete" }, logger, gitHubAppId);
 	const gitHubUserClient = await createUserClient(githubToken, jiraHost, metrics, logger, gitHubAppId);
 	const gitHubProduct = getCloudOrServerFromGitHubAppId(gitHubAppId);
 
@@ -40,7 +41,7 @@ export const GithubSubscriptionDelete = async (req: Request, res: Response): Pro
 		if (!await isUserAdminOfOrganization(
 			gitHubUserClient,
 			jiraHost,
-			gitHubAppClient,
+			gitHubInstallationClient ,
 			installation.account.login,
 			login,
 			installation.target_type,

--- a/src/services/subscription-installation-service.ts
+++ b/src/services/subscription-installation-service.ts
@@ -1,4 +1,4 @@
-import { createAppClient, createUserClient } from "utils/get-github-client-config";
+import { createAppClient, createUserClient, createInstallationClient } from "utils/get-github-client-config";
 import { Subscription } from "models/subscription";
 import { saveConfiguredAppProperties } from "utils/app-properties-utils";
 import { findOrStartSync } from "~/src/sync/sync-utils";
@@ -27,8 +27,10 @@ export const hasAdminAccess = async (githubToken: string, jiraHost: string, gitH
 		logger.info("Fetching info about installation");
 		const { data: installation } = await gitHubAppClient.getInstallation(gitHubInstallationId);
 
+		const gitHubInstallationClient = await createInstallationClient(gitHubInstallationId, jiraHost, { trigger: "hasAdminAccess" }, logger, gitHubServerAppIdPk);
+
 		logger.info("Checking if the user is an admin");
-		return await isUserAdminOfOrganization(gitHubUserClient, jiraHost, gitHubAppClient, installation.account.login, login, installation.target_type, logger);
+		return await isUserAdminOfOrganization(gitHubUserClient, jiraHost, gitHubInstallationClient, installation.account.login, login, installation.target_type, logger);
 	} catch (err) {
 		logger.warn({ err }, "Error checking user access");
 		return false;

--- a/src/services/subscription-installation-service.ts
+++ b/src/services/subscription-installation-service.ts
@@ -28,7 +28,7 @@ export const hasAdminAccess = async (githubToken: string, jiraHost: string, gitH
 		const { data: installation } = await gitHubAppClient.getInstallation(gitHubInstallationId);
 
 		logger.info("Checking if the user is an admin");
-		return await isUserAdminOfOrganization(gitHubUserClient, installation.account.login, login, installation.target_type, logger);
+		return await isUserAdminOfOrganization(gitHubUserClient, jiraHost, gitHubAppClient, installation.account.login, login, installation.target_type, logger);
 	} catch (err) {
 		logger.warn({ err }, "Error checking user access");
 		return false;

--- a/src/util/github-utils.test.ts
+++ b/src/util/github-utils.test.ts
@@ -74,13 +74,51 @@ describe("GitHub Utils", () => {
 			)).toBe(false);
 		});
 
-		it("should call app client to check permission", async () => {
+		it("should call app client to check permission, fail at non admin role", async () => {
 
 			when(booleanFlag).calledWith(BooleanFlags.USE_APP_CLIENT_CHECK_PERMISSION, expect.anything()).mockResolvedValue(true);
 
 			githubNock
 				.get("/orgs/test-org/memberships/test-user")
-				.reply(200, { role: "admin" });
+				.reply(200, { state: "active", role: "non-admin" });
+
+			expect(await isUserAdminOfOrganization(
+				githubUserClient,
+				jiraHost,
+				gitHubAppClient,
+				"test-org",
+				"test-user",
+				"Org",
+				getLogger("test")
+			)).toBe(false);
+		});
+
+		it("should call app client to check permission, fail at non-active state", async () => {
+
+			when(booleanFlag).calledWith(BooleanFlags.USE_APP_CLIENT_CHECK_PERMISSION, expect.anything()).mockResolvedValue(true);
+
+			githubNock
+				.get("/orgs/test-org/memberships/test-user")
+				.reply(200, { state: "inactive", role: "admin" });
+
+			expect(await isUserAdminOfOrganization(
+				githubUserClient,
+				jiraHost,
+				gitHubAppClient,
+				"test-org",
+				"test-user",
+				"Org",
+				getLogger("test")
+			)).toBe(false);
+		});
+
+		it("should call app client to check permission, success when active and admin", async () => {
+
+			when(booleanFlag).calledWith(BooleanFlags.USE_APP_CLIENT_CHECK_PERMISSION, expect.anything()).mockResolvedValue(true);
+
+			githubNock
+				.get("/orgs/test-org/memberships/test-user")
+				.reply(200, { state: "active", role: "admin" });
 
 			expect(await isUserAdminOfOrganization(
 				githubUserClient,

--- a/src/util/github-utils.test.ts
+++ b/src/util/github-utils.test.ts
@@ -76,7 +76,7 @@ describe("GitHub Utils", () => {
 
 		it("should call app client to check permission, fail at non admin role", async () => {
 
-			when(booleanFlag).calledWith(BooleanFlags.USE_APP_CLIENT_CHECK_PERMISSION, expect.anything()).mockResolvedValue(true);
+			when(booleanFlag).calledWith(BooleanFlags.USE_INSTALLATION_CLIENT_CHECK_PERMISSION, expect.anything()).mockResolvedValue(true);
 
 			githubNock.post("/app/installations/111/access_tokens").reply(200, { token: "token", expires_at: new Date().getTime() });
 
@@ -97,7 +97,7 @@ describe("GitHub Utils", () => {
 
 		it("should call app client to check permission, fail at non-active state", async () => {
 
-			when(booleanFlag).calledWith(BooleanFlags.USE_APP_CLIENT_CHECK_PERMISSION, expect.anything()).mockResolvedValue(true);
+			when(booleanFlag).calledWith(BooleanFlags.USE_INSTALLATION_CLIENT_CHECK_PERMISSION, expect.anything()).mockResolvedValue(true);
 
 			githubNock.post("/app/installations/111/access_tokens").reply(200, { token: "token", expires_at: new Date().getTime() });
 
@@ -118,7 +118,7 @@ describe("GitHub Utils", () => {
 
 		it("should call app client to check permission, success when active and admin", async () => {
 
-			when(booleanFlag).calledWith(BooleanFlags.USE_APP_CLIENT_CHECK_PERMISSION, expect.anything()).mockResolvedValue(true);
+			when(booleanFlag).calledWith(BooleanFlags.USE_INSTALLATION_CLIENT_CHECK_PERMISSION, expect.anything()).mockResolvedValue(true);
 
 			githubNock.post("/app/installations/111/access_tokens").reply(200, { token: "token", expires_at: new Date().getTime() });
 

--- a/src/util/github-utils.ts
+++ b/src/util/github-utils.ts
@@ -2,6 +2,7 @@ import { GitHubUserClient } from "~/src/github/client/github-user-client";
 import { GitHubAppClient } from "~/src/github/client/github-app-client";
 import Logger from "bunyan";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
+import { GithubClientNotFoundError, GithubClientInvalidPermissionsError } from "~/src/github/client/github-client-errors";
 
 export const isUserAdminOfOrganization = async (githubClient: GitHubUserClient, jiraHost: string, gitHubAppClient: GitHubAppClient, orgName: string, username: string, orgType: string, logger: Logger): Promise<boolean> => {
 	if (orgType === "User") {
@@ -12,12 +13,20 @@ export const isUserAdminOfOrganization = async (githubClient: GitHubUserClient, 
 	try {
 		if (await booleanFlag(BooleanFlags.USE_APP_CLIENT_CHECK_PERMISSION, jiraHost)) {
 			logger.info("isUserAdminOfOrganization: orgType is an org, checking membership (app client)");
-			const { data: { role } } = await gitHubAppClient.getUserMembershipForOrg(username, orgName);
-			logger.info({ orgName, username, role }, `isUserAdminOfOrganization: User has role for org`);
-			return role === "admin";
+			const { data: { state, role } } = await gitHubAppClient.getUserMembershipForOrg(username, orgName);
+			logger.info({ orgName, username, state, role }, `isUserAdminOfOrganization: User has role for org`);
+			return role === "admin" && state === "active";
 		}
-	} catch (e) {
-		logger.error({ err: e }, "Fail checking permission using GitHub App Client, fallback to user client");
+	} catch (err) {
+		if (err instanceof GithubClientNotFoundError) {
+			logger.warn({ err, orgName, username }, `could not determine admin status of user in org: GithubClientNotFoundError`);
+			return false;
+		} else if (err instanceof GithubClientInvalidPermissionsError) {
+			logger.warn({ err, orgName, username }, `could not determine admin status of user in org: GithubClientInvalidPermissionsError`);
+			return false;
+		} else {
+			logger.error({ err }, "Fail checking permission using GitHub App Client, fallback to user client");
+		}
 	}
 
 	try {

--- a/src/util/github-utils.ts
+++ b/src/util/github-utils.ts
@@ -1,10 +1,23 @@
 import { GitHubUserClient } from "~/src/github/client/github-user-client";
+import { GitHubAppClient } from "~/src/github/client/github-app-client";
 import Logger from "bunyan";
+import { booleanFlag, BooleanFlags } from "config/feature-flags";
 
-export const isUserAdminOfOrganization = async (githubClient: GitHubUserClient, orgName: string, username: string, orgType: string, logger: Logger): Promise<boolean> => {
+export const isUserAdminOfOrganization = async (githubClient: GitHubUserClient, jiraHost: string, gitHubAppClient: GitHubAppClient, orgName: string, username: string, orgType: string, logger: Logger): Promise<boolean> => {
 	if (orgType === "User") {
 		logger.info("isUserAdminOfOrganization: orgType is a user");
 		return orgName === username;
+	}
+
+	try {
+		if (await booleanFlag(BooleanFlags.USE_APP_CLIENT_CHECK_PERMISSION, jiraHost)) {
+			logger.info("isUserAdminOfOrganization: orgType is an org, checking membership (app client)");
+			const { data: { role } } = await gitHubAppClient.getUserMembershipForOrg(username, orgName);
+			logger.info({ orgName, username, role }, `isUserAdminOfOrganization: User has role for org`);
+			return role === "admin";
+		}
+	} catch (e) {
+		logger.error({ err: e }, "Fail checking permission using GitHub App Client, fallback to user client");
 	}
 
 	try {

--- a/src/util/github-utils.ts
+++ b/src/util/github-utils.ts
@@ -2,7 +2,6 @@ import { GitHubUserClient } from "~/src/github/client/github-user-client";
 import { GitHubAppClient } from "~/src/github/client/github-app-client";
 import Logger from "bunyan";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
-import { GithubClientNotFoundError, GithubClientInvalidPermissionsError } from "~/src/github/client/github-client-errors";
 
 export const isUserAdminOfOrganization = async (githubClient: GitHubUserClient, jiraHost: string, gitHubAppClient: GitHubAppClient, orgName: string, username: string, orgType: string, logger: Logger): Promise<boolean> => {
 	if (orgType === "User") {
@@ -18,15 +17,7 @@ export const isUserAdminOfOrganization = async (githubClient: GitHubUserClient, 
 			return role === "admin" && state === "active";
 		}
 	} catch (err) {
-		if (err instanceof GithubClientNotFoundError) {
-			logger.warn({ err, orgName, username }, `could not determine admin status of user in org: GithubClientNotFoundError`);
-			return false;
-		} else if (err instanceof GithubClientInvalidPermissionsError) {
-			logger.warn({ err, orgName, username }, `could not determine admin status of user in org: GithubClientInvalidPermissionsError`);
-			return false;
-		} else {
-			logger.error({ err }, "Fail checking permission using GitHub App Client, fallback to user client");
-		}
+		logger.error({ err }, "Fail checking permission using GitHub App Client, fallback to user client");
 	}
 
 	try {

--- a/src/util/github-utils.ts
+++ b/src/util/github-utils.ts
@@ -10,7 +10,7 @@ export const isUserAdminOfOrganization = async (githubClient: GitHubUserClient, 
 	}
 
 	try {
-		if (await booleanFlag(BooleanFlags.USE_APP_CLIENT_CHECK_PERMISSION, jiraHost)) {
+		if (await booleanFlag(BooleanFlags.USE_INSTALLATION_CLIENT_CHECK_PERMISSION, jiraHost)) {
 			logger.info("isUserAdminOfOrganization: orgType is an org, checking membership (app client)");
 			const { data: { state, role } } = await gitHubInstallationClient.getUserMembershipForOrg(username, orgName);
 			logger.info({ orgName, username, state, role }, `isUserAdminOfOrganization: User has role for org`);

--- a/src/util/github-utils.ts
+++ b/src/util/github-utils.ts
@@ -1,9 +1,9 @@
 import { GitHubUserClient } from "~/src/github/client/github-user-client";
-import { GitHubAppClient } from "~/src/github/client/github-app-client";
+import { GitHubInstallationClient } from "~/src/github/client/github-installation-client";
 import Logger from "bunyan";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
 
-export const isUserAdminOfOrganization = async (githubClient: GitHubUserClient, jiraHost: string, gitHubAppClient: GitHubAppClient, orgName: string, username: string, orgType: string, logger: Logger): Promise<boolean> => {
+export const isUserAdminOfOrganization = async (githubClient: GitHubUserClient, jiraHost: string, gitHubInstallationClient: GitHubInstallationClient, orgName: string, username: string, orgType: string, logger: Logger): Promise<boolean> => {
 	if (orgType === "User") {
 		logger.info("isUserAdminOfOrganization: orgType is a user");
 		return orgName === username;
@@ -12,7 +12,7 @@ export const isUserAdminOfOrganization = async (githubClient: GitHubUserClient, 
 	try {
 		if (await booleanFlag(BooleanFlags.USE_APP_CLIENT_CHECK_PERMISSION, jiraHost)) {
 			logger.info("isUserAdminOfOrganization: orgType is an org, checking membership (app client)");
-			const { data: { state, role } } = await gitHubAppClient.getUserMembershipForOrg(username, orgName);
+			const { data: { state, role } } = await gitHubInstallationClient.getUserMembershipForOrg(username, orgName);
 			logger.info({ orgName, username, state, role }, `isUserAdminOfOrganization: User has role for org`);
 			return role === "admin" && state === "active";
 		}


### PR DESCRIPTION
**What's in this PR?**
1. Use github installation client to check permission

**Why**
1. The user client is impacted by SSO error. Installation client should not.

**Added feature flags**
use-installation-client-to-check-permission

**Affected issues**  
ARC-2459

**How has this been tested?**  
Unit test
Local

**Whats Next?**
