### PR TITLE
Arc 2643 allow extra polli test

### DIFF
--- a/etc/poco/bundle/extras-stg-test.json
+++ b/etc/poco/bundle/extras-stg-test.json
@@ -1,6 +1,26 @@
 {
 	"tests": [
 		{
+			"name": "Allow Stg Basic Check (Critical) Pollinator Test to call Delete Installation endpoints",
+			"path": "/api/deleteInstallation/21266506/https%3A%2F%2Ffusion-arc-pollinator-staging-app.atlassian.net",
+			"method": "DELETE",
+			"mechanism": "asap",
+			"principals": [
+				"pollinator-check/44d4ce64-f598-4282-8cbb-189eff9b94bf"
+			],
+			"allowed": true
+		},
+		{
+			"name": "Allow Stg Basic Check (GHE) (Critical) Pollinator Test to call other admin endpoints",
+			"path": "/api/deleteInstallation/21266506/https%3A%2F%2Ffusion-arc-pollinator-staging-app.atlassian.net",
+			"method": "DELETE",
+			"mechanism": "asap",
+			"principals": [
+				"pollinator-check/06673b3a-7d8f-4f6e-8b72-0527695e241b"
+			],
+			"allowed": true
+		},
+		{
 			"name": "Allow pollinator test to call Delete Installation endpoints",
 			"path": "/api/deleteInstallation/21266506/https%3A%2F%2Ffusion-arc-pollinator-staging-app.atlassian.net",
 			"method": "DELETE",
@@ -57,6 +77,26 @@
 			"mechanism": "asap",
 			"principals": [
 				"pollinator-check/fea5d423-e21f-465b-aa67-54c8367b7777"
+			],
+			"allowed": false
+		},
+		{
+			"name": "Not allow Stg Basic Check (Critical) Pollinator Test to call other admin endpoints",
+			"path": "/api/jira/13453453/verify",
+			"method": "DELETE",
+			"mechanism": "asap",
+			"principals": [
+				"pollinator-check/44d4ce64-f598-4282-8cbb-189eff9b94bf"
+			],
+			"allowed": false
+		},
+		{
+			"name": "Not allow Stg Basic Check (GHE) (Critical) Pollinator Test to call other admin endpoints",
+			"path": "/api/jira/13453453/verify",
+			"method": "DELETE",
+			"mechanism": "asap",
+			"principals": [
+				"pollinator-check/06673b3a-7d8f-4f6e-8b72-0527695e241b"
 			],
 			"allowed": false
 		},

--- a/etc/poco/bundle/extras-stg-test.json
+++ b/etc/poco/bundle/extras-stg-test.json
@@ -1,6 +1,26 @@
 {
 	"tests": [
 		{
+			"name": "Allow Stg Basic Check (Critical) Pollinator Test to call Get Audit Log endpoints",
+			"path": "/api/audit-log/subscription/12345",
+			"method": "GET",
+			"mechanism": "asap",
+			"principals": [
+				"pollinator-check/44d4ce64-f598-4282-8cbb-189eff9b94bf"
+			],
+			"allowed": true
+		},
+		{
+			"name": "Allow Stg Basic Check (GHE) (Critical) Pollinator Test to call Get Audit Log endpoints",
+			"path": "/api/audit-log/subscription/12345",
+			"method": "GET",
+			"mechanism": "asap",
+			"principals": [
+				"pollinator-check/06673b3a-7d8f-4f6e-8b72-0527695e241b"
+			],
+			"allowed": true
+		},
+		{
 			"name": "Allow Stg Basic Check (Critical) Pollinator Test to call Delete Installation endpoints",
 			"path": "/api/deleteInstallation/21266506/https%3A%2F%2Ffusion-arc-pollinator-staging-app.atlassian.net",
 			"method": "DELETE",
@@ -11,7 +31,7 @@
 			"allowed": true
 		},
 		{
-			"name": "Allow Stg Basic Check (GHE) (Critical) Pollinator Test to call other admin endpoints",
+			"name": "Allow Stg Basic Check (GHE) (Critical) Pollinator Test to call Delete Installation endpoints",
 			"path": "/api/deleteInstallation/21266506/https%3A%2F%2Ffusion-arc-pollinator-staging-app.atlassian.net",
 			"method": "DELETE",
 			"mechanism": "asap",

--- a/etc/poco/bundle/extras-stg.json
+++ b/etc/poco/bundle/extras-stg.json
@@ -1,7 +1,7 @@
 {
 	"allow": [
 		{
-			"description": "Allow stage pollinator checks to call endpoints for testing",
+			"description": "Allow stage pollinator checks to call delete installation endpoints for testing",
 			"paths": [
 				"/api/deleteInstallation/**"
 			],
@@ -22,7 +22,7 @@
 			}
 		},
 		{
-			"description": "Allow stage pollinator checks to call endpoints for testing",
+			"description": "Allow stage pollinator checks to call view audit log endpoints for testing",
 			"paths": [
 				"/api/audit-log/**"
 			],

--- a/etc/poco/bundle/extras-stg.json
+++ b/etc/poco/bundle/extras-stg.json
@@ -1,12 +1,33 @@
 {
 	"allow": [
 		{
-			"description": "Allow prod pollinator checks to call endpoints for testing",
+			"description": "Allow stage pollinator checks to call endpoints for testing",
 			"paths": [
 				"/api/deleteInstallation/**"
 			],
 			"methods": [
 				"DELETE"
+			],
+			"principals": {
+				"asap": {
+					"issuers": [
+						"pollinator-check/44d4ce64-f598-4282-8cbb-189eff9b94bf",
+						"pollinator-check/06673b3a-7d8f-4f6e-8b72-0527695e241b",
+						"pollinator-check/f69a7641-a541-4996-adef-0a3516da26d2",
+						"pollinator-check/fea5d423-e21f-465b-aa67-54c8367b7777",
+						"pollinator-check/47fcf993-7364-49c4-8e71-25b79e046428",
+						"pollinator-check/72b41d2e-7612-4ad2-afa1-6affe7e527b9"
+					]
+				}
+			}
+		},
+		{
+			"description": "Allow stage pollinator checks to call endpoints for testing",
+			"paths": [
+				"/api/audit-log/**"
+			],
+			"methods": [
+				"GET"
 			],
 			"principals": {
 				"asap": {

--- a/etc/poco/bundle/extras-stg.json
+++ b/etc/poco/bundle/extras-stg.json
@@ -11,6 +11,8 @@
 			"principals": {
 				"asap": {
 					"issuers": [
+						"pollinator-check/44d4ce64-f598-4282-8cbb-189eff9b94bf",
+						"pollinator-check/06673b3a-7d8f-4f6e-8b72-0527695e241b",
 						"pollinator-check/f69a7641-a541-4996-adef-0a3516da26d2",
 						"pollinator-check/fea5d423-e21f-465b-aa67-54c8367b7777",
 						"pollinator-check/47fcf993-7364-49c4-8e71-25b79e046428",


### PR DESCRIPTION
**What's in this PR?**
Add poco to allow polli test to call api for audit log.

![image](https://github.com/atlassian/github-for-jira/assets/105693507/dee59e53-a8ef-4ab4-b219-244e1df757cb)


**Why**
To allow polli test

**Added feature flags**
N/A

**Affected issues**  
[ARC-2643]

**How has this been tested?**  
Unit test.

**Whats Next?**
N/A


[ARC-2643]: https://softwareteams.atlassian.net/browse/ARC-2643