### PR TITLE
updgrade stg rds instance

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -543,6 +543,7 @@ environmentOverrides:
         type: dedicated-rds
         attributes:
           parameters:
+            DBInstanceClass: db.t2.medium
             # Adding read replica in staging as it's not enabled by default so we can read state
             ReadReplica: true
 


### PR DESCRIPTION
**What's in this PR?**
Bump our RDS instance from the default t2.small to one size up t2.medium.

we have reached the limits of t2.small with the addition of a new Pollinator, it can cope when things go well but starts pushing the limits when failures start occuring
