### PR TITLE
UA-9615 - Micros is deprecating Node.js 14.x runtime for lambda - github-for-jira

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -786,7 +786,7 @@ environmentOverrides:
       - type: lambda
         name: auto-deployment-github-app
         attributes:
-          runtime: nodejs14.x
+          runtime: nodejs18.x
           prefetchMicrosEnvVars: true
           artifact: "_sox/github-for-jira/auto-deployment-github-app-${BITBUCKET_BUILD_NUMBER}.zip"
           handler: auto-deployment.handler


### PR DESCRIPTION
**What's in this PR?**
- Updating the node version of lambda to 18.

**Why**
- Cause today is the deadline

**How has this been tested?**  
- Nothing, but this shouldn't break anything because this lambda is used for the auto deployment in the pipelines.

**Whats Next?**
- Merge and check if the auto deployment is still running in the pipelines.