### PR TITLE
JST-913160 - Jira/Github integration not showing forked repos

### DIFF
--- a/src/routes/github/repository/github-repository-get.test.ts
+++ b/src/routes/github/repository/github-repository-get.test.ts
@@ -76,7 +76,7 @@ describe("GitHub Repository Search", () => {
 
 			const owner = { login: "myOrgName" };
 
-			nockSearchRepos200(`${randomString} org:myOrgName in:full_name`, {
+			nockSearchRepos200(`${randomString} org:myOrgName in:full_name fork:true`, {
 				items: [{ owner, full_name: "first", id: 1 }, { owner, full_name: "second", id: 22 }, { owner, full_name: "second", id: 333 }]
 			});
 
@@ -105,7 +105,7 @@ describe("GitHub Repository Search", () => {
 				.post(`/app/installations/${subscription.gitHubInstallationId}/access_tokens`)
 				.reply(200);
 
-			nockSearchRepos200(`${randomString} org:myOrgName in:full_name`, {
+			nockSearchRepos200(`${randomString} org:myOrgName in:full_name fork:true`, {
 				items: [{ full_name: "forth", id: 4444 }]
 			});
 
@@ -148,7 +148,7 @@ describe("GitHub Repository Search", () => {
 
 			const owner = { login: "myOrgName" };
 
-			nockSearchRepos200(`${randomString} org:myOrgName in:full_name`, {
+			nockSearchRepos200(`${randomString} org:myOrgName in:full_name fork:true`, {
 				items: [{ owner, full_name: "first", id: 1 }, { owner, full_name: "second", id: 22 }, { owner, full_name: "third", id: 333 }]
 			});
 

--- a/src/routes/github/repository/github-repository-get.test.ts
+++ b/src/routes/github/repository/github-repository-get.test.ts
@@ -152,7 +152,7 @@ describe("GitHub Repository Search", () => {
 				items: [{ owner, full_name: "first", id: 1 }, { owner, full_name: "second", id: 22 }, { owner, full_name: "third", id: 333 }]
 			});
 
-			nockSearchRepos422(`${randomString} org:anotherOrgName in:full_name`);
+			nockSearchRepos422(`${randomString} org:anotherOrgName in:full_name fork:true`);
 
 			await supertest(app)
 				.get("/github/repository").set(

--- a/src/routes/github/repository/github-repository-get.ts
+++ b/src/routes/github/repository/github-repository-get.ts
@@ -62,7 +62,7 @@ const getReposBySubscriptions = async (repoName: string, subscriptions: Subscrip
 				createInstallationClient(subscription.gitHubInstallationId, jiraHost, metrics, logger, subscription.gitHubAppId)
 			]);
 
-			const searchQueryInstallationString = `${repoName} org:${orgName} in:full_name`;
+			const searchQueryInstallationString = `${repoName} org:${orgName} in:full_name fork:true`;
 
 			const installationSearch = await gitHubInstallationClient.searchRepositories(searchQueryInstallationString, "updated")
 				.then(responseInstallationSearch => {


### PR DESCRIPTION
**What's in this PR?**
- Added `fork:true` qualifier to allow searching for forked repos([source](https://docs.github.com/en/search-github/searching-on-github/searching-in-forks))

**Why**
- One of our customers can not find their forked repo([JST-913160](https://getsupport.atlassian.com/browse/JST-913160))
