### PR TITLE
None trigger action for dummy deployment

### DIFF
--- a/.github/workflows/dummy-deployment.yml
+++ b/.github/workflows/dummy-deployment.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    needs: build
     environment:
       name: ${{ inputs.env }}
     steps:

--- a/.github/workflows/dummy-deployment.yml
+++ b/.github/workflows/dummy-deployment.yml
@@ -1,6 +1,6 @@
+name: "Dummy deployment"
 on:
   workflow_dispatch:
-
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/dummy-deployment.yml
+++ b/.github/workflows/dummy-deployment.yml
@@ -2,13 +2,13 @@ name: "Dummy deployment"
 on:
   workflow_dispatch:
     inputs:
-			env:
-				description: 'The env the dummy deploy points to'
-				type: choice
-				options:
-				- ddev
-				- stg-west
-				- prod
+    env:
+      description: 'The env the dummy deploy points to'
+      type: choice
+      options:
+        - ddev
+        - stg-west
+        - prod
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -19,7 +19,7 @@ jobs:
     - name: 'Deploy'
       id: deploy-dummy
       run: |
-				echo "Deploy to $TARGET_ENV success"
+        echo "Deploy to $TARGET_ENV success"
       env:
-				TARGET_ENV: ${{ inputs.env }}
+        TARGET_ENV: ${{ inputs.env }}
 

--- a/.github/workflows/dummy-deployment.yml
+++ b/.github/workflows/dummy-deployment.yml
@@ -2,13 +2,13 @@ name: "Dummy deployment"
 on:
   workflow_dispatch:
     inputs:
-    env:
-      description: 'The env the dummy deploy points to'
-      type: choice
-      options:
-        - ddev
-        - stg-west
-        - prod
+      env:
+        description: 'The env the dummy deploy points to'
+        type: choice
+        options:
+          - ddev
+          - stg-west
+          - prod
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/dummy-deployment.yml
+++ b/.github/workflows/dummy-deployment.yml
@@ -1,0 +1,14 @@
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: 'ddev'
+    steps:
+    - name: 'Deploy'
+      id: deploy-to-webapp
+      run: echo "Deploy to ddev success"
+

--- a/.github/workflows/dummy-deployment.yml
+++ b/.github/workflows/dummy-deployment.yml
@@ -1,14 +1,25 @@
 name: "Dummy deployment"
 on:
   workflow_dispatch:
+    inputs:
+			env:
+				description: 'The env the dummy deploy points to'
+				type: choice
+				options:
+				- ddev
+				- stg-west
+				- prod
 jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
     environment:
-      name: 'ddev'
+      name: ${{ inputs.env }}
     steps:
     - name: 'Deploy'
-      id: deploy-to-webapp
-      run: echo "Deploy to ddev success"
+      id: deploy-dummy
+      run: |
+				echo "Deploy to $TARGET_ENV success"
+      env:
+				TARGET_ENV: ${{ inputs.env }}
 

--- a/.github/workflows/dummy-deployment.yml
+++ b/.github/workflows/dummy-deployment.yml
@@ -6,9 +6,9 @@ on:
         description: 'The env the dummy deploy points to'
         type: choice
         options:
-          - ddev
-          - stg-west
-          - prod
+          - development
+          - staging
+          - production
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What's in this PR?**
Add a dummy deployment hook for github action

**Why**
1. So that during BB micros deploy, BB can do `POST https://api.github.com/repos/atlassian/github-for-jira/actions/workflows/75366764/dispatches` with a branch name and env name to trigger this action
2. And then the action will send deployment data via webhook to gh4j
3. Our gh4j will send info to DD in our jira site
4. All deployments will be linked to the correct jira issue
5. Should works for deployment on all branch, but not on sha_commits. (Sha commits is not supported in github rest api for trigger action)

**Added feature flags**
N/A

**Affected issues**  
ARC-2592

**How has this been tested?**  
Postman
![image](https://github.com/atlassian/github-for-jira/assets/105693507/d37de999-5239-45f3-82dc-277747865ede)

![image](https://github.com/atlassian/github-for-jira/assets/105693507/290e05e5-856b-4abb-9b71-b324eaaae0fd)


**Whats Next?**
Update BB pipelines to trigger a curl post to above endpoints.