### PR TITLE
ARC-2592 fix test warn

### DIFF
--- a/spa/src/pages/ConfigSteps/test.tsx
+++ b/spa/src/pages/ConfigSteps/test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { BrowserRouter } from "react-router-dom";
 import ConfigSteps from "./index";
@@ -135,10 +135,10 @@ test("Connect GitHub Screen - Checking the GitHub Cloud flow when not authentica
 		);
 	});
 
-	await act(() => userEvent.click(screen.getByText(GITHUB_CLOUD)));
-	await act(() => userEvent.click(screen.getByText(SELECT_GH_PRODUCT_CTA)));
+	userEvent.click(screen.getByText(GITHUB_CLOUD));
+	userEvent.click(screen.getByText(SELECT_GH_PRODUCT_CTA));
 
-	expect(OAuthManager.authenticateInGitHub).toHaveBeenCalled();
+	await waitFor(() => expect(OAuthManager.authenticateInGitHub).toHaveBeenCalled());
 });
 
 test("Connect GitHub Screen - Checking the GitHub Cloud flow when authenticated with orgs", async () => {

--- a/spa/src/pages/ConfigSteps/test.tsx
+++ b/spa/src/pages/ConfigSteps/test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { BrowserRouter } from "react-router-dom";
 import ConfigSteps from "./index";
@@ -127,18 +127,16 @@ test("Connect GitHub Screen - Checking the GitHub Cloud flow when not authentica
 	jest.mocked(OAuthManager).checkValidity = UnAuthenticated.checkValidity;
 	jest.mocked(OAuthManager).authenticateInGitHub = UnAuthenticated.authenticateInGitHub;
 
-	await act(async () => {
-		render(
-			<BrowserRouter>
-				<ConfigSteps />
-			</BrowserRouter>
-		);
-	});
+	render(
+		<BrowserRouter>
+			<ConfigSteps />
+		</BrowserRouter>
+	);
 
-	userEvent.click(screen.getByText(GITHUB_CLOUD));
-	userEvent.click(screen.getByText(SELECT_GH_PRODUCT_CTA));
+	await userEvent.click(screen.getByText(GITHUB_CLOUD));
+	await userEvent.click(screen.getByText(SELECT_GH_PRODUCT_CTA));
 
-	await waitFor(() => expect(OAuthManager.authenticateInGitHub).toHaveBeenCalled());
+	expect(OAuthManager.authenticateInGitHub).toHaveBeenCalled();
 });
 
 test("Connect GitHub Screen - Checking the GitHub Cloud flow when authenticated with orgs", async () => {


### PR DESCRIPTION
**What's in this PR?**
Just fix a test warning
![image](https://github.com/atlassian/github-for-jira/assets/105693507/8b90f117-2edb-43ad-89a2-9ebfd0f4260f)


**Why**
Seems `render` and `userEvent` already contains a `act()` inside. Wrapping it outside ( and have an react.setState update during the event) will cause the warning.
Just await on the userEvent.click() seems does the trick.

**Added feature flags**

**Affected issues**  
ARC-2592

**How has this been tested?**  
_Include how to test if applicable_

**Whats Next?**
