### PR TITLE
Adding endpoint in POCO for polli tests

### DIFF
--- a/etc/poco/bundle/extras-prod-test.json
+++ b/etc/poco/bundle/extras-prod-test.json
@@ -79,6 +79,36 @@
 				"pollinator-check/b33f33a7-c308-468e-a2a2-06c1f2443bfb"
 			],
 			"allowed": false
+		},
+		{
+			"name": "Allow Pollinator Pollinator test to call API configuration POST endpoint",
+			"path": "/api/configuration",
+			"method": "POST",
+			"mechanism": "asap",
+			"principals": [
+				"pollinator-check/98a88b09-1541-4c0d-aded-4f1cc467d1fd"
+			],
+			"allowed": true
+		},
+		{
+			"name": "Not allow Pollinator Pollinator test to call API configuration POST endpoint for any other principals",
+			"path": "/api/configuration",
+			"method": "POST",
+			"mechanism": "asap",
+			"principals": [
+				"pollinator-check/random-one"
+			],
+			"allowed": false
+		},
+		{
+			"name": "Not allow Pollinator Pollinator test to call any API configuration endpoint except POST",
+			"path": "/api/configuration",
+			"method": "GET",
+			"mechanism": "asap",
+			"principals": [
+				"pollinator-check/random-one"
+			],
+			"allowed": false
 		}
-  ]
+	]
 }

--- a/etc/poco/bundle/extras-prod.json
+++ b/etc/poco/bundle/extras-prod.json
@@ -1,7 +1,7 @@
 {
   "allow": [
     {
-      "description": "Allow prod pollinator checks to call endpoints for testing",
+      "description": "Allow prod pollinator checks to call delete installation endpoints for testing",
       "paths": [
         "/api/deleteInstallation/**"
       ],
@@ -18,6 +18,22 @@
 					]
         }
       }
-    }
+    },
+		{
+			"description": "Allow prod pollinator checks to call post configuration endpoints for testing",
+			"paths": [
+				"/api/configuration"
+			],
+			"methods": [
+				"POST"
+			],
+			"principals": {
+				"asap": {
+					"issuers": [
+						"pollinator-check/98a88b09-1541-4c0d-aded-4f1cc467d1fd"
+					]
+				}
+			}
+		}
   ]
 }


### PR DESCRIPTION
**What's in this PR?**
- Adding the endpoint `api/configuration` in POCO for polli tests.

**Why**
- For pollinator tests.

**How has this been tested?**  
- By running lint and testing through `atlas poco ...`

**Whats Next?**
- Merge and test in pollinator