### PR TITLE
Fixing the 500 error when going to `/spa` when no orgs

### DIFF
--- a/src/routes/jira/atlassian-connect/jira-atlassian-connect-get.ts
+++ b/src/routes/jira/atlassian-connect/jira-atlassian-connect-get.ts
@@ -215,7 +215,7 @@ const	modules = {
 			name: {
 				value: "GitHub for Jira SPA Index Page"
 			},
-			url: "/spa",
+			url: "/spa?from={ac.from}",
 			location: "none",
 			conditions: adminCondition
 		}, {

--- a/src/routes/jira/jira-get.test.ts
+++ b/src/routes/jira/jira-get.test.ts
@@ -305,7 +305,7 @@ describe.each([
 			.get(url)
 			.expect(200)
 			.then(response => {
-				expect(response.text).toContain("<html>\n			<body></body>\n    	<script src=\"https://connect-cdn.atl-paas.net/all.js\"></script>\n			<script>AP.navigator.go( \"addonmodule\", { moduleKey: \"spa-index-page\", customData: { from: \"homepage\" } });</script>\n		</html>");
+				expect(response.text).toContain("<h1 class=\"jiraConfiguration__header__title\">GitHub configuration</h1>");
 			});
 	});
 
@@ -315,8 +315,10 @@ describe.each([
 				.mockResolvedValue(true);
 			await supertest(frontendApp)
 				.get(url)
-				.expect(302)
-				.expect("location", "/spa?from=homepage");
+				.expect(200)
+				.then(response => {
+					expect(response.text).toContain("<html>\n			<body></body>\n    	<script src=\"https://connect-cdn.atl-paas.net/all.js\"></script>\n			<script>AP.navigator.go( \"addonmodule\", { moduleKey: \"spa-index-page\", customData: { from: \"homepage\" } });</script>\n		</html>");
+				});
 		});
 		it("should show existing page on empty state if ff off", async () => {
 			when(booleanFlag).calledWith(BooleanFlags.USE_NEW_5KU_SPA_EXPERIENCE, jiraHost)

--- a/src/routes/jira/jira-get.test.ts
+++ b/src/routes/jira/jira-get.test.ts
@@ -305,7 +305,7 @@ describe.each([
 			.get(url)
 			.expect(200)
 			.then(response => {
-				expect(response.text).toContain("<h1 class=\"jiraConfiguration__header__title\">GitHub configuration</h1>");
+				expect(response.text).toContain("<html>\n			<body></body>\n    	<script src=\"https://connect-cdn.atl-paas.net/all.js\"></script>\n			<script>AP.navigator.go( \"addonmodule\", { moduleKey: \"spa-index-page\", customData: { from: \"homepage\" } });</script>\n		</html>");
 			});
 	});
 

--- a/src/routes/jira/jira-get.ts
+++ b/src/routes/jira/jira-get.ts
@@ -54,7 +54,15 @@ const renderJiraCloudAndEnterpriseServer = async (res: Response, req: Request): 
 
 	const useNewSPAExperience = await booleanFlag(BooleanFlags.USE_NEW_5KU_SPA_EXPERIENCE, jiraHost);
 	if (useNewSPAExperience && !hasConnections) {
-		res.redirect("/spa?from=homepage");
+		/**
+		 * Using AP.navigator to redirect because `/spa` page now needs JWT token,
+		 * `/spa` pages need JWT token to get the FeatureFlag and pass it to the React app
+		 */
+		res.send(`<html>
+			<body></body>
+    	<script src="https://connect-cdn.atl-paas.net/all.js"></script>
+			<script>AP.navigator.go( "addonmodule", { moduleKey: "spa-index-page", customData: { from: "homepage" } });</script>
+		</html>`);
 	} else {
 		res.render("jira-configuration.hbs", {
 			host: jiraHost,

--- a/test/snapshots/routes/jira/atlassian-connect/jira-atlassian-connect-get.test.ts.snap
+++ b/test/snapshots/routes/jira/atlassian-connect/jira-atlassian-connect-get.test.ts.snap
@@ -149,7 +149,7 @@ Object {
         "name": Object {
           "value": "GitHub for Jira SPA Index Page",
         },
-        "url": "/spa",
+        "url": "/spa?from={ac.from}",
       },
       Object {
         "conditions": Array [

--- a/test/snapshots/routes/maintenance/maintenance-router.test.ts.snap
+++ b/test/snapshots/routes/maintenance/maintenance-router.test.ts.snap
@@ -149,7 +149,7 @@ Object {
         "name": Object {
           "value": "GitHub for Jira SPA Index Page",
         },
-        "url": "/spa",
+        "url": "/spa?from={ac.from}",
       },
       Object {
         "conditions": Array [


### PR DESCRIPTION
**What's in this PR?**
- Changed the `res.redirect` to `AP.navigator.go` in `jira-get`.
- Updated the `atlassian-connect.json` to pass in `from` as query parameters in `/spa` route.
  

**Why**
- Due to a [recent change ](https://github.com/atlassian/github-for-jira/pull/2392), `/spa` routes now need JWT authentication, so doing a normal `res.redirect` is throwing a 401 error from the server.

**How has this been tested?**  
- Staging
