### PR TITLE
ARC-2469 - Add analytics for the Help links in the connected page

### DIFF
--- a/spa/src/analytics/types.ts
+++ b/spa/src/analytics/types.ts
@@ -5,7 +5,8 @@ type UIEventActionSubject =
 	| "connectOrganisation" | "installToNewOrganisation"
 	| "checkBackfillStatus"
 	| "dropExperienceViaBackButton"
-	| "checkOrgAdmin";
+	| "checkOrgAdmin"
+	| "learnAboutIssueLinking" | "learnAboutDevelopmentWork";
 
 export type UIEventProps = {
 	actionSubject: UIEventActionSubject,

--- a/spa/src/pages/Connected/index.tsx
+++ b/spa/src/pages/Connected/index.tsx
@@ -45,6 +45,9 @@ const Section = styled.div`
 const SectionImg = styled.img`
 	height: 100px;
 `;
+const StyledLink = styled.a`
+	cursor: pointer;
+`;
 
 const Connected = () => {
 	useEffectScreenEvent("SuccessfulConnectedScreen");
@@ -55,6 +58,16 @@ const Connected = () => {
 	const navigateToBackfillPage = () => {
 		analyticsClient.sendUIEvent({ actionSubject: "checkBackfillStatus", action: "clicked" });
 		AP.navigator.go( "addonmodule", { moduleKey: "gh-addon-admin" });
+	};
+
+	const learnAboutIssueLinking = () => {
+		analyticsClient.sendUIEvent({ actionSubject: "learnAboutIssueLinking", action: "clicked" });
+		window.open("https://support.atlassian.com/jira-software-cloud/docs/reference-issues-in-your-development-work/", "_blank");
+	};
+
+	const learnAboutDevelopmentWork = () => {
+		analyticsClient.sendUIEvent({ actionSubject: "learnAboutDevelopmentWork", action: "clicked" });
+		window.open("https://support.atlassian.com/jira-cloud-administration/docs/integrate-with-development-tools/", "_blank");
 	};
 
 	return (<Wrapper>
@@ -87,12 +100,9 @@ const Connected = () => {
 							titles, commit messages and<br />
 							more to bring them into Jira.
 						</Paragraph>
-						<a
-							href="https://support.atlassian.com/jira-software-cloud/docs/reference-issues-in-your-development-work/"
-							target="_blank"
-						>
+						<StyledLink onClick={learnAboutIssueLinking}>
 							Learn about issue linking
-						</a>
+						</StyledLink>
 					</Section>
 					<Section>
 						<SectionImg src="/public/assets/collaborate-in-jira.svg" alt=""/>
@@ -102,12 +112,9 @@ const Connected = () => {
 							will appear in issues and the<br />
 							code feature.
 						</Paragraph>
-						<a
-							href="https://support.atlassian.com/jira-cloud-administration/docs/integrate-with-development-tools/"
-							target="_blank"
-						>
+						<StyledLink onClick={learnAboutDevelopmentWork}>
 							Learn about development work in Jira
-						</a>
+						</StyledLink>
 					</Section>
 				</FlexWrapper>
 			</div>

--- a/spa/src/pages/Connected/test.tsx
+++ b/spa/src/pages/Connected/test.tsx
@@ -10,6 +10,8 @@ import userEvent from "@testing-library/user-event";
 		go: jest.fn()
 	}
 };
+(global as any).open = jest.fn();
+
 const navigate = jest.fn();
 jest.mock("react-router-dom", () => ({
 	...jest.requireActual("react-router-dom"),
@@ -41,8 +43,11 @@ test("Basic check for the Connected Page", async () => {
 	expect(screen.queryByText("Check your backfill status")).toBeInTheDocument();
 	expect(screen.queryByText("Add another organization")).toBeInTheDocument();
 
-	expect(screen.getByText("Learn about issue linking")).toHaveAttribute("href", "https://support.atlassian.com/jira-software-cloud/docs/reference-issues-in-your-development-work/");
-	expect(screen.getByText("Learn about development work in Jira")).toHaveAttribute("href", "https://support.atlassian.com/jira-cloud-administration/docs/integrate-with-development-tools/");
+	await userEvent.click(screen.getByText("Learn about issue linking"));
+	expect(window.open).toHaveBeenCalled();
+
+	await userEvent.click(screen.getByText("Learn about development work in Jira"));
+	expect(window.open).toHaveBeenCalled();
 
 	await userEvent.click(screen.getByText("Check your backfill status"));
 	expect(AP.navigator.go).toHaveBeenCalled();

--- a/spa/src/pages/Connected/test.tsx
+++ b/spa/src/pages/Connected/test.tsx
@@ -44,10 +44,10 @@ test("Basic check for the Connected Page", async () => {
 	expect(screen.queryByText("Add another organization")).toBeInTheDocument();
 
 	await userEvent.click(screen.getByText("Learn about issue linking"));
-	expect(window.open).toHaveBeenCalled();
+	expect(window.open).toBeCalledWith("https://support.atlassian.com/jira-software-cloud/docs/reference-issues-in-your-development-work/", "_blank");
 
 	await userEvent.click(screen.getByText("Learn about development work in Jira"));
-	expect(window.open).toHaveBeenCalled();
+	expect(window.open).toBeCalledWith("https://support.atlassian.com/jira-cloud-administration/docs/integrate-with-development-tools/", "_blank");
 
 	await userEvent.click(screen.getByText("Check your backfill status"));
 	expect(AP.navigator.go).toHaveBeenCalled();


### PR DESCRIPTION
**What's in this PR?**
- Added events for the two help links in the success page.

**Why**
- To see if those links are actually helping out or not.
