### PR TITLE
NONE: fix repoview link for ghe

### DIFF
--- a/views/jira-configuration.hbs
+++ b/views/jira-configuration.hbs
@@ -238,7 +238,7 @@
                             <span class="jiraConfiguration__table__cell__settings__headerItem">Application</span>
                           </h6>
                           <aui-section class="jiraConfiguration__table__cell__settings__dropdownItems">
-                             <input type="hidden" id="_csrf" name="_csrf" value="{{../csrfToken}}">
+                             <input type="hidden" id="_csrf" name="_csrf" value="{{../../csrfToken}}">
                              <div class="jiraConfiguration__table__cell__gitHubAppItem">
                                <button
                                    class="jiraConfiguration__editGitHubApp"
@@ -267,12 +267,12 @@
                                 hideAvatar=true
                                 elementIdPrefix="gheServer-"
                                 html_url=html_url
-                                csrfToken=csrfToken
+                                csrfToken=../../csrfToken
                                 gitHubAppId=app.id
                                 successfulConnections=app.successfulConnections
                                 failedConnections=app.failedConnections
                                 gitHubAppId=app.id
-                                enableRepoConnectedPage=enableRepoConnectedPage
+                                enableRepoConnectedPage=../../enableRepoConnectedPage
                             }}
                           {{else}}
                             <div class="jiraConfiguration__collapsibleBody">

--- a/views/partials/jira-configuration-table.hbs
+++ b/views/partials/jira-configuration-table.hbs
@@ -183,7 +183,7 @@
           host=host
           html_url=html_url
           syncErrors=connection.failedSyncErrors
-          csrfToken=csrfToken
+          csrfToken=../csrfToken
         }}
 
       {{/each}}


### PR DESCRIPTION
**What's in this PR?**
Fixing RepoView link for GHEs. Also noticed that csrfToken suffered same, fixed it as well (although looks like it wasn't used :susp: )

**Why**
Cause it is broken

**Added feature flags**
Existing one

**How has this been tested?**  
locally

**Whats Next?**
