### PR TITLE
None make user token mock persist

### DIFF
--- a/src/github/pull-request.test.ts
+++ b/src/github/pull-request.test.ts
@@ -80,7 +80,7 @@ describe("Pull Request Webhook", () => {
 	});
 
 	it("should have reviewers on pull request action", async () => {
-		githubUserTokenNock(gitHubInstallationId).persist();
+		githubUserTokenNock(gitHubInstallationId);
 		githubNock.get("/users/test-pull-request-user-login")
 			.reply(200, {
 				login: "test-pull-request-author-login",
@@ -209,7 +209,7 @@ describe("Pull Request Webhook", () => {
 
 
 	it("no Write perms case should be tolerated", async () => {
-		githubUserTokenNock(gitHubInstallationId).persist();
+		githubUserTokenNock(gitHubInstallationId);
 		githubNock.get("/users/test-pull-request-user-login")
 			.reply(200, {
 				login: "test-pull-request-author-login",
@@ -309,7 +309,7 @@ describe("Pull Request Webhook", () => {
 
 	it("will not delete references if a branch still has an issue key", async () => {
 
-		githubUserTokenNock(gitHubInstallationId).persist();
+		githubUserTokenNock(gitHubInstallationId);
 
 		githubNock.get("/repos/test-repo-owner/test-repo-name/pulls/1/reviews")
 			.reply(200, reviewsPayload);
@@ -336,7 +336,7 @@ describe("Pull Request Webhook", () => {
 	describe("Trigged by Bot", () => {
 
 		it("should update the Jira issue with the linked GitHub pull_request if PR opened action was triggered by bot", async () => {
-			githubUserTokenNock(gitHubInstallationId).persist();
+			githubUserTokenNock(gitHubInstallationId);
 
 			githubNock.get("/users/test-pull-request-user-login")
 				.reply(200, {
@@ -468,7 +468,7 @@ describe("Pull Request Webhook", () => {
 
 		it("should update the Jira issue with the linked GitHub pull_request if PR closed action was triggered by bot", async () => {
 
-			githubUserTokenNock(gitHubInstallationId).persist();
+			githubUserTokenNock(gitHubInstallationId);
 
 			githubNock.get("/users/test-pull-request-user-login")
 				.reply(200, {
@@ -561,7 +561,7 @@ describe("Pull Request Webhook", () => {
 
 		it("should update the Jira issue with the linked GitHub pull_request if PR reopened action was triggered by bot", async () => {
 
-			githubUserTokenNock(gitHubInstallationId).persist();
+			githubUserTokenNock(gitHubInstallationId);
 
 			githubNock.get("/users/test-pull-request-user-login")
 				.twice()

--- a/src/routes/api/api-replay-failed-entities-from-data-depot.test.ts
+++ b/src/routes/api/api-replay-failed-entities-from-data-depot.test.ts
@@ -121,7 +121,7 @@ describe("api-replay-failed-entities-from-data-depot", () => {
 
 	it("should replay dependabot alert", async () => {
 		app = createApp();
-		githubUserTokenNock(subscription.gitHubInstallationId).persist();
+		githubUserTokenNock(subscription.gitHubInstallationId);
 		githubNock
 			.get("/repos/atlassian/repo-0/dependabot/alerts/10")
 			.reply(200, dependabotAlert);
@@ -147,7 +147,7 @@ describe("api-replay-failed-entities-from-data-depot", () => {
 
 	it("should replay code scanning alert", async () => {
 		app = createApp();
-		githubUserTokenNock(subscription.gitHubInstallationId).persist();
+		githubUserTokenNock(subscription.gitHubInstallationId);
 		githubNock
 			.get("/repos/atlassian/repo-0/code-scanning/alerts/11")
 			.reply(200, codeScanningAlert);

--- a/src/sqs/branch.test.ts
+++ b/src/sqs/branch.test.ts
@@ -44,7 +44,6 @@ describe("Branch Webhook", () => {
 			const sha = "test-branch-ref-sha";
 
 			githubUserTokenNock(gitHubInstallationId);
-			githubUserTokenNock(gitHubInstallationId);
 			githubNock.get(`/repos/test-repo-owner/test-repo-name/git/ref/${ref}`)
 				.reply(200, {
 					ref: `refs/${ref}`,

--- a/src/sqs/deployment.test.ts
+++ b/src/sqs/deployment.test.ts
@@ -76,9 +76,6 @@ describe("Deployment Webhook", () => {
 			const sha = deploymentStatusBasic.payload.deployment.sha;
 
 			githubUserTokenNock(1234);
-			githubUserTokenNock(1234);
-			githubUserTokenNock(1234);
-			githubUserTokenNock(1234);
 
 			githubNock.get(`/repos/test-repo-owner/test-repo-name/commits/${sha}`)
 				.reply(200, {

--- a/src/sync/build.test.ts
+++ b/src/sync/build.test.ts
@@ -138,7 +138,6 @@ describe("sync/builds", () => {
 		const data: BackfillMessagePayload = { installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost };
 
 		githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-		githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 
 		const fixture = cloneDeep(buildFixture);
 		fixture.workflow_runs[0].head_commit = null as unknown as any;
@@ -170,7 +169,6 @@ describe("sync/builds", () => {
 		const data: BackfillMessagePayload = { installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost };
 
 		const pageNocks = new Array(NUMBER_OF_PARALLEL_FETCHES).fill(0).map((_, index) => {
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 			return githubNock
 				.get(`/repos/integrations/test-repo-name/actions/runs?per_page=20&page=${21 + index}`)
@@ -236,7 +234,6 @@ describe("sync/builds", () => {
 	it("should sync multiple builds to Jira when they contain issue keys", async () => {
 		const data: BackfillMessagePayload = { installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost };
 
-		githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 		githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 
 		githubNock
@@ -355,8 +352,6 @@ describe("sync/builds", () => {
 
 		it("should not miss build data when page contains older build", async () => {
 
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 
 			githubNock.get(`/repos/integrations/integration-test-jira/compare/BASE_REF...HEAD_REF`).reply(200, compareReferencesFixture);

--- a/src/sync/deployment.test.ts
+++ b/src/sync/deployment.test.ts
@@ -317,9 +317,6 @@ describe("sync/deployments", () => {
 			const data: BackfillMessagePayload = { installationId, jiraHost };
 
 			githubUserTokenNock(installationId);
-			githubUserTokenNock(installationId);
-			githubUserTokenNock(installationId);
-			githubUserTokenNock(installationId);
 
 			createGitHubNock(deploymentNodesFixture);
 			const lastEdges = deploymentNodesFixture.data.repository.deployments.edges;
@@ -454,9 +451,6 @@ describe("sync/deployments", () => {
 			["51e16759cdac67b0d2a94e0674c9603b75a840f6", "7544f2fec0321a32d5effd421682463c2ebd5018"]
 				.forEach((commitId, index) => {
 					index++;
-					githubUserTokenNock(installationId);
-					githubUserTokenNock(installationId);
-					githubUserTokenNock(installationId);
 					githubUserTokenNock(installationId);
 					githubNock.get(`/repos/test-repo-owner/test-repo-name/commits/${commitId}`)
 						.reply(200, {
@@ -728,9 +722,6 @@ describe("sync/deployments", () => {
 				uuid: gitHubServerApp.uuid
 			} };
 
-			gheUserTokenNock(installationId);
-			gheUserTokenNock(installationId);
-			gheUserTokenNock(installationId);
 			gheUserTokenNock(installationId);
 
 			createGitHubServerNock(deploymentNodesFixture);

--- a/src/sync/discovery.test.ts
+++ b/src/sync/discovery.test.ts
@@ -17,7 +17,7 @@ describe("discovery", () => {
 
 	beforeEach(async () => {
 		data = { installationId: DatabaseStateCreator.GITHUB_INSTALLATION_ID, jiraHost, commitsFromDate: "2023-01-01" };
-		githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID).persist();
+		githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 		when(booleanFlag).calledWith(BooleanFlags.USE_REST_API_FOR_DISCOVERY, jiraHost).mockResolvedValue(false);
 		mockSystemTime(12345678);
 		await new DatabaseStateCreator().create();

--- a/src/sync/pull-requests.test.ts
+++ b/src/sync/pull-requests.test.ts
@@ -226,7 +226,7 @@ describe("sync/pull-request", () => {
 		});
 
 		it("should not sync if nodes do not contain issue keys", async () => {
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID).persist();
+			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 			githubNock
 				.post("/graphql")
 				.query(true)

--- a/src/transforms/transform-deployment.test.ts
+++ b/src/transforms/transform-deployment.test.ts
@@ -248,9 +248,6 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 			const deploymentPayload = cloneDeep(deployment_status_staging.payload) as any;
 			deploymentPayload.deployment.ref = "not-a-issue-key";
 			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 
 			// Mocking all GitHub API Calls
 			// Get commit
@@ -300,9 +297,6 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 
 		it(`uses user config to associate services`, async () => {
 
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 
 			// Mocking all GitHub API Calls
@@ -395,9 +389,6 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 
 			//If we use old GH Client we won't call the API because we pass already "authenticated" client to the test method
 			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 
 			// Mocking all GitHub API Calls
 			// Get commit
@@ -479,7 +470,6 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 		it(`supports branch and merge workflows, sending related commits in deploymentfor Cloud`, async () => {
 
 			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 
 			await cacheSuccessfulDeploymentInfo({
 				gitHubBaseUrl: gitHubClient.baseUrl,
@@ -546,9 +536,6 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 		describe("limits to 500 total", () => {
 			beforeEach(() => {
 				//If we use old GH Client we won't call the API because we pass already "authenticated" client to the test method
-				githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-				githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-				githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 				githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 
 				// Mocking all GitHub API Calls
@@ -713,9 +700,6 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 
 			//If we use old GH Client we won't call the API because we pass already "authenticated" client to the test method
 			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			githubUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 
 			// Mocking all GitHub API Calls
 			// Get commit
@@ -806,9 +790,6 @@ describe("transform GitHub webhook payload to Jira payload", () => {
 		it(`supports branch and merge workflows, sending related commits in deployment for Server`, async () => {
 
 			//If we use old GH Client we won't call the API because we pass already "authenticated" client to the test method
-			gheUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			gheUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
-			gheUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 			gheUserTokenNock(DatabaseStateCreator.GITHUB_INSTALLATION_ID);
 
 			// Mocking all GitHub API Calls

--- a/src/transforms/util/github-get-pull-request-reviews.test.ts
+++ b/src/transforms/util/github-get-pull-request-reviews.test.ts
@@ -28,7 +28,6 @@ describe("getPullRequestReviews", () => {
 
 	it("should return array of reviewers with valid repo and pr", async () => {
 		githubUserTokenNock(GITHUB_INSTALLATION_ID);
-		githubUserTokenNock(GITHUB_INSTALLATION_ID);
 		githubNock
 			.get(`/repos/batman/gotham-city-bus-pass/pulls/2/requested_reviewers`)
 			.reply(200, {
@@ -44,7 +43,6 @@ describe("getPullRequestReviews", () => {
 	});
 
 	it("should map a error from /reviews into an empty array", async () => {
-		githubUserTokenNock(GITHUB_INSTALLATION_ID);
 		githubUserTokenNock(GITHUB_INSTALLATION_ID);
 		githubNock
 			.get(`/repos/batman/gotham-city-bus-pass/pulls/2/requested_reviewers`)
@@ -72,7 +70,6 @@ describe("getPullRequestReviews", () => {
 	});
 
 	it("should merge requested_reviewers and reviews together", async () => {
-		githubUserTokenNock(GITHUB_INSTALLATION_ID);
 		githubUserTokenNock(GITHUB_INSTALLATION_ID);
 		githubNock
 			.get(`/repos/batman/gotham-city-bus-pass/pulls/2/requested_reviewers`)

--- a/test/jira/multiple-jira.test.ts
+++ b/test/jira/multiple-jira.test.ts
@@ -238,7 +238,7 @@ describe("multiple Jira instances", () => {
 
 	it("should not linkify issue keys for jira instance that has matching issues", async () => {
 
-		githubUserTokenNock(gitHubInstallationId).persist();
+		githubUserTokenNock(gitHubInstallationId);
 
 		githubNock.get("/users/test-pull-request-user-login")
 			.times(2)
@@ -295,7 +295,7 @@ describe("multiple Jira instances", () => {
 
 	it("should associate PR with to multiple jira with same issue keys", async () => {
 
-		githubUserTokenNock(gitHubInstallationId).persist();
+		githubUserTokenNock(gitHubInstallationId);
 
 		githubNock.get("/users/test-pull-request-user-login")
 			.twice()

--- a/test/setup/setup.ts
+++ b/test/setup/setup.ts
@@ -35,6 +35,7 @@ declare global {
 	let gheNock: nock.Scope;
 	let gheApiUrl: string;
 	let gheApiNock: nock.Scope;
+	let gheApiNockPersisted: nock.Scope;
 	let githubUserTokenNock: GithubUserTokenNockFunc;
 	let githubAppTokenNock: GithubAppTokenNockFunc;
 	let gheUserTokenNock: GithubUserTokenNockFunc;
@@ -57,6 +58,7 @@ declare global {
 			gheNock: nock.Scope;
 			gheApiUrl: string;
 			gheApiNock: nock.Scope;
+			gheApiNockPersisted: nock.Scope;
 			githubUserTokenNock: GithubUserTokenNockFunc;
 			githubAppTokenNock: GithubAppTokenNockFunc;
 			gheUserTokenNock: GithubUserTokenNockFunc;
@@ -148,8 +150,8 @@ beforeEach(() => {
 	global.gheApiNock = nock(global.gheApiUrl);
 	global.githubUserTokenNock = githubUserToken(githubNockPersisted);
 	global.githubAppTokenNock = githubAppToken(githubNockPersisted);
-	global.gheUserTokenNock = githubUserToken(gheApiNock);
-	global.gheAppTokenNock = githubAppToken(gheApiNock);
+	global.gheUserTokenNock = githubUserToken(gheApiNockPersisted);
+	global.gheAppTokenNock = githubAppToken(gheApiNockPersisted);
 	global.testEnvVars = envVars as TestEnvVars;
 	global.mockSystemTime = (time: number | string | Date) => {
 		const mock = jest.isMockFunction(Date.now) ? jest.mocked(Date.now) : jest.spyOn(Date, "now");

--- a/test/setup/setup.ts
+++ b/test/setup/setup.ts
@@ -29,6 +29,7 @@ declare global {
 	let jiraNock: nock.Scope;
 	let jiraStagingNock: nock.Scope;
 	let githubNock: nock.Scope;
+	let githubNockPersisted: nock.Scope;
 	let gheUrl: string;
 	let uuid: string;
 	let gheNock: nock.Scope;
@@ -50,6 +51,7 @@ declare global {
 			jiraNock: nock.Scope;
 			jiraStagingNock: nock.Scope;
 			githubNock: nock.Scope;
+			githubNockPersisted: nock.Scope;
 			gheUrl: string;
 			uuid: string;
 			gheNock: nock.Scope;
@@ -138,13 +140,14 @@ beforeEach(() => {
 	global.jiraNock = nock(global.jiraHost);
 	global.jiraStagingNock = nock(global.jiraHost);
 	global.githubNock = nock("https://api.github.com");
+	global.githubNockPersisted = nock("https://api.github.com");
 	global.gheUrl = "https://github.mydomain.com";
 	global.uuid = "c97806fc-c433-4ad5-b569-bf5191590be2";
 	global.gheNock = nock(global.gheUrl);
 	global.gheApiUrl = `${global.gheUrl}/api/v3`;
 	global.gheApiNock = nock(global.gheApiUrl);
-	global.githubUserTokenNock = githubUserToken(githubNock);
-	global.githubAppTokenNock = githubAppToken(githubNock);
+	global.githubUserTokenNock = githubUserToken(githubNockPersisted);
+	global.githubAppTokenNock = githubAppToken(githubNockPersisted);
 	global.gheUserTokenNock = githubUserToken(gheApiNock);
 	global.gheAppTokenNock = githubAppToken(gheApiNock);
 	global.testEnvVars = envVars as TestEnvVars;


### PR DESCRIPTION
**What's in this PR?**
Make access token nock persisted as I don't think we need to test the nock one per each time.
And it will fix many tests (potentially) in the future that forgot the nock the access token exactly times (someitmes impossible)
