### PR TITLE
None check jira issue before commit push

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -25,7 +25,8 @@ export enum BooleanFlags {
 	USE_DYNAMODB_TO_PERSIST_AUDIT_LOG = "use-dynamodb-to-persist-audit-log",
 	USE_CUSTOM_ROOT_CA_BUNDLE = "use-custom-root-ca-bundle",
 	GENERATE_CORE_HEAP_DUMPS_ON_LOW_MEM = "generate-core-heap-dumps-on-low-mem",
-	USE_RATELIMIT_ON_JIRA_CLIENT = "use-ratelimit-on-jira-client"
+	USE_RATELIMIT_ON_JIRA_CLIENT = "use-ratelimit-on-jira-client",
+	SKIP_PROCESS_QUEUE_IF_ISSUE_NOT_FOUND = "skip-process-queue-when-issue-not-exists"
 }
 
 export enum StringFlags {

--- a/src/transforms/push.test.ts
+++ b/src/transforms/push.test.ts
@@ -1,12 +1,15 @@
-import { enqueuePush } from "./push";
+import { enqueuePush, processPush } from "./push";
 import { sqsQueues } from "../sqs/queues";
 import { when } from "jest-when";
 import { GitHubCommit, GitHubRepository } from "interfaces/github";
-import { shouldSendAll } from "config/feature-flags";
+import { shouldSendAll, booleanFlag, BooleanFlags } from "config/feature-flags";
 import { getLogger } from "config/logger";
+import { GitHubInstallationClient } from "../github/client/github-installation-client";
+import { DatabaseStateCreator, CreatorResult } from "test/utils/database-state-creator";
 
 jest.mock("../sqs/queues");
 jest.mock("config/feature-flags");
+const logger = getLogger("test");
 
 describe("Enqueue push", () => {
 	it("should push GitHubAppConfig to payload", async () => {
@@ -101,4 +104,118 @@ describe("Enqueue push", () => {
 			shas: []
 		}), 0, expect.anything());
 	});
+
+	describe.only("Skipping msg when issue not exist", () => {
+
+		let db: CreatorResult;
+		beforeEach(async () => {
+			db = await new DatabaseStateCreator()
+				.forCloud()
+				.create();
+			when(shouldSendAll).calledWith("commits", expect.anything(), expect.anything()).mockResolvedValue(false);
+		});
+
+		it("should NOT process issue if skip ff is on and the issue keys is not valid", async () => {
+
+			when(booleanFlag).calledWith(BooleanFlags.SKIP_PROCESS_QUEUE_IF_ISSUE_NOT_FOUND, expect.anything())
+				.mockResolvedValue(true);
+
+			mockIssueNotExists("ABC-111");
+
+			await processPush(getGitHubClient(), getPushPayload("sha-111", [ "ABC-111" ]), logger);
+
+		});
+
+		it("should process issue if skip ff is on and the issue keys is valid", async () => {
+
+			when(booleanFlag).calledWith(BooleanFlags.SKIP_PROCESS_QUEUE_IF_ISSUE_NOT_FOUND, expect.anything())
+				.mockResolvedValue(true);
+
+			mockIssueExists("ABC-222");
+
+			githubUserTokenNock(db.subscription.gitHubInstallationId);
+			mockGitHubCommitRestApi("sha-222");
+
+			mockJiraDevInfoAcceptUpdate("ABC-222");
+
+			await processPush(getGitHubClient(), getPushPayload("sha-222", [ "ABC-222" ]), logger);
+
+		});
+
+		it("should process issue if skip ff is off and the issue keys is not valid", async () => {
+
+			when(booleanFlag).calledWith(BooleanFlags.SKIP_PROCESS_QUEUE_IF_ISSUE_NOT_FOUND, expect.anything())
+				.mockResolvedValue(false);
+
+			githubUserTokenNock(db.subscription.gitHubInstallationId);
+			mockGitHubCommitRestApi("sha-333");
+
+			mockJiraDevInfoAcceptUpdate("ABC-333");
+
+			await processPush(getGitHubClient(), getPushPayload("sha-333", [ "ABC-333" ]), logger);
+
+		});
+
+		const mockJiraDevInfoAcceptUpdate = (...issueKeys) => {
+			jiraNock.post("/rest/devinfo/0.10/bulk", (reqBody) => {
+				return reqBody.repositories[0].commits.flatMap(c => c.issueKeys).some(ck => issueKeys.includes(ck));
+			}).reply(202, "");
+		};
+
+		const mockGitHubCommitRestApi = (sha) => {
+			githubNock
+				.get("/repos/org1/repo1/commits/" + sha)
+				.reply(200, {
+					files: [],
+					sha
+				});
+		};
+
+		const getPushPayload = (sha, issueKeys: string[]) => {
+			return {
+				jiraHost,
+				installationId: db.subscription.gitHubInstallationId,
+				gitHubAppConfig: undefined,
+				webhookId: "aaa",
+				repository: {
+					owner: { login: "org1" },
+					name: "repo1"
+				} as GitHubRepository,
+				shas: [{
+					id: sha,
+					issueKeys: [...issueKeys]
+				}]
+			};
+		};
+
+		const mockIssueExists = (...issueKeys) => {
+			issueKeys.forEach(k => {
+				jiraNock.get(`/rest/api/latest/issue/${k}`)
+					.query({ fields: "summary" }).reply(200, {});
+			});
+		};
+
+		const mockIssueNotExists = (...issueKeys) => {
+			issueKeys.forEach(k => {
+				jiraNock.get(`/rest/api/latest/issue/${k}`)
+					.query({ fields: "summary" }).reply(404, "");
+			});
+		};
+
+		const getGitHubClient = () => {
+			return new GitHubInstallationClient({
+				appId: 2,
+				githubBaseUrl: "https://api.github.com",
+				installationId: db.subscription.gitHubInstallationId
+			}, {
+				apiUrl: "https://api.github.com",
+				baseUrl: "https://github.com",
+				graphqlUrl: "https://api.github.com/graphql",
+				hostname: "https://github.com",
+				apiKeyConfig: undefined,
+				proxyBaseUrl: undefined
+			}, jiraHost, { trigger: "test" }, logger, undefined);
+		};
+	});
+
 });

--- a/src/util/jira-issue-check-redis-util.ts
+++ b/src/util/jira-issue-check-redis-util.ts
@@ -1,0 +1,29 @@
+import IORedis  from "ioredis";
+import { getRedisInfo } from "config/redis-info";
+
+//five seconds
+const REDIS_CLEANUP_TIMEOUT = 5 * 1000;
+
+const redis = new IORedis(getRedisInfo("JiraIssueStatusStorage"));
+
+export const saveIssueStatusToRedis = async (
+	jiraHost: string,
+	issueKey: string,
+	status: "exist" | "not_exist"
+) => {
+	const key = getKey(jiraHost, issueKey);
+	await redis.set(key, status, "px", REDIS_CLEANUP_TIMEOUT);
+};
+
+export const getIssueStatusFromRedis = async (
+	jiraHost: string,
+	issueKey: string
+): Promise<"exist" | "not_exist" | null> => {
+	const key = getKey(jiraHost, issueKey);
+	const status = await redis.get(key);
+	return status as "exist" | "not_exist" | null;
+};
+
+const getKey = (jiraHost: string, issueKey: string) => {
+	return `jiraHost_${jiraHost}_issueKey_${issueKey}`;
+};


### PR DESCRIPTION
**What's in this PR?**
Skip processing commit msg when issue not found on jira

**Why**
To avoid lots of 429 on both github and jira api when processing msg and ends up in dlq.

**Added feature flags**
skip-process-queue-when-issue-not-exists

**Affected issues**  
None

**How has this been tested?**  
Unit test

**Whats Next?**
Turn on FF for a particular customer.
