### PR TITLE
NONE try to relax to allow multiple tabs to auth

### DIFF
--- a/spa/src/services/oauth-manager/index.ts
+++ b/spa/src/services/oauth-manager/index.ts
@@ -5,7 +5,7 @@ import { popup, reportError } from "../../utils";
 let username: string | undefined;
 let email: string | undefined;
 
-let oauthState: string | undefined;
+let oauthStates: string[] = [];
 
 async function checkValidity(): Promise<boolean | AxiosError> {
 	if (!Api.token.hasGitHubToken()) return false;
@@ -42,7 +42,7 @@ async function authenticateInGitHub({
 }): Promise<void> {
 	const res = await Api.auth.generateOAuthUrl();
 	if (res.data.redirectUrl && res.data.state) {
-		oauthState = res.data.state;
+		oauthStates.push(res.data.state);
 		const win = popup(res.data.redirectUrl);
 		if (win === null) {
 			onPopupBlocked();
@@ -73,7 +73,6 @@ async function authenticateInGitHub({
 }
 
 async function finishOAuthFlow(code: string, state: string): Promise<boolean | AxiosError> {
-
 	if (!code && !state) {
 		reportError({
 			message: "code or state missing"
@@ -85,18 +84,17 @@ async function finishOAuthFlow(code: string, state: string): Promise<boolean | A
 		return false;
 	}
 
-	const prevState = oauthState;
-	oauthState = undefined;
-
-	if (state !== prevState) {
+	if (!oauthStates.includes(state)) {
 		reportError({
 			message: "state not match"
 		}, {
 			path: "finishOAuthFlow",
-			isPrevStateEmpty: !prevState,
+			oauthStateLength: oauthStates.length,
 			isStateEmpty: !state
 		});
 		return false;
+	} else {
+		oauthStates.splice(oauthStates.indexOf(state), 1);
 	}
 
 	try {
@@ -127,6 +125,10 @@ function clear() {
 	email = undefined;
 }
 
+export function __test_only_clearOAuthStates() {
+	oauthStates = [];
+}
+
 export default {
 	checkValidity,
 	authenticateInGitHub,
@@ -134,4 +136,5 @@ export default {
 	getUserDetails,
 	clear
 };
+
 

--- a/spa/src/services/oauth-manager/test.ts
+++ b/spa/src/services/oauth-manager/test.ts
@@ -40,13 +40,11 @@ describe("AuthManager", () => {
 
 		it("should prevent CSRF attack by providing invalid state", async () => {
 
-			mockExchangeTokenOnce("code123", "some-state", "token123");
-
 			//just try to exchange token without a previous set state
 			const result = await AuthManager.finishOAuthFlow("code123", "some-state");
 
 			expect(result).toBe(false);
-			expect(Api.token.setGitHubToken).not.toHaveBeenCalled();
+			expect(Api.auth.exchangeToken).not.toHaveBeenCalled();
 
 		});
 

--- a/spa/src/services/oauth-manager/test.ts
+++ b/spa/src/services/oauth-manager/test.ts
@@ -1,0 +1,85 @@
+import { when } from "jest-when";
+import AuthManager, { __test_only_clearOAuthStates } from "./index";
+import Api from "../../api";
+import { popup } from "../../utils";
+
+jest.mock("../../api");
+jest.mock("../../utils");
+
+describe("AuthManager", () => {
+	describe("oauth", () => {
+
+		beforeEach(() => {
+			__test_only_clearOAuthStates();
+		});
+
+		const REDIRECT_URL = "https://some-redirect-url";
+		const mockRedirectUrlOnce = (state: string) => {
+			when(Api.auth.generateOAuthUrl)
+				.calledWith()
+				.mockResolvedValueOnce({ data: { redirectUrl: REDIRECT_URL, state: state } } as any);
+		}
+
+		const mockExchangeTokenOnce= (code: string, state: string, accessToken: string) => {
+			when(Api.auth.exchangeToken)
+				.calledWith(code, state)
+				.mockResolvedValueOnce({ data: { accessToken } } as any);
+		};
+
+		const onWinCloseAndBlock = { onWinClosed: () => {}, onPopupBlocked: () => {} };
+
+		it("should redirect to oauth url correctly", async () => {
+
+			mockRedirectUrlOnce("some-state");
+
+			await AuthManager.authenticateInGitHub(onWinCloseAndBlock);
+
+			expect(popup).toHaveBeenCalledWith(REDIRECT_URL);
+
+		});
+
+		it("should prevent CSRF attack by providing invalid state", async () => {
+
+			mockExchangeTokenOnce("code123", "some-state", "token123");
+
+			//just try to exchange token without a previous set state
+			const result = await AuthManager.finishOAuthFlow("code123", "some-state");
+
+			expect(result).toBe(false);
+			expect(Api.token.setGitHubToken).not.toHaveBeenCalled();
+
+		});
+
+		it("should exchange oauth token successfully", async () => {
+
+			mockRedirectUrlOnce("some-state");
+			mockExchangeTokenOnce("code123", "some-state", "token123");
+
+			await AuthManager.authenticateInGitHub(onWinCloseAndBlock);
+
+			const result = await AuthManager.finishOAuthFlow("code123", "some-state");
+			expect(result).toBe(true);
+			expect(Api.token.setGitHubToken).toHaveBeenCalledWith("token123");
+
+		});
+
+		it("should exchange oauth token successfully -- with multi tabs/states", async () => {
+
+			mockRedirectUrlOnce("some-state-1");
+			mockRedirectUrlOnce("some-state-2");
+
+			mockExchangeTokenOnce("code123", "some-state-1", "token123");
+
+			await AuthManager.authenticateInGitHub(onWinCloseAndBlock);
+			//Open the auth second time to override the first time state
+			await AuthManager.authenticateInGitHub(onWinCloseAndBlock);
+
+			//But do the oauth with state from first open tab
+			const result = await AuthManager.finishOAuthFlow("code123", "some-state-1");
+			expect(result).toBe(true);
+			expect(Api.token.setGitHubToken).toHaveBeenCalledWith("token123");
+
+		});
+
+	});
+});


### PR DESCRIPTION
**What's in this PR?**
1. Use arrays to store the oauth state to allow multiple table for oauth dance.

**Why**
1. We receive some [errors](https://atlassian-2y.sentry.io/issues/4459820321/?project=4505604384292864&query=&referrer=issue-stream&sort=date&statsPeriod=24h&stream_index=0) regarding the the state is not matching. I couldn't figure out why, but suspect it is because user open multi tab for auth (like press the auth button multi times). Because currently we only store the state of last time, hence user may receive error on first tab. 

**Added feature flags**
N/A

**Affected issues**  
N/A

**How has this been tested?**  
Unit test.

**Whats Next?**
Monitor errors.
