### PR TITLE
Arc 2643 workflow log

### DIFF
--- a/src/github/workflow.test.ts
+++ b/src/github/workflow.test.ts
@@ -63,7 +63,7 @@ describe("Workflow Webhook", () => {
 				[
 					{
 						schemaVersion: "1.0",
-						pipelineId: 9751894,
+						pipelineId: "9751894",
 						buildNumber: 84,
 						updateSequenceNumber: 12345678,
 						displayName: "My Deployment flow",

--- a/src/interfaces/github.ts
+++ b/src/interfaces/github.ts
@@ -161,15 +161,11 @@ interface GitHubWorkflowRun {
 	// Can be null according to https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28 (see response schema)
 	head_commit: GitHubWorkflowRunHeadCommit | null;
 	repository: GitHubWorkflowRunRepository;
-}
-
-interface GitHubWorkflow {
-	id: string;
+	workflow_id: number;
 }
 
 export interface GitHubWorkflowPayload {
 	workflow_run: GitHubWorkflowRun;
-	workflow: GitHubWorkflow;
 }
 
 interface GitHubData {

--- a/src/jira/client/jira-client-audit-log-helper.ts
+++ b/src/jira/client/jira-client-audit-log-helper.ts
@@ -204,6 +204,15 @@ export const processAuditLogsForWorkflowSubmit = (
 			options: options,
 			logger
 		});
+
+		logger.info("workflow audit log processed result", {
+			repoFullName,
+			responseData: response?.data,
+			isSuccess,
+			auditInfo,
+			options
+		});
+
 		if (isSuccess) {
 			auditInfo?.map(async (auditInf) => {
 				await saveAuditLog(auditInf, logger);

--- a/src/jira/client/jira-client-audit-log-helper.ts
+++ b/src/jira/client/jira-client-audit-log-helper.ts
@@ -205,14 +205,6 @@ export const processAuditLogsForWorkflowSubmit = (
 			logger
 		});
 
-		logger.info("workflow audit log processed result", {
-			repoFullName,
-			responseData: response?.data,
-			isSuccess,
-			auditInfo,
-			options
-		});
-
 		if (isSuccess) {
 			auditInfo?.map(async (auditInf) => {
 				await saveAuditLog(auditInf, logger);

--- a/src/jira/client/jira-client.ts
+++ b/src/jira/client/jira-client.ts
@@ -407,6 +407,7 @@ export const getJiraClient = async (
 					operationType: options?.operationType || "NORMAL"
 				};
 
+				logger.info("Posting backfill workflow info for " , { repositoryId, repoFullName, data });
 				const response =  await instance.post("/rest/builds/0.1/bulk", payload);
 				const responseData = {
 					status: response.status,

--- a/src/sync/build.test.ts
+++ b/src/sync/build.test.ts
@@ -94,7 +94,7 @@ describe("sync/builds", () => {
 		createJiraNock([
 			{
 				"schemaVersion": "1.0",
-				"pipelineId": 2152266464,
+				"pipelineId": "19236895",
 				"buildNumber": 59,
 				"updateSequenceNumber": 12345678,
 				"displayName": "Build",
@@ -249,7 +249,7 @@ describe("sync/builds", () => {
 		createJiraNock([
 			{
 				"schemaVersion": "1.0",
-				"pipelineId": 2152266464,
+				"pipelineId": "19236895",
 				"buildNumber": 59,
 				"updateSequenceNumber": 12345678,
 				"displayName": "Build",
@@ -274,7 +274,7 @@ describe("sync/builds", () => {
 			},
 			{
 				"schemaVersion": "1.0",
-				"pipelineId": 2152266464,
+				"pipelineId": "19236895",
 				"buildNumber": 59,
 				"updateSequenceNumber": 12345678,
 				"displayName": "Build",

--- a/src/sync/build.ts
+++ b/src/sync/build.ts
@@ -14,8 +14,8 @@ type BuildWithCursor = { cursor: string } & Octokit.ActionsListRepoWorkflowRunsR
 
 // TODO: add types
 const getTransformedBuilds = async (workflowRun, gitHubInstallationClient, alwaysSend: boolean, logger) => {
-	const transformTasks = workflowRun.map(workflow => {
-		const workflowItem = { workflow_run: workflow, workflow: { id: workflow.id } } as GitHubWorkflowPayload;
+	const transformTasks = workflowRun.map(workflowRun => {
+		const workflowItem = { workflow_run: workflowRun } as GitHubWorkflowPayload;
 		return transformWorkflow(gitHubInstallationClient, workflowItem, alwaysSend, logger);
 	});
 

--- a/src/transforms/transform-workflow.ts
+++ b/src/transforms/transform-workflow.ts
@@ -62,12 +62,13 @@ export const transformWorkflow = async (
 			head_branch,
 			html_url,
 			name,
+			workflow_id,
 			pull_requests,
 			repository,
 			run_number,
 			status,
 			updated_at
-		}, workflow
+		}
 	} = payload;
 
 	const workflowHasPullRequest = !!pull_requests?.length;
@@ -95,7 +96,7 @@ export const transformWorkflow = async (
 		builds: [
 			{
 				schemaVersion: "1.0",
-				pipelineId: workflow.id,
+				pipelineId: String(workflow_id),
 				buildNumber: run_number,
 				updateSequenceNumber: Date.now(),
 				displayName: name,


### PR DESCRIPTION
**What's in this PR?**
Use workflow id instead of workflow_run.id as the pipelineId

**Why**
Because `workflow_id` is the pipeline id, `workflow_run.id` is just the id of each run, kind of equivelant of what we use as the "run_number" from the webhook payload.
And this is why both links link to same page
![image](https://github.com/atlassian/github-for-jira/assets/105693507/28ceee9c-413b-4408-9bdc-210d979cc17d)


**Added feature flags**

**Affected issues**  
[ARC-2643]

**How has this been tested?**  
unit and stg

**Whats Next?**


[ARC-2643]: https://softwareteams.atlassian.net/browse/ARC-2643