### PR TITLE
ARC-2643 prepend entityId with repofull name for uniqueness

### DIFF
--- a/src/jira/client/jira-client-audit-log-helper.test.ts
+++ b/src/jira/client/jira-client-audit-log-helper.test.ts
@@ -139,7 +139,7 @@ describe("processAuditLogsForDevInfoBulkUpdate", () => {
 			auditInfo:[{
 				"createdAt": expect.anything(),
 				"entityAction": "COMMIT_PUSH",
-				"entityId": "e3fe8bf05f50f87c18611298e312217c4895747b",
+				"entityId": "KamaksheeSamant/react-cods-hub_e3fe8bf05f50f87c18611298e312217c4895747b",
 				"entityType": "commits",
 				"issueKey": "KAM-1",
 				"source": "WEBHOOK",
@@ -195,7 +195,7 @@ describe("processAuditLogsForDevInfoBulkUpdate", () => {
 			auditInfo:[{
 				"createdAt": expect.anything(),
 				"entityAction": "COMMIT_PUSH",
-				"entityId": "e3fe8bf05f50f87c18611298e312217c4895747b",
+				"entityId": "KamaksheeSamant/react-cods-hub_e3fe8bf05f50f87c18611298e312217c4895747b",
 				"entityType": "commits",
 				"issueKey": "KAM-1",
 				"source": "WEBHOOK",
@@ -204,7 +204,7 @@ describe("processAuditLogsForDevInfoBulkUpdate", () => {
 			{
 				"createdAt": expect.anything(),
 				"entityAction": "COMMIT_PUSH",
-				"entityId": "e3fe8bf05f50f87c18611298e312217c4895747b",
+				"entityId": "KamaksheeSamant/react-cods-hub_e3fe8bf05f50f87c18611298e312217c4895747b",
 				"entityType": "commits",
 				"issueKey": "KAM-2",
 				"source": "WEBHOOK",
@@ -260,7 +260,7 @@ describe("processAuditLogsForDevInfoBulkUpdate", () => {
 			auditInfo:[{
 				"createdAt": expect.anything(),
 				"entityAction": "COMMIT_PUSH",
-				"entityId": "e3fe8bf05f50f87c18611298e312217c4895747b",
+				"entityId": "KamaksheeSamant/react-cods-hub_e3fe8bf05f50f87c18611298e312217c4895747b",
 				"entityType": "commits",
 				"issueKey": "KAM-1",
 				"source": "WEBHOOK",
@@ -314,7 +314,7 @@ describe("processAuditLogsForDevInfoBulkUpdate", () => {
 			auditInfo:[{
 				"createdAt": expect.anything(),
 				"entityAction": "COMMIT_PUSH",
-				"entityId": "KAM-1-and-KAM-2",
+				"entityId": "KamaksheeSamant/react-cods-hub_KAM-1-and-KAM-2",
 				"entityType": "branches",
 				"issueKey": "KAM-1",
 				"source": "WEBHOOK",
@@ -323,7 +323,7 @@ describe("processAuditLogsForDevInfoBulkUpdate", () => {
 			{
 				"createdAt": expect.anything(),
 				"entityAction": "COMMIT_PUSH",
-				"entityId": "KAM-1-and-KAM-2",
+				"entityId": "KamaksheeSamant/react-cods-hub_KAM-1-and-KAM-2",
 				"entityType": "branches",
 				"issueKey": "KAM-2",
 				"source": "WEBHOOK",
@@ -399,7 +399,7 @@ describe("processAuditLogsForDevInfoBulkUpdate", () => {
 			auditInfo:[{
 				"createdAt": expect.anything(),
 				"entityAction": "PR_OPENED",
-				"entityId": "KAM-5-feat",
+				"entityId": "kamaOrgOne/repo_react_KAM-5-feat",
 				"entityType": "branches",
 				"issueKey": "KAM-5",
 				"source": "WEBHOOK",
@@ -408,7 +408,7 @@ describe("processAuditLogsForDevInfoBulkUpdate", () => {
 			{
 				"createdAt": expect.anything(),
 				"entityAction": "PR_OPENED",
-				"entityId": "10",
+				"entityId": "kamaOrgOne/repo_react_10",
 				"entityType": "pullRequests",
 				"issueKey": "KAM-5",
 				"source": "WEBHOOK",

--- a/src/jira/client/jira-client-audit-log-helper.ts
+++ b/src/jira/client/jira-client-audit-log-helper.ts
@@ -3,6 +3,7 @@ import { isArray, isObject } from "lodash";
 
 const getAuditInfo = ({
 	acceptedGithubEntities,
+	repoFullName,
 	repoEntities,
 	githubEntityType,
 	options
@@ -15,7 +16,7 @@ const getAuditInfo = ({
 		issueKeys.map((issueKey) => {
 			const obj: AuditInfo = {
 				createdAt,
-				entityId: githubEntityId,
+				entityId: `${repoFullName}_${githubEntityId}`,
 				entityType: githubEntityType,
 				issueKey,
 				subscriptionId: options?.subscriptionId,
@@ -59,6 +60,7 @@ export const processBatchedBulkUpdateResp = ({
 				const commitAuditInfo = getAuditInfo({
 					acceptedGithubEntities: commits,
 					githubEntityType: "commits",
+					repoFullName: repoData.name,
 					repoEntities: repoData["commits"],
 					options
 				});
@@ -68,6 +70,7 @@ export const processBatchedBulkUpdateResp = ({
 				const branchAuditInfo = getAuditInfo({
 					acceptedGithubEntities: branches,
 					githubEntityType: "branches",
+					repoFullName: repoData.name,
 					repoEntities: repoData["branches"],
 					options
 				});
@@ -77,6 +80,7 @@ export const processBatchedBulkUpdateResp = ({
 				const PRAuditInfo = getAuditInfo({
 					acceptedGithubEntities: pullRequests,
 					githubEntityType: "pullRequests",
+					repoFullName: repoData.name,
 					repoEntities: repoData["pullRequests"],
 					options
 				});


### PR DESCRIPTION
**What's in this PR?**
prepend entityId with repofull name for uniqueness

**Why**
Coz one subscription can have multiple repo with same pr number or branch name

**Added feature flags**

**Affected issues**  
[ARC-2643]

**How has this been tested?**  
Unit test

**Whats Next?**


[ARC-2643]: https://softwareteams.atlassian.net/browse/ARC-2643