### PR TITLE
Arc 2713 use retry after header in jira client

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -24,7 +24,8 @@ export enum BooleanFlags {
 	ENABLE_5KU_BACKFILL_PAGE = "enable-5ku-experience-backfill-page",
 	USE_DYNAMODB_TO_PERSIST_AUDIT_LOG = "use-dynamodb-to-persist-audit-log",
 	USE_CUSTOM_ROOT_CA_BUNDLE = "use-custom-root-ca-bundle",
-	GENERATE_CORE_HEAP_DUMPS_ON_LOW_MEM = "generate-core-heap-dumps-on-low-mem"
+	GENERATE_CORE_HEAP_DUMPS_ON_LOW_MEM = "generate-core-heap-dumps-on-low-mem",
+	USE_RATELIMIT_ON_JIRA_CLIENT = "use-ratelimit-on-jira-client"
 }
 
 export enum StringFlags {

--- a/src/config/metric-names.ts
+++ b/src/config/metric-names.ts
@@ -16,6 +16,7 @@ export const sqsQueueMetrics = {
 	received: `${server}.sqs.queue.received`,
 	completed: `${server}.sqs.queue.success`,
 	failed: `${server}.sqs.queue.failed`,
+	exception: `${server}.sqs.queue.exception`,
 	sent: `${server}.sqs.queue.sent`,
 	deleted: `${server}.sqs.queue.deleted`,
 	duration: `${server}.sqs.queue.duration`

--- a/src/jira/client/axios.test.ts
+++ b/src/jira/client/axios.test.ts
@@ -120,4 +120,21 @@ describe("Jira axios instance", () => {
 		expect(error?.message).toEqual("Error executing Axios Request HTTP 404 - Bad REST path, or Jira instance not found, renamed or temporarily suspended.");
 	});
 
+	describe("when having a rate limited", () => {
+		it("should extract the retry after header if present", async () => {
+			const requestPayload = "TestRequestPayload";
+			jiraNock.post("/foo/bar", requestPayload)
+				.reply(429, "", {
+					"Retry-After": "100"
+				});
+
+			await expect(getAxiosInstance(jiraHost, "secret", getLogger("test")).post("/foo/bar", requestPayload))
+				.rejects.toMatchObject({
+					status: 429,
+					retryAfterInSeconds: 100
+				});
+
+		});
+	});
+
 });

--- a/src/jira/client/axios.ts
+++ b/src/jira/client/axios.ts
@@ -105,16 +105,19 @@ const getErrorMiddleware = (logger: Logger) =>
 
 		if (error.response?.status === 429) {
 			return Promise.reject(new JiraClientRateLimitingError(errorMessage, error, status, getRetryAfterInSec(error)));
-		} else {
-			return Promise.reject(new JiraClientError(errorMessage, error, status));
 		}
+
+		return Promise.reject(new JiraClientError(errorMessage, error, status));
 	};
 
 const getRetryAfterInSec = (error: AxiosError): number | undefined => {
-	const retryAfterInSecondsStr = error.response?.headers[	"retry-after"];
+
+	const retryAfterInSecondsStr = error.response?.headers["retry-after"];
 	const retryAfterInSeconds = parseInt(retryAfterInSecondsStr || "unknown");
+
 	if (isNaN(retryAfterInSeconds)) return undefined;
-	else return retryAfterInSeconds;
+
+	return retryAfterInSeconds;
 };
 
 /**

--- a/src/sqs/backfill-error-handler.test.ts
+++ b/src/sqs/backfill-error-handler.test.ts
@@ -125,7 +125,7 @@ describe("backfillErrorHandler", () => {
 			status: 403
 		};
 		const result = await backfillErrorHandler(jest.fn())(abuseDetectionError, createContext(2, false));
-		expect(result).toEqual({
+		expect(result).toMatchObject({
 			isFailure: true,
 			retryDelaySec: 540,
 			retryable: true
@@ -150,7 +150,7 @@ describe("backfillErrorHandler", () => {
 		}
 
 		const result = await backfillErrorHandler(jest.fn())(new TaskError(task, sequelizeConnectionError), createContext(2, false));
-		expect(result).toEqual({
+		expect(result).toMatchObject({
 			isFailure: true,
 			retryDelaySec: 540,
 			retryable: true
@@ -162,7 +162,7 @@ describe("backfillErrorHandler", () => {
 			new TaskError(task, (await create500FromGitHub())!),
 			createContext(2, false)
 		);
-		expect(result).toEqual({
+		expect(result).toMatchObject({
 			isFailure: true,
 			retryDelaySec: 540,
 			retryable: true
@@ -174,7 +174,7 @@ describe("backfillErrorHandler", () => {
 			new TaskError(task, (await create500FromJira())!),
 			createContext(2, false)
 		);
-		expect(result).toEqual({
+		expect(result).toMatchObject({
 			isFailure: true,
 			retryDelaySec: 540,
 			retryable: true
@@ -187,7 +187,7 @@ describe("backfillErrorHandler", () => {
 			createContext(5, true)
 		);
 
-		expect(result).toEqual({
+		expect(result).toMatchObject({
 			isFailure: false
 		});
 		const mockMessage = sendMessageMock.mock.calls[0] as any[];
@@ -204,7 +204,7 @@ describe("backfillErrorHandler", () => {
 			createContext(5, true)
 		);
 
-		expect(result).toEqual({
+		expect(result).toMatchObject({
 			isFailure: false
 		});
 		const mockMessage = sendMessageMock.mock.calls[0] as any[];
@@ -254,7 +254,7 @@ describe("backfillErrorHandler", () => {
 			createContext(3, false)
 		);
 
-		expect(result).toEqual({
+		expect(result).toMatchObject({
 			isFailure: false
 		});
 		const mockMessage = sendMessageMock.mock.calls[0] as any[];

--- a/src/sqs/backfill-error-handler.ts
+++ b/src/sqs/backfill-error-handler.ts
@@ -35,7 +35,7 @@ const handleTaskError = async (sendSQSBackfillMessage: (message, delaySec, logge
 			isFailure: false,
 			statusCode: cause.status,
 			source: "github",
-			errorName: cause.constructor?.name
+			errorName: cause.constructor.name
 		};
 	}
 
@@ -56,7 +56,7 @@ const handleTaskError = async (sendSQSBackfillMessage: (message, delaySec, logge
 			isFailure: false,
 			statusCode: cause.status,
 			source: "github",
-			errorName: cause.constructor?.name
+			errorName: cause.constructor.name
 		};
 	}
 
@@ -68,7 +68,7 @@ const handleTaskError = async (sendSQSBackfillMessage: (message, delaySec, logge
 			isFailure: false,
 			statusCode: cause.status,
 			source: "github",
-			errorName: cause.constructor?.name
+			errorName: cause.constructor.name
 		};
 	}
 
@@ -79,9 +79,9 @@ const handleTaskError = async (sendSQSBackfillMessage: (message, delaySec, logge
 		await markCurrentTaskAsFailedAndContinue(context.payload, task, false, sendSQSBackfillMessage, log, cause);
 		return {
 			isFailure: false,
-			statusCode: parseInt(cause["status"]),
+			statusCode: parseInt(String(cause["status"])),
 			source: "github",
-			errorName: cause.constructor?.name
+			errorName: cause.constructor.name
 		};
 	}
 

--- a/src/sqs/error-handlers.test.ts
+++ b/src/sqs/error-handlers.test.ts
@@ -1,11 +1,15 @@
 import { statsd }  from "config/statsd";
 import { jiraAndGitHubErrorsHandler, webhookMetricWrapper } from "./error-handlers";
 import { getLogger } from "config/logger";
-import { JiraClientError } from "../jira/client/axios";
+import { JiraClientError, JiraClientRateLimitingError } from "../jira/client/axios";
 import { Octokit } from "@octokit/rest";
 import { GithubClientRateLimitingError } from "../github/client/github-client-errors";
 import { AxiosError, AxiosResponse, AxiosResponseHeaders } from "axios";
 import { ErrorHandlingResult, SQSMessageContext, BaseMessagePayload } from "~/src/sqs/sqs.types";
+import { booleanFlag, BooleanFlags } from "config/feature-flags";
+import { when } from "jest-when";
+
+jest.mock("config/feature-flags");
 
 describe("error-handlers", () => {
 
@@ -68,7 +72,7 @@ describe("error-handlers", () => {
 				message: "",
 				name: "",
 				config: {}, isAxiosError: true, toJSON: () => ({})
-			}, code, undefined);
+			}, code);
 		};
 
 		it("Unretryable and not an error on Jira 401", async () => {
@@ -114,6 +118,46 @@ describe("error-handlers", () => {
 			expect(result.retryable).toBe(true);
 			//Make sure delay is equal to recommended delay + 50 seconds
 			expect(result.retryDelaySec).toBe(150);
+			expect(result.isFailure).toBe(true);
+		});
+
+		it("Retryable with proper delay on Rate Limiting - Jira Error when ff is on", async () => {
+
+			when(booleanFlag).calledWith(BooleanFlags.USE_RATELIMIT_ON_JIRA_CLIENT, expect.anything())
+				.mockResolvedValue(true);
+
+			const headers: AxiosResponseHeaders = { "retry-after": "1000" };
+			const mockedResponse = { status: 403, headers: headers } as AxiosResponse;
+
+			const result = await jiraAndGitHubErrorsHandler(
+				new JiraClientRateLimitingError("test rate limit error", {
+					response: mockedResponse
+				} as AxiosError, 429, 1000),
+				createContext(1, false)
+			);
+
+			expect(result.retryable).toBe(true);
+			expect(result.retryDelaySec).toBe(1000);
+			expect(result.isFailure).toBe(true);
+		});
+
+		it("Retryable with proper origin delay on Rate Limiting - Jira Error when ff is off", async () => {
+
+			when(booleanFlag).calledWith(BooleanFlags.USE_RATELIMIT_ON_JIRA_CLIENT, expect.anything())
+				.mockResolvedValue(false);
+
+			const headers: AxiosResponseHeaders = { "retry-after": "1000" };
+			const mockedResponse = { status: 403, headers: headers } as AxiosResponse;
+
+			const result = await jiraAndGitHubErrorsHandler(
+				new JiraClientRateLimitingError("test rate limit error", {
+					response: mockedResponse
+				} as AxiosError, 429, 1000),
+				createContext(1, false)
+			);
+
+			expect(result.retryable).toBe(true);
+			expect(result.retryDelaySec).toBe(180);
 			expect(result.isFailure).toBe(true);
 		});
 

--- a/src/sqs/error-handlers.test.ts
+++ b/src/sqs/error-handlers.test.ts
@@ -121,7 +121,7 @@ describe("error-handlers", () => {
 			expect(result.isFailure).toBe(true);
 		});
 
-		it("Retryable with proper delay on Rate Limiting - Jira Error when ff is on", async () => {
+		it("Retryable with proper delay on Rate Limiting - when ff is on", async () => {
 
 			when(booleanFlag).calledWith(BooleanFlags.USE_RATELIMIT_ON_JIRA_CLIENT, expect.anything())
 				.mockResolvedValue(true);
@@ -141,7 +141,27 @@ describe("error-handlers", () => {
 			expect(result.isFailure).toBe(true);
 		});
 
-		it("Retryable with proper origin delay on Rate Limiting - Jira Error when ff is off", async () => {
+		it("Retryable with origin delay on Rate Limiting but have undefined retry after header - when ff is on", async () => {
+
+			when(booleanFlag).calledWith(BooleanFlags.USE_RATELIMIT_ON_JIRA_CLIENT, expect.anything())
+				.mockResolvedValue(true);
+
+			const headers: AxiosResponseHeaders = { };
+			const mockedResponse = { status: 403, headers: headers } as AxiosResponse;
+
+			const result = await jiraAndGitHubErrorsHandler(
+				new JiraClientRateLimitingError("test rate limit error", {
+					response: mockedResponse
+				} as AxiosError, 429, undefined),
+				createContext(1, false)
+			);
+
+			expect(result.retryable).toBe(true);
+			expect(result.retryDelaySec).toBe(180);
+			expect(result.isFailure).toBe(true);
+		});
+
+		it("Retryable with origin delay on Rate Limiting - when ff is off", async () => {
 
 			when(booleanFlag).calledWith(BooleanFlags.USE_RATELIMIT_ON_JIRA_CLIENT, expect.anything())
 				.mockResolvedValue(false);

--- a/src/sqs/error-handlers.test.ts
+++ b/src/sqs/error-handlers.test.ts
@@ -68,7 +68,7 @@ describe("error-handlers", () => {
 				message: "",
 				name: "",
 				config: {}, isAxiosError: true, toJSON: () => ({})
-			}, code);
+			}, code, undefined);
 		};
 
 		it("Unretryable and not an error on Jira 401", async () => {

--- a/src/sqs/error-handlers.ts
+++ b/src/sqs/error-handlers.ts
@@ -101,7 +101,7 @@ const maybeHandleRateLimitingError = async <MessagePayload extends BaseMessagePa
 	}
 
 	if (await booleanFlag(BooleanFlags.USE_RATELIMIT_ON_JIRA_CLIENT, context.payload.jiraHost)) {
-		if (error instanceof JiraClientRateLimitingError) {
+		if (error instanceof JiraClientRateLimitingError && error.retryAfterInSeconds !== undefined) {
 			context.log.warn({ error, source: "jira", retryDelaySec: error.retryAfterInSeconds }, `Rate limiting error, retrying`);
 			return { retryable: true, retryDelaySec: error.retryAfterInSeconds, isFailure: true };
 		}

--- a/src/sqs/error-handlers.ts
+++ b/src/sqs/error-handlers.ts
@@ -30,9 +30,9 @@ export const handleUnknownError: ErrorHandler<BaseMessagePayload> = <MessagePayl
 		retryable: true,
 		retryDelaySec: delaySec,
 		isFailure: true,
-		statusCode: parseInt(err["status"]),
+		statusCode: parseInt(String(err["status"])),
 		source: err instanceof GithubClientError ? "github" : (err instanceof JiraClientError ? "jira" : "other"),
-		errorName: err.constructor?.name
+		errorName: err.constructor.name
 	});
 };
 
@@ -75,7 +75,7 @@ const maybeHandleNonFailureCase = <MessagePayload extends BaseMessagePayload>(er
 		error.status &&
 		UNRETRYABLE_STATUS_CODES.includes(error.status)) {
 		context.log.warn(`Received ${error.status} from Jira. Unretryable. Discarding the message`);
-		return { retryable: false, isFailure: false, statusCode: error.status, source: "jira", errorName: error.constructor?.name };
+		return { retryable: false, isFailure: false, statusCode: error.status, source: "jira", errorName: error.constructor.name };
 	}
 
 	return undefined;
@@ -94,7 +94,7 @@ const maybeHandleNonRetryableResponseCode = <MessagePayload extends BaseMessageP
 			isFailure: false,
 			statusCode: status,
 			source: error instanceof GithubClientError ? "github" : (error instanceof JiraClientError ? "jira" : "other"),
-			errorName: error.constructor?.name
+			errorName: error.constructor.name
 		};
 	}
 	return undefined;
@@ -111,13 +111,13 @@ const maybeHandleRateLimitingError = async <MessagePayload extends BaseMessagePa
 		// this attempts to ease the load across multiple refreshes
 		const retryDelaySec = rateLimitReset + ONE_HOUR_IN_SECONDS * (context.receiveCount - 1);
 		context.log.warn({ error, source: "github", retryDelaySec }, `Rate limiting error, retrying`);
-		return { retryable: true, retryDelaySec, isFailure: true, source: "github", statusCode: error.status, errorName: error.constructor?.name };
+		return { retryable: true, retryDelaySec, isFailure: true, source: "github", statusCode: error.status, errorName: error.constructor.name };
 	}
 
 	if (await booleanFlag(BooleanFlags.USE_RATELIMIT_ON_JIRA_CLIENT, context.payload.jiraHost)) {
 		if (error instanceof JiraClientRateLimitingError && error.retryAfterInSeconds !== undefined) {
 			context.log.warn({ error, source: "jira", retryDelaySec: error.retryAfterInSeconds }, `Rate limiting error, retrying`);
-			return { retryable: true, retryDelaySec: error.retryAfterInSeconds, isFailure: true, source: "jira", statusCode: error.status, errorName: error.constructor?.name };
+			return { retryable: true, retryDelaySec: error.retryAfterInSeconds, isFailure: true, source: "jira", statusCode: error.status, errorName: error.constructor.name };
 		}
 	}
 

--- a/src/sqs/error-handlers.ts
+++ b/src/sqs/error-handlers.ts
@@ -31,7 +31,8 @@ export const handleUnknownError: ErrorHandler<BaseMessagePayload> = <MessagePayl
 		retryDelaySec: delaySec,
 		isFailure: true,
 		statusCode: parseInt(err["status"]),
-		source: err instanceof GithubClientError ? "github" : (err instanceof JiraClientError ? "jira" : "other")
+		source: err instanceof GithubClientError ? "github" : (err instanceof JiraClientError ? "jira" : "other"),
+		errorName: err.constructor?.name
 	});
 };
 
@@ -73,7 +74,7 @@ const maybeHandleNonFailureCase = <MessagePayload extends BaseMessagePayload>(er
 		error.status &&
 		UNRETRYABLE_STATUS_CODES.includes(error.status)) {
 		context.log.warn(`Received ${error.status} from Jira. Unretryable. Discarding the message`);
-		return { retryable: false, isFailure: false, statusCode: error.status, source: "jira" };
+		return { retryable: false, isFailure: false, statusCode: error.status, source: "jira", errorName: error.constructor?.name };
 	}
 
 	return undefined;
@@ -91,7 +92,8 @@ const maybeHandleNonRetryableResponseCode = <MessagePayload extends BaseMessageP
 			retryable: false,
 			isFailure: false,
 			statusCode: status,
-			source: error instanceof GithubClientError ? "github" : (error instanceof JiraClientError ? "jira" : "other")
+			source: error instanceof GithubClientError ? "github" : (error instanceof JiraClientError ? "jira" : "other"),
+			errorName: error.constructor?.name
 		};
 	}
 	return undefined;
@@ -108,13 +110,13 @@ const maybeHandleRateLimitingError = async <MessagePayload extends BaseMessagePa
 		// this attempts to ease the load across multiple refreshes
 		const retryDelaySec = rateLimitReset + ONE_HOUR_IN_SECONDS * (context.receiveCount - 1);
 		context.log.warn({ error, source: "github", retryDelaySec }, `Rate limiting error, retrying`);
-		return { retryable: true, retryDelaySec, isFailure: true, source: "github", statusCode: error.status };
+		return { retryable: true, retryDelaySec, isFailure: true, source: "github", statusCode: error.status, errorName: error.constructor?.name };
 	}
 
 	if (await booleanFlag(BooleanFlags.USE_RATELIMIT_ON_JIRA_CLIENT, context.payload.jiraHost)) {
 		if (error instanceof JiraClientRateLimitingError && error.retryAfterInSeconds !== undefined) {
 			context.log.warn({ error, source: "jira", retryDelaySec: error.retryAfterInSeconds }, `Rate limiting error, retrying`);
-			return { retryable: true, retryDelaySec: error.retryAfterInSeconds, isFailure: true, source: "jira", statusCode: error.status };
+			return { retryable: true, retryDelaySec: error.retryAfterInSeconds, isFailure: true, source: "jira", statusCode: error.status, errorName: error.constructor?.name };
 		}
 	}
 

--- a/src/sqs/error-handlers.ts
+++ b/src/sqs/error-handlers.ts
@@ -1,7 +1,7 @@
 import { JiraClientError, JiraClientRateLimitingError } from "../jira/client/axios";
 import { emitWebhookFailedMetrics } from "utils/webhook-utils";
 import { ErrorHandler, ErrorHandlingResult, SQSMessageContext, BaseMessagePayload } from "./sqs.types";
-import { GithubClientRateLimitingError } from "../github/client/github-client-errors";
+import { GithubClientError, GithubClientRateLimitingError } from "../github/client/github-client-errors";
 import { booleanFlag, BooleanFlags } from "config/feature-flags";
 
 /**
@@ -26,7 +26,13 @@ export const handleUnknownError: ErrorHandler<BaseMessagePayload> = <MessagePayl
 ): Promise<ErrorHandlingResult> => {
 	const delaySec = EXPONENTIAL_BACKOFF_BASE_SEC * Math.pow(EXPONENTIAL_BACKOFF_MULTIPLIER, context.receiveCount);
 	context.log.warn({ err, delaySec }, "Unknown error: retrying with exponential backoff");
-	return Promise.resolve({ retryable: true, retryDelaySec: delaySec, isFailure: true });
+	return Promise.resolve({
+		retryable: true,
+		retryDelaySec: delaySec,
+		isFailure: true,
+		statusCode: parseInt(err["status"]),
+		source: err instanceof GithubClientError ? "github" : (err instanceof JiraClientError ? "jira" : "other")
+	});
 };
 
 export const jiraAndGitHubErrorsHandler: ErrorHandler<BaseMessagePayload> = async <MessagePayload extends BaseMessagePayload> (error: Error,
@@ -67,7 +73,7 @@ const maybeHandleNonFailureCase = <MessagePayload extends BaseMessagePayload>(er
 		error.status &&
 		UNRETRYABLE_STATUS_CODES.includes(error.status)) {
 		context.log.warn(`Received ${error.status} from Jira. Unretryable. Discarding the message`);
-		return { retryable: false, isFailure: false };
+		return { retryable: false, isFailure: false, statusCode: error.status, source: "jira" };
 	}
 
 	return undefined;
@@ -81,7 +87,12 @@ const maybeHandleNonRetryableResponseCode = <MessagePayload extends BaseMessageP
 	const status: number | undefined = error["status"] as number | undefined;
 	if (status && UNRETRYABLE_STATUS_CODES.includes(status)) {
 		context.log.warn({ err: error }, `Received error with ${status} status. Unretryable. Discarding the message`);
-		return { retryable: false, isFailure: false };
+		return {
+			retryable: false,
+			isFailure: false,
+			statusCode: status,
+			source: error instanceof GithubClientError ? "github" : (error instanceof JiraClientError ? "jira" : "other")
+		};
 	}
 	return undefined;
 };
@@ -97,13 +108,13 @@ const maybeHandleRateLimitingError = async <MessagePayload extends BaseMessagePa
 		// this attempts to ease the load across multiple refreshes
 		const retryDelaySec = rateLimitReset + ONE_HOUR_IN_SECONDS * (context.receiveCount - 1);
 		context.log.warn({ error, source: "github", retryDelaySec }, `Rate limiting error, retrying`);
-		return { retryable: true, retryDelaySec, isFailure: true };
+		return { retryable: true, retryDelaySec, isFailure: true, source: "github", statusCode: error.status };
 	}
 
 	if (await booleanFlag(BooleanFlags.USE_RATELIMIT_ON_JIRA_CLIENT, context.payload.jiraHost)) {
 		if (error instanceof JiraClientRateLimitingError && error.retryAfterInSeconds !== undefined) {
 			context.log.warn({ error, source: "jira", retryDelaySec: error.retryAfterInSeconds }, `Rate limiting error, retrying`);
-			return { retryable: true, retryDelaySec: error.retryAfterInSeconds, isFailure: true };
+			return { retryable: true, retryDelaySec: error.retryAfterInSeconds, isFailure: true, source: "jira", statusCode: error.status };
 		}
 	}
 

--- a/src/sqs/sqs.ts
+++ b/src/sqs/sqs.ts
@@ -385,6 +385,9 @@ export class SqsQueue<MessagePayload extends BaseMessagePayload> {
 
 			statsd.increment(sqsQueueMetrics.exception, {
 				...this.metricsTags,
+				statusCode: String(errorHandlingResult.statusCode),
+				source: String(errorHandlingResult.source),
+				errorName: String(errorHandlingResult.errorName),
 				isFailure: String(errorHandlingResult.isFailure),
 				retryable: String(errorHandlingResult.retryable),
 				retryDelayInMin: String(errorHandlingResult.retryDelaySec && Math.floor(errorHandlingResult.retryDelaySec / 60)),

--- a/src/sqs/sqs.ts
+++ b/src/sqs/sqs.ts
@@ -397,7 +397,7 @@ export class SqsQueue<MessagePayload extends BaseMessagePayload> {
 				maxAttempts: String(this.maxAttempts),
 				remainingBeforeDlq: String(this.maxAttempts - context.receiveCount),
 				reachedRetryLimit: String(this.isMessageReachedRetryLimit(context))
-			}, { jiraHost: context.payload?.jiraHost });
+			}, { jiraHost: context.payload.jiraHost });
 
 		} catch (errorHandlingException: unknown) {
 			context.log.error({ err: errorHandlingException, originalError: err }, "Error while performing error handling on SQS message");

--- a/src/sqs/sqs.ts
+++ b/src/sqs/sqs.ts
@@ -390,6 +390,9 @@ export class SqsQueue<MessagePayload extends BaseMessagePayload> {
 				retryDelayInMin: String(errorHandlingResult.retryDelaySec && Math.floor(errorHandlingResult.retryDelaySec / 60)),
 				msgVisibilityChangedInMin: String(visibilityChangedSec && Math.floor(visibilityChangedSec / 60)),
 				skipDlq: String(errorHandlingResult.skipDlq),
+				receiveCount: String(context.receiveCount),
+				maxAttempts: String(this.maxAttempts),
+				remainingBeforeDlq: String(this.maxAttempts - context.receiveCount),
 				reachedRetryLimit: String(this.isMessageReachedRetryLimit(context))
 			}, { jiraHost: context.payload?.jiraHost });
 

--- a/src/sqs/sqs.ts
+++ b/src/sqs/sqs.ts
@@ -404,6 +404,7 @@ export class SqsQueue<MessagePayload extends BaseMessagePayload> {
 			log.info(`Delaying the retry for ${retryDelaySec} seconds`);
 			return await this.changeVisibilityTimeout(message, retryDelaySec, log);
 		}
+		return undefined;
 	}
 
 	private isMessageReachedRetryLimit(context: SQSMessageContext<MessagePayload>) {
@@ -414,12 +415,12 @@ export class SqsQueue<MessagePayload extends BaseMessagePayload> {
 	public async changeVisibilityTimeout(message: Message, timeoutSec: number, logger: Logger): Promise<number | undefined> {
 		if (!message.ReceiptHandle) {
 			logger.error(`No ReceiptHandle in message with ID = ${message.MessageId ?? ""}`);
-			return;
+			return undefined;
 		}
 
 		if (timeoutSec < 0) {
 			logger.error(`Timeout needs to be a positive number.`);
-			return;
+			return undefined;
 		}
 
 		if (timeoutSec >= MAX_MESSAGE_VISIBILITY_TIMEOUT_SEC) {
@@ -438,6 +439,7 @@ export class SqsQueue<MessagePayload extends BaseMessagePayload> {
 			return finalRoundedSec;
 		} catch (err: unknown) {
 			logger.error("Message visibility timeout change failed");
+			return undefined;
 		}
 	}
 

--- a/src/sqs/sqs.types.ts
+++ b/src/sqs/sqs.types.ts
@@ -95,6 +95,18 @@ export interface ErrorHandlingResult {
 	 */
 	skipDlq?: boolean;
 
+	/**
+	 * the http status of error
+	 * For metrics only, NOT used for logic handling.
+	 */
+	statusCode?: number;
+
+	/**
+	 * the source of error
+	 * For metrics only, NOT used for logic handling.
+	 */
+	source?: "github" | "jira" | "other";
+
 }
 
 export interface SQSContext {

--- a/src/sqs/sqs.types.ts
+++ b/src/sqs/sqs.types.ts
@@ -107,6 +107,12 @@ export interface ErrorHandlingResult {
 	 */
 	source?: "github" | "jira" | "other";
 
+	/**
+	 * name of error
+	 * For metrics only, NOT used for logic handling.
+	 */
+	errorName?: string;
+
 }
 
 export interface SQSContext {


### PR DESCRIPTION
**What's in this PR?**
Use the retry-after header in jira api to retry message. 

**Why**
As jira implemented the retry-after info
https://developer.atlassian.com/cloud/jira/software/rest/api-group-development-information/#api-rest-devinfo-0-10-bulk-post

**Added feature flags**
use-ratelimit-on-jira-client

**Affected issues**  
ARC-2713

**How has this been tested?**  
Unit test

**Whats Next?**
