### PR TITLE
ISOC-4016 Limit vulnerability description to 5000 characters

### DIFF
--- a/src/transforms/transform-code-scanning-alert.ts
+++ b/src/transforms/transform-code-scanning-alert.ts
@@ -6,7 +6,7 @@ import {
 } from "interfaces/jira";
 import { GitHubInstallationClient } from "../github/client/github-installation-client";
 import Logger from "bunyan";
-import { capitalize } from "lodash";
+import { capitalize, truncate } from "lodash";
 import { createInstallationClient } from "../util/get-github-client-config";
 import { WebhookContext } from "../routes/github/webhook/webhook-context";
 import { transformRepositoryId } from "~/src/transforms/transform-repository-id";
@@ -166,7 +166,9 @@ export const getCodeScanningVulnDescription = (
 		const branches = getBranches(alertInstances);
 		const identifiersText = getIdentifiersText(identifiers);
 		// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-		return `**Vulnerability:** ${alert.rule.description}\n\n**Impact:** The vulnerability in ${alert.tool.name} impacts ${toSentence(branches)}.\n\n**Severity:** ${capitalize(alert.rule?.security_severity_level)}\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** ${capitalize(alert.state)}\n\n**Weaknesses:** ${identifiersText}\n\nVisit the vulnerability’s [code scanning alert page](${alert.html_url}) in GitHub for a recommendation and relevant example.`;
+		const description = `**Vulnerability:** ${alert.rule.description}\n\n**Impact:** The vulnerability in ${alert.tool.name} impacts ${toSentence(branches)}.\n\n**Severity:** ${capitalize(alert.rule?.security_severity_level)}\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** ${capitalize(alert.state)}\n\n**Weaknesses:** ${identifiersText}\n\nVisit the vulnerability’s [code scanning alert page](${alert.html_url}) in GitHub for a recommendation and relevant example.`;
+		// description cannot exceed 5000 characters
+		return truncate(description, { length: 4999 });
 	} catch (err) {
 		logger.warn({ err }, "Failed to construct vulnerability description");
 		return alert.rule?.description;

--- a/src/transforms/transform-secret-scanning-alert.ts
+++ b/src/transforms/transform-secret-scanning-alert.ts
@@ -6,7 +6,7 @@ import { transformRepositoryId } from "~/src/transforms/transform-repository-id"
 import Logger from "bunyan";
 import { Repository } from "@octokit/webhooks-types";
 import { SecretScanningAlertResponseItem } from "../github/client/github-client.types";
-import { capitalize } from "lodash";
+import { capitalize, truncate } from "lodash";
 
 export const transformSecretScanningAlert = async (
 	alert: SecretScanningAlertResponseItem,
@@ -61,7 +61,9 @@ export const transformGitHubStateToJiraStatus = (state: string | undefined, logg
 
 export const getSecretScanningVulnDescription = (alert: SecretScanningAlertResponseItem, logger: Logger) => {
 	try {
-		return `**Vulnerability:** Fix ${alert.secret_type_display_name}\n\n**State:** ${capitalize(alert.state)}\n\n**Secret type:** ${alert.secret_type}\n\nVisit the vulnerability’s [secret scanning alert page](${alert.html_url}) in GitHub to learn more about the potential active secret and remediation steps.`;
+		const description = `**Vulnerability:** Fix ${alert.secret_type_display_name}\n\n**State:** ${capitalize(alert.state)}\n\n**Secret type:** ${alert.secret_type}\n\nVisit the vulnerability’s [secret scanning alert page](${alert.html_url}) in GitHub to learn more about the potential active secret and remediation steps.`;
+		// description cannot exceed 5000 characters
+		return truncate(description, { length: 4999 });
 	} catch (err) {
 		logger.warn({ err }, "Failed to construct vulnerability description");
 		return alert.secret_type_display_name;


### PR DESCRIPTION
**What's in this PR?**
This PR limits the vulnerability description to 5000 characters 

**Why**
Data depot rejects the vulnerability with description more than 5000 characters

**Added feature flags**
ENABLE_GITHUB_SECURITY_IN_JIRA

**Affected issues**  
[ISOC-4016]


[ISOC-4016]: https://softwareteams.atlassian.net/browse/ISOC-4016