### PR TITLE
ARC-2938 - Support use case starts from GitHub installation

### DIFF
--- a/src/routes/github/configuration/github-configuration-app-installs-get.test.ts
+++ b/src/routes/github/configuration/github-configuration-app-installs-get.test.ts
@@ -41,7 +41,7 @@ describe("GitHub Branches Get", () => {
 				}));
 
 		expect(result.status).toStrictEqual(302);
-		expect(result.headers.location).toStrictEqual("https://github.com/apps/jira/installations/new");
+		expect(result.headers.location).toStrictEqual("https://github.com/apps/jira/installations/new?state=non-spa");
 	});
 
 	it("Should successfully regenerate URL and redirect to GitHub path for server", async () => {
@@ -66,7 +66,7 @@ describe("GitHub Branches Get", () => {
 				}));
 
 		expect(result.status).toStrictEqual(302);
-		expect(result.headers.location).toStrictEqual("https://github.mydomain.com/github-apps/jira/installations/new");
+		expect(result.headers.location).toStrictEqual("https://github.mydomain.com/github-apps/jira/installations/new?state=non-spa");
 	});
 
 	it("should redirect to oauth dance when no github token", async () => {

--- a/src/routes/github/configuration/github-configuration-app-installs-get.ts
+++ b/src/routes/github/configuration/github-configuration-app-installs-get.ts
@@ -27,9 +27,9 @@ export const GithubConfigurationAppInstallsGet = async (req: Request, res: Respo
 	// We need to re-generate the URL for server because API gateway might override the hostname
 	if (data.html_url.indexOf("/github-apps/") > 0) {
 		// https://docs.github.com/en/enterprise-server@3.8/apps/maintaining-github-apps/installing-github-apps
-		newInstallationUrl = `${gitHubAppConfig.hostname as string}/github-apps/${data.html_url.split("/github-apps/")[1]}/installations/new`;
+		newInstallationUrl = `${gitHubAppConfig.hostname as string}/github-apps/${data.html_url.split("/github-apps/")[1]}/installations/new?state=non-spa`;
 	} else {
-		newInstallationUrl = `${data.html_url}/installations/new`;
+		newInstallationUrl = `${data.html_url}/installations/new?state=non-spa`;
 	}
 	res.redirect(newInstallationUrl);
 

--- a/src/routes/github/github-5ku-router.test.ts
+++ b/src/routes/github/github-5ku-router.test.ts
@@ -24,9 +24,15 @@ describe("Github Setup 5ku redirector", () => {
 				.expect("location", "/rest/app/cloud/github-requested?setup_action=request");
 		});
 
-		it("should continue to next route if no spa exp set", async () => {
-			await supertest(frontendApp).get("/github/setup?setup_action=request")
-				.expect(401); // coz it goes to next route, which expect an jira jwt token in session cookie
+		it("should continue to next route if no spa cloud is set", async () => {
+			await supertest(frontendApp).get("/github/setup?setup_action=request&state=non-spa")
+				.expect(401); // coz it goes to next route, which expect a Jira jwt token
+		});
+
+		it("should redirect to marketplace when there is no state", async () => {
+			const response = await supertest(frontendApp).get("/github/setup?installation_id=12345");
+			expect(response.status).toStrictEqual(302);
+			expect(response.header.location).toEqual("https://marketplace.atlassian.com/apps/1219592/github-for-jira?tab=overview");
 		});
 
 	});

--- a/src/routes/github/github-5ku-router.ts
+++ b/src/routes/github/github-5ku-router.ts
@@ -2,19 +2,36 @@ import { Request, Response, NextFunction } from "express";
 import sanitize from "sanitize-html";
 
 export const GitHub5KURedirectHandler = (req: Request, res: Response, next: NextFunction) => {
-	if (req.query["state"] === "spa") {
-		const sanitizedGitHubInstallationId: string = sanitize(String(req.query.installation_id || ""));
-		const sanitizedSetupAction: string = sanitize(String(req.query.setup_action || ""));
-		if (sanitizedGitHubInstallationId) {
-			res.redirect(`/rest/app/cloud/github-installed?installation_id=${sanitizedGitHubInstallationId}`);
-		} else if (sanitizedSetupAction) {
-			res.redirect(`/rest/app/cloud/github-requested?setup_action=${sanitizedSetupAction}`);
-		} else {
-			res.status(422).send("Missing informations");
+	/**
+	 * If the user is installing from Jira's side, then there always will be a state
+	 * For spa views, it should be `spa-cloud`, no `spa-enterprise` yet
+	 * And for the existing views, it should be `non-spa-cloud` for cloud flow,
+	 * and it should be `non-spa-enterprise` for enterprise flow
+	 *
+	 * If there is no state, that means the user is installing from GitHub side
+	 */
+	const state = req.query["state"];
+
+	switch (state) {
+		case "spa": {
+			const sanitizedGitHubInstallationId: string = sanitize(String(req.query.installation_id || ""));
+			const sanitizedSetupAction: string = sanitize(String(req.query.setup_action || ""));
+			if (sanitizedGitHubInstallationId) {
+				res.redirect(`/rest/app/cloud/github-installed?installation_id=${sanitizedGitHubInstallationId}`);
+			} else if (sanitizedSetupAction) {
+				res.redirect(`/rest/app/cloud/github-requested?setup_action=${sanitizedSetupAction}`);
+			} else {
+				res.status(422).send("Missing information");
+			}
+			return;
 		}
-		return;
-	} else {
-		next();
+		case "non-spa":
+			next();
+			break;
+		default:
+			// Redirecting the user to marketplace page, when installing from GitHub side
+			res.redirect(`https://marketplace.atlassian.com/apps/1219592/github-for-jira?tab=overview`);
+			return;
 	}
 };
 

--- a/src/routes/github/setup/github-setup-router.test.ts
+++ b/src/routes/github/setup/github-setup-router.test.ts
@@ -35,7 +35,7 @@ describe("Github Setup", () => {
 		it("should return error when missing 'installation_id' from query", async () => {
 			githubAppTokenNock();
 			await supertest(frontendApp)
-				.get("/github/setup")
+				.get("/github/setup?state=non-spa")
 				.set(
 					"Cookie",
 					generateSignedSessionCookieHeader({
@@ -51,7 +51,7 @@ describe("Github Setup", () => {
 				.get(`/app/installations/${installation_id}`)
 				.reply(404);
 			await supertest(frontendApp)
-				.get("/github/setup")
+				.get("/github/setup?state=non-spa")
 				.set(
 					"Cookie",
 					generateSignedSessionCookieHeader({
@@ -68,7 +68,7 @@ describe("Github Setup", () => {
 				.get(`/app/installations/${installation_id}`)
 				.reply(200, singleInstallation);
 			await supertest(frontendApp)
-				.get("/github/setup")
+				.get("/github/setup?state=non-spa")
 				.set(
 					"Cookie",
 					generateSignedSessionCookieHeader({
@@ -85,7 +85,7 @@ describe("Github Setup", () => {
 				.get(`/app/installations/${installation_id}`)
 				.reply(200, singleInstallation);
 			await supertest(frontendApp)
-				.get("/github/setup")
+				.get("/github/setup?state=non-spa")
 				.query({ installation_id })
 				.set(
 					"Cookie",

--- a/static/js/github-setup.js
+++ b/static/js/github-setup.js
@@ -17,7 +17,7 @@ if (cancelNewJiraSiteBtn) {
 const hasProtocol = (str) =>
 	str.includes("http://") || str.includes("https://") || str.includes("www.");
 
-const githubSetupPost = (data, url = "/github/setup") =>
+const githubSetupPost = (data, url = "/github/setup?state=non-spa") =>
 	// TODO do something here to show user that form is being submitted
 	$.post(url, data)
 		.done(function(body) {

--- a/views/partials/github-setup-form.hbs
+++ b/views/partials/github-setup-form.hbs
@@ -2,7 +2,7 @@
   <form
     class="githubSetup__form aui top-label"
     method="post"
-    action="/github/setup">
+    action="/github/setup?state=non-spa">
     <input type="hidden" name="_csrf" value="{{csrfToken}}" />
     <div class="field-group githubSetup__form__fieldGroup">
       <label for="{{id}}">Jira Cloud site</label>


### PR DESCRIPTION
**What's in this PR?**
- Added query parameter `state` for installation routes coming from our side.
- Updated test cases.

**Why**
- So that the users do not see any error screen when installing the app from Github side.

**Video**  

https://github.com/atlassian/github-for-jira/assets/13076255/fe835926-34fa-4738-a9a1-fe587c9129ff


**How has this been tested?**  
- Locally
- Test cases
