### PR TITLE
fix: org with zero repo count display

### DIFF
--- a/src/util/handlebars/handlebar-helpers.ts
+++ b/src/util/handlebars/handlebar-helpers.ts
@@ -27,7 +27,7 @@ export const registerHandlebarsHelpers = () => {
 				: `${numberOfSyncedRepos} / ${totalNumberOfRepos}`
 	);
 
-	hbs.registerHelper("checkRepoCount", (totalNumberOfRepos: number) => (totalNumberOfRepos >= 0));
+	hbs.registerHelper("checkRepoCount", (totalNumberOfRepos: unknown | undefined) => (typeof totalNumberOfRepos === "number" &&  totalNumberOfRepos >= 0));
 
 	hbs.registerHelper("repoAccessType", (repository_selection: string) =>
 		repository_selection === "all" ? "All repos" : "Only select repos"

--- a/src/util/handlebars/handlebar-helpers.ts
+++ b/src/util/handlebars/handlebar-helpers.ts
@@ -27,8 +27,7 @@ export const registerHandlebarsHelpers = () => {
 				: `${numberOfSyncedRepos} / ${totalNumberOfRepos}`
 	);
 
-	//check to display repo count as zero in case of org with zero repos
-	hbs.registerHelper("hasTotalNumberOfRepos", (totalNumberOfRepos: number) => (totalNumberOfRepos || totalNumberOfRepos === 0));
+	hbs.registerHelper("checkRepos", (totalNumberOfRepos: number) => (totalNumberOfRepos >= 0));
 
 	hbs.registerHelper("repoAccessType", (repository_selection: string) =>
 		repository_selection === "all" ? "All repos" : "Only select repos"

--- a/src/util/handlebars/handlebar-helpers.ts
+++ b/src/util/handlebars/handlebar-helpers.ts
@@ -27,6 +27,9 @@ export const registerHandlebarsHelpers = () => {
 				: `${numberOfSyncedRepos} / ${totalNumberOfRepos}`
 	);
 
+	//check to display repo count as zero in case of org with zero repos
+	hbs.registerHelper("hasTotalNumberOfRepos", (totalNumberOfRepos: number) => (totalNumberOfRepos || totalNumberOfRepos === 0));
+
 	hbs.registerHelper("repoAccessType", (repository_selection: string) =>
 		repository_selection === "all" ? "All repos" : "Only select repos"
 	);

--- a/src/util/handlebars/handlebar-helpers.ts
+++ b/src/util/handlebars/handlebar-helpers.ts
@@ -27,7 +27,7 @@ export const registerHandlebarsHelpers = () => {
 				: `${numberOfSyncedRepos} / ${totalNumberOfRepos}`
 	);
 
-	hbs.registerHelper("checkRepos", (totalNumberOfRepos: number) => (totalNumberOfRepos >= 0));
+	hbs.registerHelper("checkRepoCount", (totalNumberOfRepos: number) => (totalNumberOfRepos >= 0));
 
 	hbs.registerHelper("repoAccessType", (repository_selection: string) =>
 		repository_selection === "all" ? "All repos" : "Only select repos"

--- a/views/partials/jira-configuration-table.hbs
+++ b/views/partials/jira-configuration-table.hbs
@@ -50,12 +50,12 @@
               {{/if}}
             {{/if}}
 
-            {{#if connection.totalNumberOfRepos}}
+            {{#if (hasTotalNumberOfRepos connection.totalNumberOfRepos)}}
               <span class="jiraConfiguration__table__syncCount">
-                {{ifAllReposSynced
-                    connection.numberOfSyncedRepos
-                    connection.totalNumberOfRepos
-                }}
+                  {{ifAllReposSynced
+                      connection.numberOfSyncedRepos
+                      connection.totalNumberOfRepos
+                  }}
               </span>
             {{/if}}
             <a

--- a/views/partials/jira-configuration-table.hbs
+++ b/views/partials/jira-configuration-table.hbs
@@ -50,7 +50,7 @@
               {{/if}}
             {{/if}}
 
-            {{#if (checkRepos connection.totalNumberOfRepos)}}
+            {{#if (checkRepoCount connection.totalNumberOfRepos)}}
               <span class="jiraConfiguration__table__syncCount">
                   {{ifAllReposSynced
                       connection.numberOfSyncedRepos

--- a/views/partials/jira-configuration-table.hbs
+++ b/views/partials/jira-configuration-table.hbs
@@ -50,7 +50,7 @@
               {{/if}}
             {{/if}}
 
-            {{#if (hasTotalNumberOfRepos connection.totalNumberOfRepos)}}
+            {{#if (checkRepos connection.totalNumberOfRepos)}}
               <span class="jiraConfiguration__table__syncCount">
                   {{ifAllReposSynced
                       connection.numberOfSyncedRepos


### PR DESCRIPTION
**What's in this PR?**
Currently we are still not showing repo count as zero for the org with zero repo 
Issue:
<img width="1503" alt="Screenshot 2023-10-04 at 9 12 19 am" src="https://github.com/atlassian/github-for-jira/assets/142195272/3f8e3600-e26b-4901-adc8-0d27b5395b69">
Applying fix for the same.
Fix:
<img width="1728" alt="Screenshot 2023-10-04 at 11 24 39 am" src="https://github.com/atlassian/github-for-jira/assets/142195272/147ed336-8794-42f4-b91f-9fba98c7e73f">

**Why**
https://softwareteams.atlassian.net/browse/ARC-316

**Added feature flags**
NA

**Affected issues**  
[_Jira Issues_](https://softwareteams.atlassian.net/browse/ARC-316)

**How has this been tested?**  
Manually in local env and via unit test cases

**Whats Next?**
