### PR TITLE
ISOC-4017 Limit vulnerability display name to 255 characters

### DIFF
--- a/src/sync/code-scanning-alerts.ts
+++ b/src/sync/code-scanning-alerts.ts
@@ -13,6 +13,7 @@ import {
 	transformGitHubStateToJiraStatus
 } from "~/src/transforms/util/github-security-alerts";
 import { getCodeScanningVulnDescription } from "../transforms/transform-code-scanning-alert";
+import { truncate } from "lodash";
 
 export const getCodeScanningAlertTask = async (
 	parentLogger: Logger,
@@ -99,7 +100,8 @@ const transformCodeScanningAlert = async (
 			id: `c-${transformRepositoryId(repository.id, gitHubClientConfig.baseUrl)}-${alert.number}`,
 			updateSequenceNumber: Date.now(),
 			containerId: transformRepositoryId(repository.id, gitHubClientConfig.baseUrl),
-			displayName: alert.rule.description || alert.rule.name,
+			// display name cannot exceed 255 characters
+			displayName: truncate(alert.rule.description || alert.rule.name, { length: 254 }),
 			description: getCodeScanningVulnDescription(alert, identifiers, alertInstances, logger),
 			url: alert.html_url,
 			type: "sast",

--- a/src/sync/dependabot-alerts.ts
+++ b/src/sync/dependabot-alerts.ts
@@ -12,6 +12,7 @@ import {
 	transformGitHubSeverityToJiraSeverity,
 	transformGitHubStateToJiraStatus
 } from "~/src/transforms/util/github-security-alerts";
+import { truncate } from "lodash";
 
 export const getDependabotAlertTask = async (
 	parentLogger: Logger,
@@ -96,7 +97,8 @@ const transformDependabotAlerts = async (
 			id: `d-${transformRepositoryId(repository.id, gitHubClientConfig.baseUrl)}-${alert.number}`,
 			updateSequenceNumber: Date.now(),
 			containerId: transformRepositoryId(repository.id, gitHubClientConfig.baseUrl),
-			displayName: alert.security_advisory.summary,
+			// display name cannot exceed 255 characters
+			displayName: truncate(alert.security_advisory.summary, { length: 254 }),
 			description: getDependabotScanningVulnDescription(alert, identifiers,logger),
 			url: alert.html_url,
 			type: "sca",

--- a/src/sync/secret-scanning-alerts.ts
+++ b/src/sync/secret-scanning-alerts.ts
@@ -8,6 +8,7 @@ import { JiraVulnerabilityBulkSubmitData, JiraVulnerabilitySeverityEnum } from "
 import { PageSizeAwareCounterCursor } from "./page-counter-cursor";
 import { SecretScanningAlertResponseItem, SortDirection } from "../github/client/github-client.types";
 import { getSecretScanningVulnDescription, transformGitHubStateToJiraStatus } from "../transforms/transform-secret-scanning-alert";
+import { truncate } from "lodash";
 
 export const getSecretScanningAlertTask = async (
 	parentLogger: Logger,
@@ -88,7 +89,8 @@ const transformSecretScanningAlert = async (
 			id: `s-${transformRepositoryId(repository.id, gitHubClientConfig.baseUrl)}-${alert.number}`,
 			updateSequenceNumber: Date.now(),
 			containerId: transformRepositoryId(repository.id, gitHubClientConfig.baseUrl),
-			displayName: alert.secret_type_display_name || `${alert.secret_type} secret exposed`,
+			// display name cannot exceed 255 characters
+			displayName: truncate(alert.secret_type_display_name || `${alert.secret_type} secret exposed`,{ length: 254 }),
 			description: getSecretScanningVulnDescription(alert, logger),
 			url: alert.html_url,
 			type: "sast",

--- a/src/transforms/transform-code-scanning-alert.ts
+++ b/src/transforms/transform-code-scanning-alert.ts
@@ -138,7 +138,8 @@ export const transformCodeScanningAlertToJiraSecurity = async (context: WebhookC
 			id: `c-${transformRepositoryId(repository.id, gitHubInstallationClient.baseUrl)}-${alert.number as number}`,
 			updateSequenceNumber: Date.now(),
 			containerId: transformRepositoryId(repository.id, gitHubInstallationClient.baseUrl),
-			displayName: alert.rule.description || alert.rule.name,
+			// display name cannot exceed 255 characters
+			displayName: truncate(alert.rule.description || alert.rule.name, { length: 254 }),
 			description: getCodeScanningVulnDescription(alert, identifiers, alertInstances, context.log),
 			url: alert.html_url,
 			type: "sast",

--- a/src/transforms/transform-dependabot-alert.ts
+++ b/src/transforms/transform-dependabot-alert.ts
@@ -47,7 +47,8 @@ export const transformDependabotAlert = async (context: WebhookContext<Dependabo
 			id: `d-${transformRepositoryId(repository.id, githubClientConfig.baseUrl)}-${alert.number}`,
 			updateSequenceNumber: Date.now(),
 			containerId: transformRepositoryId(repository.id, githubClientConfig.baseUrl),
-			displayName: alert.security_advisory.summary,
+			// display name cannot exceed 255 characters
+			displayName: truncate(alert.security_advisory.summary, { length: 254 }),
 			description: getDependabotScanningVulnDescription(alert, identifiers, context.log),
 			url: alert.html_url,
 			type: "sca",

--- a/src/transforms/transform-secret-scanning-alert.ts
+++ b/src/transforms/transform-secret-scanning-alert.ts
@@ -22,7 +22,8 @@ export const transformSecretScanningAlert = async (
 			id: `s-${transformRepositoryId(repository.id, githubClientConfig.baseUrl)}-${alert.number}`,
 			updateSequenceNumber: Date.now(),
 			containerId: transformRepositoryId(repository.id, githubClientConfig.baseUrl),
-			displayName: alert.secret_type_display_name || `${alert.secret_type} secret exposed`,
+			// display name cannot exceed 255 characters
+			displayName: truncate(alert.secret_type_display_name || `${alert.secret_type} secret exposed`, { length: 254 }),
 			description: getSecretScanningVulnDescription(alert, logger),
 			url: alert.html_url,
 			type: "sast",


### PR DESCRIPTION
**What's in this PR?**
This PR limits the vulnerability display name to 255 characters

**Why**
Data depot rejects the vulnerability with display name more than 255 characters

**Added feature flags**
ENABLE_GITHUB_SECURITY_IN_JIRA

**Affected issues**  
[ISOC-4017]



[ISOC-4017]: https://softwareteams.atlassian.net/browse/ISOC-4017