### PR TITLE
ISOC-4040 - Remove Impact from code scanning alert description

### DIFF
--- a/src/github/client/github-client.types.ts
+++ b/src/github/client/github-client.types.ts
@@ -199,11 +199,3 @@ type CodeScanningAlertResponseItemMostRecentInstance = {
 	commit_sha: string;
 	html_url: string;
 }
-
-export type CodeScanningAlertInstanceResponseItem = {
-	ref: string;
-	environment: string;
-	category: string;
-	state: string;
-	commit_sha: string;
-}

--- a/src/github/client/github-installation-client.ts
+++ b/src/github/client/github-installation-client.ts
@@ -33,8 +33,7 @@ import {
 	PaginatedAxiosResponse,
 	ReposGetContentsResponse,
 	SecretScanningAlertResponseItem,
-	CodeScanningAlertResponseItem,
-	CodeScanningAlertInstanceResponseItem
+	CodeScanningAlertResponseItem
 } from "./github-client.types";
 import { GITHUB_ACCEPT_HEADER } from "./github-client-constants";
 import { GitHubClient, GitHubConfig, Metrics } from "./github-client";
@@ -104,14 +103,6 @@ export class GitHubInstallationClient extends GitHubClient {
 		return await this.get<CodeScanningAlertResponseItem[]>(`/repos/{owner}/{repo}/code-scanning/alerts`, codeScanningAlertRequestParams, {
 			owner,
 			repo
-		});
-	}
-
-	public async getCodeScanningAlertInstances(owner: string, repo: string, alertNumber: number): Promise<AxiosResponse<CodeScanningAlertInstanceResponseItem[]>> {
-		return await this.get<CodeScanningAlertInstanceResponseItem[]>(`/repos/{owner}/{repo}/code-scanning/alerts/{alertNumber}/instances`, { }, {
-			owner,
-			repo,
-			alertNumber
 		});
 	}
 

--- a/src/sync/code-scanning-alerts.test.ts
+++ b/src/sync/code-scanning-alerts.test.ts
@@ -50,12 +50,7 @@ describe("sync/code-scanning-alerts", () => {
 			githubNock
 				.get("/repos/integrations/test-repo-name/code-scanning/alerts?per_page=20&page=1&sort=created&direction=desc")
 				.reply(200, codeScanningAlerts);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID).persist();
-			for (const codeScanningAlert of codeScanningAlerts) {
-				githubNock
-					.get(`/repos/integrations/test-repo-name/code-scanning/alerts/${codeScanningAlert.number}/instances`)
-					.reply(200, [{ "ref": "refs/heads/main" }, { "ref": "refs/pull/123" }, { "ref": "refs/heads/dev" }]);
-			}
+			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 			jiraNock
 				.post("/rest/security/1.0/bulk", expectedResponseCloudServer(subscription))
 				.reply(200);
@@ -129,15 +124,10 @@ describe("sync/code-scanning-alerts", () => {
 					gitHubApiUrl: gitHubServerApp.gitHubBaseUrl
 				}
 			};
-			gheUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID).persist();
+			gheUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 			gheNock
 				.get("/api/v3/repos/integrations/test-repo-name/code-scanning/alerts?per_page=20&page=1&sort=created&direction=desc")
 				.reply(200, codeScanningAlerts);
-			for (const codeScanningAlert of codeScanningAlerts) {
-				gheNock
-					.get(`/api/v3/repos/integrations/test-repo-name/code-scanning/alerts/${codeScanningAlert.number}/instances`)
-					.reply(200, [{ "ref": "refs/heads/main" }, { "ref": "refs/pull/123" }, { "ref": "refs/heads/dev" }]);
-			}
 			jiraNock
 				.post("/rest/security/1.0/bulk", expectedResponseGHEServer(subscription))
 				.reply(200);
@@ -184,7 +174,7 @@ const expectedResponseCloudServer = (subscription: Subscription) => ({
 			"updateSequenceNumber": 12345678,
 			"containerId": "1",
 			"displayName": "Reflected cross-site scripting",
-			"description": "**Vulnerability:** Reflected cross-site scripting\n\n**Impact:** The vulnerability in CodeQL impacts main branch and dev branch.\n\n**Severity:** Medium\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Open\n\n**Weaknesses:** [CWE-79](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=79), [CWE-116](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=116)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/9) in GitHub for a recommendation and relevant example.",
+			"description": "**Vulnerability:** Reflected cross-site scripting\n\n**Severity:** Medium\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Open\n\n**Weaknesses:** [CWE-79](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=79), [CWE-116](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=116)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/9) in GitHub for a recommendation and relevant example.",
 			"url": "https://github.com/auzwang/sequelize-playground/security/code-scanning/9",
 			"type": "sast",
 			"introducedDate": "2023-08-18T04:33:51Z",
@@ -213,7 +203,7 @@ const expectedResponseCloudServer = (subscription: Subscription) => ({
 			"updateSequenceNumber": 12345678,
 			"containerId": "1",
 			"displayName": "Hard-coded credentials",
-			"description": "**Vulnerability:** Hard-coded credentials\n\n**Impact:** The vulnerability in CodeQL impacts main branch and dev branch.\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/8) in GitHub for a recommendation and relevant example.",
+			"description": "**Vulnerability:** Hard-coded credentials\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/8) in GitHub for a recommendation and relevant example.",
 			"url": "https://github.com/auzwang/sequelize-playground/security/code-scanning/8",
 			"type": "sast",
 			"introducedDate": "2023-08-18T04:15:14Z",
@@ -246,7 +236,7 @@ const expectedResponseCloudServer = (subscription: Subscription) => ({
 			"updateSequenceNumber": 12345678,
 			"containerId": "1",
 			"displayName": "Database query built from user-controlled sources",
-			"description": "**Vulnerability:** Database query built from user-controlled sources\n\n**Impact:** The vulnerability in CodeQL impacts main branch and dev branch.\n\n**Severity:** High\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Open\n\n**Weaknesses:** [CWE-89](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=89), [CWE-90](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=90), [CWE-943](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=943)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/7) in GitHub for a recommendation and relevant example.",
+			"description": "**Vulnerability:** Database query built from user-controlled sources\n\n**Severity:** High\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Open\n\n**Weaknesses:** [CWE-89](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=89), [CWE-90](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=90), [CWE-943](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=943)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/7) in GitHub for a recommendation and relevant example.",
 			"url": "https://github.com/auzwang/sequelize-playground/security/code-scanning/7",
 			"type": "sast",
 			"introducedDate": "2023-08-09T04:26:41Z",
@@ -279,7 +269,7 @@ const expectedResponseCloudServer = (subscription: Subscription) => ({
 			"updateSequenceNumber": 12345678,
 			"containerId": "1",
 			"displayName": "Reflected cross-site scripting",
-			"description": "**Vulnerability:** Reflected cross-site scripting\n\n**Impact:** The vulnerability in CodeQL impacts main branch and dev branch.\n\n**Severity:** Medium\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-79](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=79), [CWE-116](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=116)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/6) in GitHub for a recommendation and relevant example.",
+			"description": "**Vulnerability:** Reflected cross-site scripting\n\n**Severity:** Medium\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-79](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=79), [CWE-116](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=116)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/6) in GitHub for a recommendation and relevant example.",
 			"url": "https://github.com/auzwang/sequelize-playground/security/code-scanning/6",
 			"type": "sast",
 			"introducedDate": "2023-08-09T04:26:41Z",
@@ -308,7 +298,7 @@ const expectedResponseCloudServer = (subscription: Subscription) => ({
 			"updateSequenceNumber": 12345678,
 			"containerId": "1",
 			"displayName": "Hard-coded credentials",
-			"description": "**Vulnerability:** Hard-coded credentials\n\n**Impact:** The vulnerability in CodeQL impacts main branch and dev branch.\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/3) in GitHub for a recommendation and relevant example.",
+			"description": "**Vulnerability:** Hard-coded credentials\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/3) in GitHub for a recommendation and relevant example.",
 			"url": "https://github.com/auzwang/sequelize-playground/security/code-scanning/3",
 			"type": "sast",
 			"introducedDate": "2023-08-03T05:47:19Z",
@@ -341,7 +331,7 @@ const expectedResponseCloudServer = (subscription: Subscription) => ({
 			"updateSequenceNumber": 12345678,
 			"containerId": "1",
 			"displayName": "Hard-coded credentials",
-			"description": "**Vulnerability:** Hard-coded credentials\n\n**Impact:** The vulnerability in CodeQL impacts main branch and dev branch.\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/2) in GitHub for a recommendation and relevant example.",
+			"description": "**Vulnerability:** Hard-coded credentials\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/2) in GitHub for a recommendation and relevant example.",
 			"url": "https://github.com/auzwang/sequelize-playground/security/code-scanning/2",
 			"type": "sast",
 			"introducedDate": "2023-08-01T00:25:22Z",
@@ -374,7 +364,7 @@ const expectedResponseCloudServer = (subscription: Subscription) => ({
 			"updateSequenceNumber": 12345678,
 			"containerId": "1",
 			"displayName": "Hard-coded credentials",
-			"description": "**Vulnerability:** Hard-coded credentials\n\n**Impact:** The vulnerability in CodeQL impacts main branch and dev branch.\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/1) in GitHub for a recommendation and relevant example.",
+			"description": "**Vulnerability:** Hard-coded credentials\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/1) in GitHub for a recommendation and relevant example.",
 			"url": "https://github.com/auzwang/sequelize-playground/security/code-scanning/1",
 			"type": "sast",
 			"introducedDate": "2023-07-31T06:37:26Z",
@@ -412,7 +402,7 @@ const expectedResponseGHEServer = (subscription: Subscription) => ({
 			"updateSequenceNumber": 12345678,
 			"containerId": "6769746875626d79646f6d61696e636f6d-1",
 			"displayName": "Reflected cross-site scripting",
-			"description": "**Vulnerability:** Reflected cross-site scripting\n\n**Impact:** The vulnerability in CodeQL impacts main branch and dev branch.\n\n**Severity:** Medium\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Open\n\n**Weaknesses:** [CWE-79](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=79), [CWE-116](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=116)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/9) in GitHub for a recommendation and relevant example.",
+			"description": "**Vulnerability:** Reflected cross-site scripting\n\n**Severity:** Medium\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Open\n\n**Weaknesses:** [CWE-79](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=79), [CWE-116](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=116)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/9) in GitHub for a recommendation and relevant example.",
 			"url": "https://github.com/auzwang/sequelize-playground/security/code-scanning/9",
 			"type": "sast",
 			"introducedDate": "2023-08-18T04:33:51Z",
@@ -441,7 +431,7 @@ const expectedResponseGHEServer = (subscription: Subscription) => ({
 			"updateSequenceNumber": 12345678,
 			"containerId": "6769746875626d79646f6d61696e636f6d-1",
 			"displayName": "Hard-coded credentials",
-			"description": "**Vulnerability:** Hard-coded credentials\n\n**Impact:** The vulnerability in CodeQL impacts main branch and dev branch.\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/8) in GitHub for a recommendation and relevant example.",
+			"description": "**Vulnerability:** Hard-coded credentials\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/8) in GitHub for a recommendation and relevant example.",
 			"url": "https://github.com/auzwang/sequelize-playground/security/code-scanning/8",
 			"type": "sast",
 			"introducedDate": "2023-08-18T04:15:14Z",
@@ -474,7 +464,7 @@ const expectedResponseGHEServer = (subscription: Subscription) => ({
 			"updateSequenceNumber": 12345678,
 			"containerId": "6769746875626d79646f6d61696e636f6d-1",
 			"displayName": "Database query built from user-controlled sources",
-			"description": "**Vulnerability:** Database query built from user-controlled sources\n\n**Impact:** The vulnerability in CodeQL impacts main branch and dev branch.\n\n**Severity:** High\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Open\n\n**Weaknesses:** [CWE-89](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=89), [CWE-90](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=90), [CWE-943](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=943)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/7) in GitHub for a recommendation and relevant example.",
+			"description": "**Vulnerability:** Database query built from user-controlled sources\n\n**Severity:** High\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Open\n\n**Weaknesses:** [CWE-89](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=89), [CWE-90](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=90), [CWE-943](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=943)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/7) in GitHub for a recommendation and relevant example.",
 			"url": "https://github.com/auzwang/sequelize-playground/security/code-scanning/7",
 			"type": "sast",
 			"introducedDate": "2023-08-09T04:26:41Z",
@@ -507,7 +497,7 @@ const expectedResponseGHEServer = (subscription: Subscription) => ({
 			"updateSequenceNumber": 12345678,
 			"containerId": "6769746875626d79646f6d61696e636f6d-1",
 			"displayName": "Reflected cross-site scripting",
-			"description": "**Vulnerability:** Reflected cross-site scripting\n\n**Impact:** The vulnerability in CodeQL impacts main branch and dev branch.\n\n**Severity:** Medium\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-79](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=79), [CWE-116](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=116)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/6) in GitHub for a recommendation and relevant example.",
+			"description": "**Vulnerability:** Reflected cross-site scripting\n\n**Severity:** Medium\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-79](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=79), [CWE-116](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=116)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/6) in GitHub for a recommendation and relevant example.",
 			"url": "https://github.com/auzwang/sequelize-playground/security/code-scanning/6",
 			"type": "sast",
 			"introducedDate": "2023-08-09T04:26:41Z",
@@ -536,7 +526,7 @@ const expectedResponseGHEServer = (subscription: Subscription) => ({
 			"updateSequenceNumber": 12345678,
 			"containerId": "6769746875626d79646f6d61696e636f6d-1",
 			"displayName": "Hard-coded credentials",
-			"description": "**Vulnerability:** Hard-coded credentials\n\n**Impact:** The vulnerability in CodeQL impacts main branch and dev branch.\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/3) in GitHub for a recommendation and relevant example.",
+			"description": "**Vulnerability:** Hard-coded credentials\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/3) in GitHub for a recommendation and relevant example.",
 			"url": "https://github.com/auzwang/sequelize-playground/security/code-scanning/3",
 			"type": "sast",
 			"introducedDate": "2023-08-03T05:47:19Z",
@@ -569,7 +559,7 @@ const expectedResponseGHEServer = (subscription: Subscription) => ({
 			"updateSequenceNumber": 12345678,
 			"containerId": "6769746875626d79646f6d61696e636f6d-1",
 			"displayName": "Hard-coded credentials",
-			"description": "**Vulnerability:** Hard-coded credentials\n\n**Impact:** The vulnerability in CodeQL impacts main branch and dev branch.\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/2) in GitHub for a recommendation and relevant example.",
+			"description": "**Vulnerability:** Hard-coded credentials\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/2) in GitHub for a recommendation and relevant example.",
 			"url": "https://github.com/auzwang/sequelize-playground/security/code-scanning/2",
 			"type": "sast",
 			"introducedDate": "2023-08-01T00:25:22Z",
@@ -602,7 +592,7 @@ const expectedResponseGHEServer = (subscription: Subscription) => ({
 			"updateSequenceNumber": 12345678,
 			"containerId": "6769746875626d79646f6d61696e636f6d-1",
 			"displayName": "Hard-coded credentials",
-			"description": "**Vulnerability:** Hard-coded credentials\n\n**Impact:** The vulnerability in CodeQL impacts main branch and dev branch.\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/1) in GitHub for a recommendation and relevant example.",
+			"description": "**Vulnerability:** Hard-coded credentials\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Fixed\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/1) in GitHub for a recommendation and relevant example.",
 			"url": "https://github.com/auzwang/sequelize-playground/security/code-scanning/1",
 			"type": "sast",
 			"introducedDate": "2023-07-31T06:37:26Z",

--- a/src/sync/code-scanning-alerts.ts
+++ b/src/sync/code-scanning-alerts.ts
@@ -86,7 +86,7 @@ export const getCodeScanningAlertTask = async (
 	const nextPageCursorStr = smartCursor.copyWithPageNo(smartCursor.pageNo + 1).serialise();
 	const edgesWithCursor = [{ codeScanningAlerts: codeScanningAlerts, cursor: nextPageCursorStr }];
 
-	const jiraPayload = await transformCodeScanningAlert(codeScanningAlerts, repository, jiraHost, logger, messagePayload.gitHubAppConfig?.gitHubAppId, gitHubClient);
+	const jiraPayload = await transformCodeScanningAlert(codeScanningAlerts, repository, jiraHost, logger, messagePayload.gitHubAppConfig?.gitHubAppId);
 	logger.info({ processingTime: Date.now() - startTime, jiraPayloadLength: jiraPayload?.vulnerabilities?.length }, "Backfill task complete");
 	return {
 		edges: edgesWithCursor,
@@ -111,8 +111,7 @@ const transformCodeScanningAlert = async (
 	repository: Repository,
 	jiraHost: string,
 	logger: Logger,
-	gitHubAppId: number | undefined,
-	gitHubClient: GitHubInstallationClient
+	gitHubAppId: number | undefined
 ): Promise<JiraVulnerabilityBulkSubmitData> => {
 
 	const gitHubClientConfig = await getGitHubClientConfigFromAppId(gitHubAppId, jiraHost);
@@ -120,8 +119,7 @@ const transformCodeScanningAlert = async (
 	const handleUnmappedState = (state: string) => logger.info(`Received unmapped state from code_scanning_alert sync: ${state}`);
 	const handleUnmappedSeverity = (severity: string | null) => logger.info(`Received unmapped severity from code_scanning_alert sync: ${severity ?? "Missing Severity"}`);
 
-	const vulnerabilities = await Promise.all(alerts.map(async (alert) => {
-		const { data: alertInstances } = await gitHubClient.getCodeScanningAlertInstances(repository.owner.login, repository.name, alert.number);
+	const vulnerabilities = alerts.map((alert) => {
 		const identifiers = transformRuleTagsToIdentifiers(alert.rule.tags);
 
 		return {
@@ -131,7 +129,7 @@ const transformCodeScanningAlert = async (
 			containerId: transformRepositoryId(repository.id, gitHubClientConfig.baseUrl),
 			// display name cannot exceed 255 characters
 			displayName: truncate(alert.rule.description || alert.rule.name || `Code scanning alert #${alert.number}`, { length: 254 }),
-			description: getCodeScanningVulnDescription(alert, identifiers, alertInstances, logger),
+			description: getCodeScanningVulnDescription(alert, identifiers, logger),
 			url: alert.html_url,
 			type: "sast",
 			introducedDate: alert.created_at,
@@ -145,7 +143,7 @@ const transformCodeScanningAlert = async (
 				content: truncate(alert.tool.name, { length: 254 })
 			}
 		};
-	}));
+	});
 	return { vulnerabilities };
 
 };

--- a/src/transforms/transform-code-scanning-alert.test.ts
+++ b/src/transforms/transform-code-scanning-alert.test.ts
@@ -177,10 +177,6 @@ describe("code_scanning_alert transform", () => {
 
 	describe("security vulnerabilities", () => {
 		it("transform code scanning alert to jira security payload", async () => {
-			githubUserTokenNock(gitHubInstallationId);
-			githubNock
-				.get(`/repos/${codeScanningCreatedPayload.repository.owner.login}/${codeScanningCreatedPayload.repository.name}/code-scanning/alerts/${codeScanningCreatedPayload.alert.number}/instances`)
-				.reply(200, [{ "ref": "refs/heads/main" }, { "ref": "refs/pull/123" }, { "ref": "refs/heads/dev" }]);
 			const result = await transformCodeScanningAlertToJiraSecurity(
 				buildContext(codeScanningCreatedPayload),
 				gitHubInstallationId,
@@ -193,7 +189,7 @@ describe("code_scanning_alert transform", () => {
 					},
 					"containerId": "119484675",
 					"displayName": "Hard-coded credentials",
-					"description": "**Vulnerability:** Hard-coded credentials\n\n**Impact:** The vulnerability in CodeQL impacts main branch and dev branch.\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Open\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/2) in GitHub for a recommendation and relevant example.",
+					"description": "**Vulnerability:** Hard-coded credentials\n\n**Severity:** Critical\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** Open\n\n**Weaknesses:** [CWE-259](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=259), [CWE-321](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=321), [CWE-798](https://cwe.mitre.org/cgi-bin/jumpmenu.cgi?id=798)\n\nVisit the vulnerability’s [code scanning alert page](https://github.com/auzwang/sequelize-playground/security/code-scanning/2) in GitHub for a recommendation and relevant example.",
 					"id": "c-119484675-2",
 					"identifiers": [
 						{
@@ -232,7 +228,6 @@ describe("code_scanning_alert transform", () => {
 		])(
 			"transform code scanning alert state %s to security vulnerability status %s",
 			async (state, expectedStatus) => {
-				setupNock(gitHubInstallationId, codeScanningCreatedPayload);
 				const payload = {
 					...codeScanningCreatedPayload,
 					alert: { ...codeScanningCreatedPayload.alert, state }
@@ -248,7 +243,6 @@ describe("code_scanning_alert transform", () => {
 		);
 
 		it("map fixed code scanning alert fixed_at to jira security lastUpdated", async () => {
-			setupNock(gitHubInstallationId, codeScanningFixedPayload);
 			const result = await transformCodeScanningAlertToJiraSecurity(
 				buildContext(codeScanningFixedPayload),
 				gitHubInstallationId,
@@ -260,7 +254,6 @@ describe("code_scanning_alert transform", () => {
 		});
 
 		it("map closed by user code scanning alert dismissed_at to jira security lastUpdated", async () => {
-			setupNock(gitHubInstallationId, codeScanningClosedByUserPayload);
 			const result = await transformCodeScanningAlertToJiraSecurity(
 				buildContext(codeScanningClosedByUserPayload),
 				gitHubInstallationId,
@@ -281,7 +274,6 @@ describe("code_scanning_alert transform", () => {
 		});
 
 		it("should log unmapped state", async () => {
-			setupNock(gitHubInstallationId, codeScanningCreatedPayload);
 			const payload = {
 				...codeScanningCreatedPayload,
 				alert: { ...codeScanningCreatedPayload.alert, state: "unmapped_state" }
@@ -298,7 +290,6 @@ describe("code_scanning_alert transform", () => {
 		});
 
 		it("should log unmapped severity", async () => {
-			setupNock(gitHubInstallationId, codeScanningCreatedPayload);
 			const payload = {
 				...codeScanningCreatedPayload,
 				alert: {
@@ -321,7 +312,6 @@ describe("code_scanning_alert transform", () => {
 		});
 
 		it("set identifiers when alert rule tags contains CWEs", async () => {
-			setupNock(gitHubInstallationId, codeScanningCreatedJsXssPayload);
 			const payload = codeScanningCreatedJsXssPayload;
 			const context = buildContext(payload);
 			const result = await transformCodeScanningAlertToJiraSecurity(
@@ -344,7 +334,6 @@ describe("code_scanning_alert transform", () => {
 		});
 
 		it("omit identifiers when alert rule tags is null", async () => {
-			setupNock(gitHubInstallationId, codeScanningCreatedJsXssPayload);
 			const payload = {
 				...codeScanningCreatedJsXssPayload,
 				alert: {
@@ -365,7 +354,6 @@ describe("code_scanning_alert transform", () => {
 		});
 
 		it("omit identifiers when alert rule tags is empty", async () => {
-			setupNock(gitHubInstallationId, codeScanningCreatedJsXssPayload);
 			const payload = {
 				...codeScanningCreatedJsXssPayload,
 				alert: {
@@ -386,7 +374,6 @@ describe("code_scanning_alert transform", () => {
 		});
 
 		it("omit identifiers when alert rule tags have no CWEs", async () => {
-			setupNock(gitHubInstallationId, codeScanningCreatedJsXssPayload);
 			const payload = {
 				...codeScanningCreatedJsXssPayload,
 				alert: {
@@ -407,12 +394,3 @@ describe("code_scanning_alert transform", () => {
 		});
 	});
 });
-
-
-const setupNock = (gitHubInstallationId, codeScanningPayload) => {
-	githubUserTokenNock(gitHubInstallationId);
-	githubNock
-		// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-		.get(`/repos/${codeScanningPayload.repository.owner.login}/${codeScanningPayload.repository.name}/code-scanning/alerts/${codeScanningPayload.alert.number}/instances`)
-		.reply(200);
-};

--- a/src/transforms/transform-code-scanning-alert.ts
+++ b/src/transforms/transform-code-scanning-alert.ts
@@ -14,7 +14,6 @@ import {
 	transformGitHubSeverityToJiraSeverity,
 	transformGitHubStateToJiraStatus, transformRuleTagsToIdentifiers
 } from "~/src/transforms/util/github-security-alerts";
-import { CodeScanningAlertInstanceResponseItem } from "../github/client/github-client.types";
 
 const MAX_STRING_LENGTH = 255;
 
@@ -125,7 +124,6 @@ export const transformCodeScanningAlertToJiraSecurity = async (context: WebhookC
 		subTrigger: "code_scanning_alert"
 	};
 	const gitHubInstallationClient = await createInstallationClient(githubInstallationId, jiraHost, metrics, context.log, context.gitHubAppConfig?.gitHubAppId);
-	const { data: alertInstances } = await gitHubInstallationClient.getCodeScanningAlertInstances(repository.owner.login, repository.name, alert.number);
 
 	const handleUnmappedState = (state: string) => context.log.info(`Received unmapped state from code_scanning_alert webhook: ${state}`);
 	const handleUnmappedSeverity = (severity: string | null) => context.log.info(`Received unmapped severity from code_scanning_alert webhook: ${severity ?? "Missing Severity"}`);
@@ -141,7 +139,7 @@ export const transformCodeScanningAlertToJiraSecurity = async (context: WebhookC
 			// display name cannot exceed 255 characters
 			// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 			displayName: truncate(alert.rule.description || alert.rule.name || `Code scanning alert #${alert.number}`, { length: 254 }),
-			description: getCodeScanningVulnDescription(alert, identifiers, alertInstances, context.log),
+			description: getCodeScanningVulnDescription(alert, identifiers, context.log),
 			url: alert.html_url,
 			type: "sast",
 			introducedDate: alert.created_at,
@@ -162,37 +160,17 @@ export const transformCodeScanningAlertToJiraSecurity = async (context: WebhookC
 export const getCodeScanningVulnDescription = (
 	alert,
 	identifiers: { displayName: string, url: string; }[] | null,
-	alertInstances: CodeScanningAlertInstanceResponseItem[],
 	logger: Logger) => {
 	try {
-		const branches = getBranches(alertInstances);
 		const identifiersText = getIdentifiersText(identifiers);
 		// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-		const description = `**Vulnerability:** ${alert.rule.description}\n\n**Impact:** The vulnerability in ${alert.tool.name} impacts ${toSentence(branches)}.\n\n**Severity:** ${capitalize(alert.rule?.security_severity_level)}\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** ${capitalize(alert.state)}\n\n**Weaknesses:** ${identifiersText}\n\nVisit the vulnerability’s [code scanning alert page](${alert.html_url}) in GitHub for a recommendation and relevant example.`;
+		const description = `**Vulnerability:** ${alert.rule.description}\n\n**Severity:** ${capitalize(alert.rule?.security_severity_level)}\n\nGitHub uses  [Common Vulnerability Scoring System (CVSS)](https://www.atlassian.com/trust/security/security-severity-levels) data to calculate security severity.\n\n**Status:** ${capitalize(alert.state)}\n\n**Weaknesses:** ${identifiersText}\n\nVisit the vulnerability’s [code scanning alert page](${alert.html_url}) in GitHub for a recommendation and relevant example.`;
 		// description cannot exceed 5000 characters
 		return truncate(description, { length: 4999 });
 	} catch (err) {
 		logger.warn({ err }, "Failed to construct vulnerability description");
 		return alert.rule?.description;
 	}
-};
-
-const toSentence = (branches: string[]) => {
-	if (!branches) {
-		return "";
-	}
-	if (branches.length == 1) {
-		return `${branches[0]} branch`;
-	}
-	const last = branches.pop();
-	return `${branches.join(" branch, ")} branch and ${last} branch`;
-};
-
-const getBranches = (alertInstances: CodeScanningAlertInstanceResponseItem[]): string[] => {
-	const branchesAlertInstances = alertInstances.filter(alertInstance => alertInstance.ref?.startsWith("refs/heads"));
-	return branchesAlertInstances.map(alertInstance => {
-		return alertInstance.ref.replace("refs/heads/", "");
-	});
 };
 
 const getIdentifiersText = (identifiers: { displayName: string, url: string; }[] | null): string => {


### PR DESCRIPTION
**What's in this PR?**
This PR removes the Impact from code scanning alert description.

**Why**
To fetch impact details, we need to call [code canning alert instances ](https://docs.github.com/en/free-pro-team@latest/rest/code-scanning/code-scanning?apiVersion=2022-11-28#list-instances-of-a-code-scanning-alert)API which is not stable and list of instances could be huge. We're dropping impact from the description for now.

Affected issues
[ISOC-4040]

**How has this been tested?**  
Unit test



[ISOC-4035]: https://softwareteams.atlassian.net/browse/ISOC-4035

[ISOC-4040]: https://softwareteams.atlassian.net/browse/ISOC-4040