### PR TITLE
Arc 2745 fix exp time

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -42,7 +42,8 @@ export enum NumberFlags {
 	NUMBER_OF_BUILD_PAGES_TO_FETCH_IN_PARALLEL = "number-of-build-to-fetch-in-parallel",
 	BACKFILL_PAGE_SIZE = "backfill-page-size",
 	INSTALLATION_TOKEN_CACHE_MAX_SIZE = "installation-token-cache-max-size",
-	SKIP_PROCESS_QUEUE_IF_ISSUE_NOT_FOUND_TIMEOUT = "skip-process-queue-when-issue-not-exists-timeout"
+	SKIP_PROCESS_QUEUE_IF_ISSUE_NOT_FOUND_TIMEOUT = "skip-process-queue-when-issue-not-exists-timeout",
+	APP_TOKEN_EXP_IN_MILLI_SEC = "app-token-exp-in-milli-sec"
 }
 
 const createLaunchdarklyUser = (key?: string): LDUser => {

--- a/src/github/client/github-app-client.test.ts
+++ b/src/github/client/github-app-client.test.ts
@@ -1,0 +1,97 @@
+import { GitHubAppClient } from "./github-app-client";
+import { numberFlag, NumberFlags } from "config/feature-flags";
+import { when } from "jest-when";
+import { getLogger } from "config/logger";
+import fs from "fs";
+import path from "path";
+import { envVars } from "config/env";
+
+jest.mock("config/feature-flags");
+const log = getLogger("test");
+
+const APP_ID = "11111";
+const TEN_MINUTES = 10 * 60 * 1000;
+const ONE_SEC_IN_MILLISE = 1000;
+const PRIVATE_KEY = fs.readFileSync(path.join(process.cwd(), envVars.PRIVATE_KEY_PATH), "utf-8");
+
+describe("GitHubAppClient", () => {
+	describe("App token", () => {
+		describe("With new exp time settings in ff turn on", () => {
+			beforeEach(async () => {
+				when(numberFlag)
+					.calledWith(NumberFlags.APP_TOKEN_EXP_IN_MILLI_SEC, expect.anything(), expect.anything())
+					.mockResolvedValue(ONE_SEC_IN_MILLISE);
+			});
+			it("should use the the provided exp timeout", async () => {
+
+				let expTimeInMillSec: number | undefined;
+
+				githubNock.get("/app")
+					.matchHeader("Authorization", (authTokenBearer) => {
+						const token = authTokenBearer.substring("Bearer ".length);
+						const parts = token.split(".").map(p => Buffer.from(p, "base64").toString());
+						expTimeInMillSec = JSON.parse(parts[1]).exp * 1000;
+						return true;
+					})
+					.reply(200, {
+						name: "app1"
+					});
+
+				const startTime = new Date().getTime();
+				const appClient = new GitHubAppClient({
+					apiUrl: "https://api.github.com",
+					baseUrl: "https://api.github.com",
+					graphqlUrl: "https://api.github.com/graphql",
+					hostname: "github.com"
+				}, jiraHost, { trigger: "test" }, log, APP_ID, PRIVATE_KEY);
+
+				const app = (await appClient.getApp()).data;
+
+				expect(app).toMatchObject({
+					name: "app1"
+				});
+
+				expect(expTimeInMillSec).toBeDefined();
+				const diff = expTimeInMillSec!- startTime;
+				expect(diff).toBeGreaterThan(0);
+				expect(diff).toBeLessThanOrEqual(ONE_SEC_IN_MILLISE);
+			});
+		});
+		describe("With new exp time settings in ff turn off", () => {
+			it("should use the the buildin exp timeout", async () => {
+
+				let expTimeInMillSec: number | undefined;
+
+				githubNock.get("/app")
+					.matchHeader("Authorization", (authTokenBearer) => {
+						const token = authTokenBearer.substring("Bearer ".length);
+						const parts = token.split(".").map(p => Buffer.from(p, "base64").toString());
+						expTimeInMillSec = JSON.parse(parts[1]).exp * 1000;
+						return true;
+					})
+					.reply(200, {
+						name: "app1"
+					});
+
+				const startTime = new Date().getTime();
+				const appClient = new GitHubAppClient({
+					apiUrl: "https://api.github.com",
+					baseUrl: "https://api.github.com",
+					graphqlUrl: "https://api.github.com/graphql",
+					hostname: "github.com"
+				}, jiraHost, { trigger: "test" }, log, APP_ID, PRIVATE_KEY);
+
+				const app = (await appClient.getApp()).data;
+
+				expect(app).toMatchObject({
+					name: "app1"
+				});
+
+				expect(expTimeInMillSec).toBeDefined();
+				const diff = expTimeInMillSec!- startTime;
+				expect(diff).toBeGreaterThan(0);
+				expect(Math.abs(TEN_MINUTES - diff)).toBeLessThan(1000);
+			});
+		});
+	});
+});

--- a/src/routes/api/ghes-app-verification/ghes-app-verify-get-apps.ts
+++ b/src/routes/api/ghes-app-verification/ghes-app-verify-get-apps.ts
@@ -5,6 +5,7 @@ import { Installation } from "models/installation";
 import { runCurl } from "utils/curl/curl-utils";
 import { AppTokenHolder } from "~/src/github/client/app-token-holder";
 
+const FIVE_MINUTES_IN_MILLI_SEC = 5 * 60 * 1000;
 export const GHESVerifyGetApps = async (req: Request, res: Response): Promise<void> => {
 
 	const gitHubAppId = parseInt(req.params["gitHubAppId"] || "");
@@ -36,7 +37,7 @@ export const GHESVerifyGetApps = async (req: Request, res: Response): Promise<vo
 			const output = await runCurl({
 				fullUrl: `${gitHubAppClient.restApiUrl}/app`,
 				method: "GET",
-				authorization: `Bearer ${AppTokenHolder.createAppJwt(await app.getDecryptedPrivateKey(installation.jiraHost), String(app.appId)).token}`
+				authorization: `Bearer ${AppTokenHolder.createAppJwt(await app.getDecryptedPrivateKey(installation.jiraHost), String(app.appId), FIVE_MINUTES_IN_MILLI_SEC).token}`
 			});
 			res.status(500).json({ error: e, output });
 			return;


### PR DESCRIPTION
What's in this PR?
Add ff to reduce the app token exp time

Why
TEN MINUTES is the max allowed, prone to error

Added feature flags
app-token-exp-in-milli-sec

Affected issues
[ARC-2745]

How has this been tested?
Unit test

Whats Next?

[ARC-2745]: https://softwareteams.atlassian.net/browse/ARC-2745