### PR TITLE
ARC-2490 - Provide accurate error message for Create branch if write access permission is not granted

### DIFF
--- a/src/routes/github/create-branch/github-create-branch-post.test.ts
+++ b/src/routes/github/create-branch/github-create-branch-post.test.ts
@@ -108,7 +108,7 @@ describe("github-create-branch", () => {
 
 		expect(res.status).toHaveBeenCalledWith(403);
 		expect(res.json).toBeCalledWith({
-			error: "We couldn’t create this branch, possibly because this GitHub repository hasn't been configured to your Jira site."
+			error: "We couldn’t create this branch, because GitHub for Jira app does not have permission to write to the GitHub repository. If you want to enable this feature, please contact your GitHub admin to grant permission."
 		});
 	});
 

--- a/src/routes/github/create-branch/github-create-branch-post.ts
+++ b/src/routes/github/create-branch/github-create-branch-post.ts
@@ -12,7 +12,7 @@ import { Errors } from "config/errors";
 const getErrorMessages = (statusCode: number): string => {
 	switch (statusCode) {
 		case 403: {
-			return "We couldn’t create this branch, possibly because this GitHub repository hasn't been configured to your Jira site.";
+			return "We couldn’t create this branch, because GitHub for Jira app does not have permission to write to the GitHub repository. If you want to enable this feature, please contact your GitHub admin to grant permission.";
 		}
 		case 400: {
 			return "We couldn’t create this branch. Check that you’ve entered valid values for repository, source branch name, and new branch name.";


### PR DESCRIPTION
**What's in this PR?**
- Changing the error message for 403 errors when creating a GitHub branch

**Why**
- The previous error message was not very clear.
