### PR TITLE
Fixing the broken e2e tests

### DIFF
--- a/test/e2e/utils/jira.ts
+++ b/test/e2e/utils/jira.ts
@@ -56,7 +56,7 @@ export const jiraAppInstall = async (page: Page): Promise<Page> => {
 	await page.click("#upm-upload-dialog .aui-button-primary");
 	await page.click(`#upm-plugin-status-dialog .confirm`, { timeout: 60000 });
 	const iframe = await page.frameLocator("#ak-main-content iframe");
-	await (await iframe.locator(".jiraConfiguration")).waitFor();
+	await (await iframe.locator("#root")).waitFor();
 	return page;
 };
 


### PR DESCRIPTION
**What's in this PR?**
- Changing the locator on the e2e test.

**Why**
Now that we've removed the 5KU FF, the very first screen the user will get to is the Get Started page from the 5KU react. So the previous locator defined in the e2e test won't work now.

**How has this been tested?**  
- In e2e tests.

**Whats Next?**
- Just merge and see everything green again.