### PR TITLE
ARC-2460: Map CHANGES_REQUESTED PR reviewer status to NEEDSWORK

### DIFF
--- a/src/github/pull-request.ts
+++ b/src/github/pull-request.ts
@@ -6,7 +6,7 @@ import { JiraPullRequestBulkSubmitData } from "interfaces/jira";
 import { jiraIssueKeyParser } from "utils/jira-utils";
 import { GitHubIssueData } from "interfaces/github";
 import { createInstallationClient } from "utils/get-github-client-config";
-import { WebhookContext } from "../routes/github/webhook/webhook-context";
+import { WebhookContext } from "routes/github/webhook/webhook-context";
 import { transformRepositoryId } from "~/src/transforms/transform-repository-id";
 import { getPullRequestReviews } from "~/src/transforms/util/github-get-pull-request-reviews";
 import { Subscription } from "models/subscription";

--- a/src/transforms/transform-pull-request.test.ts
+++ b/src/transforms/transform-pull-request.test.ts
@@ -349,6 +349,64 @@ describe("pull_request transform REST", () => {
 		});
 	});
 
+	it("maps CHANGES_REQUESTED state to NEEDSWORK", async () => {
+		const pullRequestList = Object.assign({},
+			transformPullRequestList
+		);
+
+		const pulLRequestFixture = pullRequestList[0];
+		pulLRequestFixture.title = "[TEST-1] Branch payload with loads of issue keys Test";
+
+		const reviewersListChangesRequestedState = _.cloneDeep(reviewersListHasUser);
+		reviewersListChangesRequestedState[0].state = "CHANGES_REQUESTED";
+
+		const data = await transformPullRequestRest(client, pulLRequestFixture as any, reviewersListChangesRequestedState as any, getLogger("test"), jiraHost);
+
+		const { updated_at, title } = pulLRequestFixture;
+
+		expect(data).toStrictEqual({
+			id: "100403908",
+			name: "integrations/test",
+			pullRequests: [
+				{
+					author: {
+						avatar: "https://github.com/ghost.png",
+						email: "deleted@noreply.user.github.com",
+						name: "Deleted User",
+						url: "https://github.com/ghost"
+					},
+					commentCount: 0,
+					destinationBranch: "devel",
+					destinationBranchUrl: "https://github.com/integrations/test/tree/devel",
+					displayId: "#51",
+					id: 51,
+					issueKeys: ["TEST-1"],
+					lastUpdate: updated_at,
+					reviewers: [
+						{
+							avatar: "https://github.com/images/error/octocat_happy.gif",
+							name: "octocat",
+							email: "octocat@noreply.user.github.com",
+							url: "https://github.com/octocat",
+							approvalStatus: "NEEDSWORK"
+						}
+					],
+					sourceBranch: "use-the-force",
+					sourceBranchUrl:
+						"https://github.com/integrations/test/tree/use-the-force",
+					status: "MERGED",
+					timestamp: updated_at,
+					title: title,
+					url: "https://github.com/integrations/test/pull/51",
+					updateSequenceId: 12345678
+				}
+			],
+			branches: [],
+			url: "https://github.com/integrations/test",
+			updateSequenceId: 12345678
+		});
+	});
+
 	it("should resolve reviewer's email", async () => {
 		const pullRequestList = Object.assign({},
 			transformPullRequestList
@@ -429,7 +487,7 @@ describe("pull_request transform REST", () => {
 
 		expect({ firstReviewStatus: data?.pullRequests[0].reviewers[0] }).toEqual(expect.objectContaining({
 			firstReviewStatus: expect.objectContaining({
-				approvalStatus: "UNAPPROVED"
+				approvalStatus: "NEEDSWORK"
 			})
 		}));
 
@@ -617,6 +675,48 @@ describe("pull_request transform GraphQL", () => {
 					name: "test-pull-request-reviewer-login",
 					url: "https://github.com/reviewer",
 					approvalStatus: "UNAPPROVED"
+				}
+			],
+			sourceBranch: "evernote-test",
+			sourceBranchUrl: "https://github.com/integrations/test/tree/evernote-test",
+			status: "MERGED",
+			timestamp: updatedAt,
+			title,
+			url: "https://github.com/integrations/test/pull/51",
+			updateSequenceId: 12345678
+		});
+	});
+
+	it("maps CHANGES_REQUESTED state to NEEDSWORK", async () => {
+		const title = "[TES-123] Branch payload Test";
+		const payload = { ...createPullPayload(title) };
+		payload.reviews = createReview("CHANGES_REQUESTED");
+
+		const { updatedAt } = payload;
+
+		const data = await transformPullRequest(REPO_OBJ, jiraHost, payload as any, logger);
+
+		expect(data).toStrictEqual({
+			author: {
+				avatar: "test-pull-request-author-avatar",
+				email: "test-pull-request-author-login@noreply.user.github.com",
+				name: "test-pull-request-author-login",
+				url: "test-pull-request-author-url"
+			},
+			commentCount: 10,
+			destinationBranch: "devel",
+			destinationBranchUrl: "https://github.com/integrations/test/tree/devel",
+			displayId: "#51",
+			id: 51,
+			issueKeys: ["TES-123"],
+			lastUpdate: updatedAt,
+			reviewers: [
+				{
+					avatar: "test-pull-request-reviewer-avatar",
+					email: "test-pull-request-reviewer-login@email.test",
+					name: "test-pull-request-reviewer-login",
+					url: "https://github.com/reviewer",
+					approvalStatus: "NEEDSWORK"
 				}
 			],
 			sourceBranch: "evernote-test",

--- a/src/transforms/transform-pull-request.ts
+++ b/src/transforms/transform-pull-request.ts
@@ -6,7 +6,7 @@ import { getJiraAuthor, jiraIssueKeyParser } from "utils/jira-utils";
 import { getGithubUser } from "services/github/user";
 import { generateCreatePullRequestUrl } from "./util/pull-request-link-generator";
 import { GitHubInstallationClient } from "../github/client/github-installation-client";
-import { JiraReview } from "../interfaces/jira";
+import { JiraReview } from "interfaces/jira";
 import { transformRepositoryDevInfoBulk } from "~/src/transforms/transform-repository";
 import { pullRequestNode } from "~/src/github/client/github-queries";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
@@ -26,8 +26,20 @@ interface JiraReviewer extends JiraReview {
 	login: string;
 }
 
+// Data Depot valid ENUM values
 const STATE_APPROVED = "APPROVED";
 const STATE_UNAPPROVED = "UNAPPROVED";
+const STATE_NEEDS_WORK = "NEEDSWORK";
+
+const mapReviewState = (state: string | undefined) => {
+	if (state === STATE_APPROVED) {
+		return STATE_APPROVED;
+	} else if (state === "CHANGES_REQUESTED") {
+		return STATE_NEEDS_WORK;
+	} else {
+		return STATE_UNAPPROVED;
+	}
+};
 
 const mapReviewsRest = async (reviews: Array<{ state?: string, user: Octokit.PullsUpdateResponseRequestedReviewersItem }> = [], gitHubInstallationClient: GitHubInstallationClient): Promise<JiraReview[]> => {
 
@@ -46,13 +58,13 @@ const mapReviewsRest = async (reviews: Array<{ state?: string, user: Octokit.Pul
 			usernames[reviewerUsername] = {
 				...getJiraAuthor(reviewer),
 				login: reviewerUsername,
-				approvalStatus: review.state === STATE_APPROVED ? STATE_APPROVED : STATE_UNAPPROVED
+				approvalStatus: mapReviewState(review.state)
 			};
 
 			acc.push(usernames[reviewerUsername]);
 
 		} else {
-			usernames[reviewerUsername].approvalStatus = review.state === STATE_APPROVED ? STATE_APPROVED : STATE_UNAPPROVED;
+			usernames[reviewerUsername].approvalStatus = mapReviewState(review.state);
 		}
 
 		// Returns the reviews' array with unique users
@@ -153,7 +165,8 @@ export const transformPullRequestRest = async (
 };
 
 // Do not send the branch on the payload when the Pull Request Merged event is called.
-// Reason: If "Automatically delete head branches" is enabled, the branch deleted and PR merged events might be sent out “at the same time” and received out of order, which causes the branch being created again.
+// Reason: If "Automatically delete head branches" is enabled, the branch deleted and PR merged events might be sent out
+// “at the same time” and received out of order, which causes the branch being created again.
 const getBranches = async (gitHubInstallationClient: GitHubInstallationClient, pullRequest: Octokit.PullsGetResponse, issueKeys: string[]) => {
 	if (mapStatus(pullRequest.state, pullRequest.merged_at) === "MERGED") {
 		return [];
@@ -242,13 +255,13 @@ const mapReviews = (reviews: pullRequestNode["reviews"]["nodes"] = [], reviewReq
 			usernames[reviewerUsername] = {
 				...getJiraAuthor(reviewer),
 				login: reviewerUsername,
-				approvalStatus: review.state === STATE_APPROVED ? STATE_APPROVED : STATE_UNAPPROVED
+				approvalStatus: mapReviewState(review.state)
 			};
 
 			acc.push(usernames[reviewerUsername]);
 
 		} else {
-			usernames[reviewerUsername].approvalStatus = review.state === STATE_APPROVED ? STATE_APPROVED : STATE_UNAPPROVED;
+			usernames[reviewerUsername].approvalStatus = mapReviewState(review.state);
 		}
 
 		// Returns the reviews' array with unique users


### PR DESCRIPTION
**What's in this PR?**
Data Depot used to only accept `APPROVED` and `UNAPPROVED` for a PR Reviewer status. They are now accepting `NEEDSWORK` as well, so we are mapping the `CHANGES_REQUESTED` Reviewers status from GitHub now too.

Data Depot API info: https://developer.atlassian.com/cloud/jira/software/rest/api-group-development-information/#api-rest-devinfo-0-10-bulk-post

GitHub ENUM for PR Review State: https://docs.github.com/en/graphql/reference/enums#pullrequestreviewstate

**Why**
Because of ATLAS-38809


**Affected issues**  
[ARC-2320]
[ARC-2460]

**How has this been tested?**  
Locally + Added a couple of UTs in this PR

**Whats Next?**

- Mapping Draft PR
- Mapping PR Task Count
- Mapping Deployment triggeredBy

More info [here](https://hello.atlassian.net/wiki/spaces/OTFS/pages/2772633793/ATLAS-38809+GH4J+needs+to+send+new+fields+for+Pullrequest).


[ARC-2320]: https://softwareteams.atlassian.net/browse/ARC-2320
[ARC-2460]: https://softwareteams.atlassian.net/browse/ARC-2460