### PR TITLE
ARC-2643 use repo full name in workflow

### DIFF
--- a/src/github/workflow.test.ts
+++ b/src/github/workflow.test.ts
@@ -108,6 +108,7 @@ describe("Workflow Webhook", () => {
 		expect(lastMockedWorkflowSubmitFn).toBeCalledWith(
 			expect.anything(),
 			123,
+			"test-repo-owner/test-repo-name",
 			expect.objectContaining({
 				auditLogsource: "WEBHOOK",
 				entityAction: "WORKFLOW_RUN_REQUESTED",

--- a/src/github/workflow.ts
+++ b/src/github/workflow.ts
@@ -32,13 +32,18 @@ export const workflowWebhookHandler = async (context: WebhookContext, jiraClient
 
 	logger.info({ jiraHost: jiraClient.baseURL }, `Sending workflow event to Jira`);
 
-	const jiraResponse = await jiraClient.workflow.submit(jiraPayload, payload.repository.id, {
-		preventTransitions: false,
-		operationType: "NORMAL",
-		auditLogsource: "WEBHOOK",
-		entityAction: `WORKFLOW_RUN_${context.action}`.toUpperCase(),
-		subscriptionId: subscription.id
-	});
+	const jiraResponse = await jiraClient.workflow.submit(
+		jiraPayload,
+		payload.repository.id,
+		payload.repository.full_name,
+		{
+			preventTransitions: false,
+			operationType: "NORMAL",
+			auditLogsource: "WEBHOOK",
+			entityAction: `WORKFLOW_RUN_${context.action}`.toUpperCase(),
+			subscriptionId: subscription.id
+		}
+	);
 	const { webhookReceived, name, log } = context;
 
 	webhookReceived && emitWebhookProcessedMetrics(

--- a/src/jira/client/jira-client-audit-log-helper.test.ts
+++ b/src/jira/client/jira-client-audit-log-helper.test.ts
@@ -445,6 +445,7 @@ describe("processWorkflowSubmitResp", () => {
 
 		const result = processWorkflowSubmitResp({
 			reqBuildDataArray,
+			repoFullName: "org/repo1",
 			response,
 			options,
 			logger: mockLogger
@@ -478,6 +479,7 @@ describe("processWorkflowSubmitResp", () => {
 
 		const result = processWorkflowSubmitResp({
 			reqBuildDataArray,
+			repoFullName: "org/repo1",
 			response,
 			options,
 			logger: mockLogger
@@ -511,6 +513,7 @@ describe("processWorkflowSubmitResp", () => {
 
 		const result = processWorkflowSubmitResp({
 			reqBuildDataArray,
+			repoFullName: "org/repo1",
 			response,
 			options,
 			logger: mockLogger
@@ -520,8 +523,8 @@ describe("processWorkflowSubmitResp", () => {
 			isSuccess: true,
 			auditInfo:[{
 				"createdAt": expect.anything(),
-				"entityAction": "WORKFLOW_RUN",
-				"entityId": "6_77164279",
+				"entityAction": "SUCCESSFUL",
+				"entityId": "org/repo1_77164279_6",
 				"entityType": "builds",
 				"issueKey": "KAM-5",
 				"source": "WEBHOOK",
@@ -553,6 +556,7 @@ describe("processWorkflowSubmitResp", () => {
 
 		const result = processWorkflowSubmitResp({
 			reqBuildDataArray,
+			repoFullName: "org/repo1",
 			response,
 			options,
 			logger: mockLogger
@@ -562,8 +566,8 @@ describe("processWorkflowSubmitResp", () => {
 			isSuccess: true,
 			auditInfo:[{
 				"createdAt": expect.anything(),
-				"entityAction": "WORKFLOW_RUN",
-				"entityId": "6_77164279",
+				"entityAction": "SUCCESSFUL",
+				"entityId": "org/repo1_77164279_6",
 				"entityType": "builds",
 				"issueKey": "KAM-5",
 				"source": "WEBHOOK",
@@ -571,8 +575,8 @@ describe("processWorkflowSubmitResp", () => {
 			},
 			{
 				"createdAt": expect.anything(),
-				"entityAction": "WORKFLOW_RUN",
-				"entityId": "6_77164279",
+				"entityAction": "SUCCESSFUL",
+				"entityId": "org/repo1_77164279_6",
 				"entityType": "builds",
 				"issueKey": "KAM-6",
 				"source": "WEBHOOK",
@@ -614,6 +618,7 @@ describe("processWorkflowSubmitResp", () => {
 
 		const result = processWorkflowSubmitResp({
 			reqBuildDataArray,
+			repoFullName: "org/repo1",
 			response,
 			options,
 			logger: mockLogger
@@ -623,8 +628,8 @@ describe("processWorkflowSubmitResp", () => {
 			isSuccess: true,
 			auditInfo:[{
 				"createdAt": expect.anything(),
-				"entityAction": "WORKFLOW_RUN",
-				"entityId": "6_77164279",
+				"entityAction": "SUCCESSFUL",
+				"entityId": "org/repo1_77164279_6",
 				"entityType": "builds",
 				"issueKey": "KAM-5",
 				"source": "WEBHOOK",
@@ -632,8 +637,8 @@ describe("processWorkflowSubmitResp", () => {
 			},
 			{
 				"createdAt": expect.anything(),
-				"entityAction": "WORKFLOW_RUN",
-				"entityId": "7_77164280",
+				"entityAction": "SUCCESSFUL",
+				"entityId": "org/repo1_77164280_7",
 				"entityType": "builds",
 				"issueKey": "KAM-6",
 				"source": "WEBHOOK",

--- a/src/jira/client/jira-client-audit-log-helper.ts
+++ b/src/jira/client/jira-client-audit-log-helper.ts
@@ -105,11 +105,13 @@ export const processBatchedBulkUpdateResp = ({
 
 export const processWorkflowSubmitResp = ({
 	reqBuildDataArray,
+	repoFullName,
 	response,
 	options,
 	logger
 }: {
 	reqBuildDataArray: JiraBuild[],
+	repoFullName: string,
 	response: { status: number, data: any },
 	options: JiraSubmitOptions,
 	logger: Logger
@@ -136,12 +138,12 @@ export const processWorkflowSubmitResp = ({
 					issueKeys.map((issueKey) => {
 						const obj: AuditInfo = {
 							createdAt,
-							entityId: `${reqBuildNo}_${reqBuildPipelineId}`,
+							entityId: `${repoFullName}_${reqBuildPipelineId}_${reqBuildNo}`,
 							entityType: "builds",
 							issueKey,
 							subscriptionId: options.subscriptionId,
 							source: options.auditLogsource || "WEBHOOK",
-							entityAction: options.entityAction || "null"
+							entityAction: (reqBuildData.state || "").toUpperCase()
 						};
 						if (obj.subscriptionId && obj.entityId) {
 							auditInfo.push(obj);
@@ -181,8 +183,9 @@ export const processAuditLogsForDevInfoBulkUpdate = ({ reqRepoData, response, op
 };
 
 export const processAuditLogsForWorkflowSubmit = (
-	{ reqBuildDataArray, response, options, logger }: {
+	{ reqBuildDataArray, repoFullName, response, options, logger }: {
 		reqBuildDataArray: JiraBuild[],
+		repoFullName: string,
 		response: { status: number, data: any },
 		options: JiraSubmitOptions,
 		logger: Logger
@@ -196,6 +199,7 @@ export const processAuditLogsForWorkflowSubmit = (
 
 		const { isSuccess, auditInfo } = processWorkflowSubmitResp({
 			reqBuildDataArray,
+			repoFullName,
 			response,
 			options: options,
 			logger

--- a/src/jira/client/jira-client.ts
+++ b/src/jira/client/jira-client.ts
@@ -73,7 +73,7 @@ export interface JiraClient {
 		},
 	},
 	workflow: {
-		submit: (data: JiraBuildBulkSubmitData, repositoryId: number, options: JiraSubmitOptions) => Promise<any>;
+		submit: (data: JiraBuildBulkSubmitData, repositoryId: number, repoFullName: string, options: JiraSubmitOptions) => Promise<any>;
 	},
 	deployment: {
 		submit: (
@@ -383,7 +383,7 @@ export const getJiraClient = async (
 			}
 		},
 		workflow: {
-			submit: async (data: JiraBuildBulkSubmitData, repositoryId: number, options: JiraSubmitOptions) => {
+			submit: async (data: JiraBuildBulkSubmitData, repositoryId: number, repoFullName: string, options: JiraSubmitOptions) => {
 				updateIssueKeysFor(data.builds, uniq);
 				if (!withinIssueKeyLimit(data.builds)) {
 					logger.warn({
@@ -414,7 +414,7 @@ export const getJiraClient = async (
 				};
 				const reqBuildDataArray: JiraBuild[] = data?.builds || [];
 				if (await booleanFlag(BooleanFlags.USE_DYNAMODB_TO_PERSIST_AUDIT_LOG, jiraHost)) {
-					processAuditLogsForWorkflowSubmit({ reqBuildDataArray, response:responseData, options, logger });
+					processAuditLogsForWorkflowSubmit({ reqBuildDataArray, repoFullName, response:responseData, options, logger });
 				}
 				return response;
 			}

--- a/src/sync/build.test.ts
+++ b/src/sync/build.test.ts
@@ -122,11 +122,16 @@ describe("sync/builds", () => {
 		await expect(processInstallation(mockBackfillQueueSendMessage)(data, sentry, getLogger("test"))).toResolve();
 		expect(mockBackfillQueueSendMessage).toBeCalledWith(data, 0, expect.anything());
 
-		expect(lastMockedWorkflowSubmit).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.objectContaining({
-			auditLogsource: "BACKFILL",
-			entityAction: "WORKFLOW_RUN",
-			subscriptionId: db.subscription.id
-		}));
+		expect(lastMockedWorkflowSubmit).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.anything(),
+			"test-repo-name",
+			expect.objectContaining({
+				auditLogsource: "BACKFILL",
+				entityAction: "WORKFLOW_RUN",
+				subscriptionId: db.subscription.id
+			})
+		);
 	});
 
 	it("should not explode when returned payload doesn't have head_commit", async () => {

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -223,11 +223,11 @@ const markSyncAsCompleteAndStop = async (data: BackfillMessagePayload, subscript
 	logger.info({ startTime, endTime, timeDiff, gitHubProduct }, "Sync status is complete");
 };
 
-const sendPayloadToJira = async (task: TaskType, jiraClient, subscription: Subscription, jiraPayload, repositoryId, sentry: Hub, logger: Logger) => {
+const sendPayloadToJira = async (task: TaskType, jiraClient, subscription: Subscription, jiraPayload, repository: Task["repository"], sentry: Hub, logger: Logger) => {
 	try {
 		switch (task) {
 			case "build":
-				await jiraClient.workflow.submit(jiraPayload, repositoryId, {
+				await jiraClient.workflow.submit(jiraPayload, repository.id, repository.full_name, {
 					preventTransitions: true,
 					operationType: "BACKFILL",
 					auditLogsource: "BACKFILL",
@@ -236,7 +236,7 @@ const sendPayloadToJira = async (task: TaskType, jiraClient, subscription: Subsc
 				});
 				break;
 			case "deployment":
-				await jiraClient.deployment.submit(jiraPayload, repositoryId, {
+				await jiraClient.deployment.submit(jiraPayload, repository.id, {
 					preventTransitions: true,
 					operationType: "BACKFILL",
 					auditLogsource: "BACKFILL",
@@ -332,7 +332,7 @@ const doProcessInstallation = async (data: BackfillMessagePayload, sentry: Hub, 
 					data.gitHubAppConfig?.gitHubAppId,
 					logger
 				);
-				await sendPayloadToJira(task, jiraClient, subscription, taskPayload.jiraPayload, repository.id, sentry, logger);
+				await sendPayloadToJira(task, jiraClient, subscription, taskPayload.jiraPayload, repository, sentry, logger);
 			}
 
 			await updateTaskStatusAndContinue(


### PR DESCRIPTION
**What's in this PR?**
1. Add repofull name to audit log of workflow
2. Use state instead of entity action.

**Why**
Polli test needs them.

**Added feature flags**

**Affected issues**  
[arc-2643]

**How has this been tested?**  
unit test

**Whats Next?**
