### PR TITLE
don't add ticket references to markdown links in PRs

### DIFF
--- a/src/jira/util/jira-client-util.test.ts
+++ b/src/jira/util/jira-client-util.test.ts
@@ -89,6 +89,27 @@ describe("Jira util", () => {
 			expect(result).toBe(rendered);
 		});
 
+		it("should not add reference to existing markdown links", () => {
+			const { source, rendered } = loadFixture("existing-markdown-links");
+			const issues = [
+				{
+					key: "TEST-2019",
+					fields: {
+						summary: "Example Issue"
+					}
+				},
+				{
+					key: "TEST-2020",
+					fields: {
+						summary: "Another Example Issue"
+					}
+				}
+			];
+
+			const result = util.addJiraIssueLinks(source, issues);
+			expect(result).toBe(rendered);
+		});
+
 		it("should not linkify Jira references to invalid issues", () => {
 			const text = "Should not linkify [TEST-123] as a link";
 			const issues = [];

--- a/src/util/jira-utils.ts
+++ b/src/util/jira-utils.ts
@@ -79,7 +79,7 @@ const jiraIssueRegex = (): RegExp => {
  * This regex is used when adding links to Jira issues in GitHub PR issue/descriptions.
  */
 export const jiraIssueInSquareBracketsRegex = (): RegExp => {
-	return /(^|[^A-Z\d])\[([A-Z][A-Z\d]{1,255}-[1-9]\d{0,255})\]/giu;
+	return /(^|[^A-Z\d])\[([A-Z][A-Z\d]{1,255}-[1-9]\d{0,255})\](?!\()/giu;
 };
 
 /**

--- a/test/fixtures/text/existing-markdown-links.rendered.md
+++ b/test/fixtures/text/existing-markdown-links.rendered.md
@@ -1,0 +1,3 @@
+Should add a reference for [TEST-2019], but not for [TEST-2020](http://example.com/browse/TEST-2020?focusedCommentId=123).
+
+[TEST-2019]: http://example.com/browse/TEST-2019

--- a/test/fixtures/text/existing-markdown-links.source.md
+++ b/test/fixtures/text/existing-markdown-links.source.md
@@ -1,0 +1,1 @@
+Should add a reference for [TEST-2019], but not for [TEST-2020](http://example.com/browse/TEST-2020?focusedCommentId=123).


### PR DESCRIPTION
**What's in this PR?**
Modified regex to not match ticket numbers in square brackets followed by `(` i.e. markdown links

**Why**
To avoid unnecessary PR description edits

**Added feature flags**
–

**Affected issues**  
–

**How has this been tested?**  
–

**Whats Next?**
–