### PR TITLE
add dlq-service during BB pipeline

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -18,10 +18,6 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-      - name: remove internal package
-        run: |
-          sed -i '/sqs-queue-dlq-service/d' ./package.json
-          cat ./package.json
       - run: yarn install --frozen-lockfile
       - run: yarn run lint
       - run: yarn run build:release
@@ -35,10 +31,6 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-      - name: remove internal package
-        run: |
-          sed -i '/sqs-queue-dlq-service/d' ./package.json
-          cat ./package.json
       - run: yarn install --frozen-lockfile
       - run: yarn run playwright install
       - name: create .env file
@@ -92,10 +84,6 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-      - name: remove internal package
-        run: |
-          sed -i '/sqs-queue-dlq-service/d' ./package.json
-          cat ./package.json
       - run: yarn install --frozen-lockfile
       - run: yarn spa:build
       - name: create .env file
@@ -150,10 +138,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v1
-      - name: remove internal package
-        run: |
-          sed -i '/sqs-queue-dlq-service/d' ./package.json
-          cat ./package.json
       - name: Build Docker image
         uses: docker/build-push-action@v2.7.0
         with:

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,0 @@
---install.ignore-optional true
---add.ignore-optional true

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ COPY . /app
 WORKDIR /app
 
 # Installing packages
-RUN sed -i '/sqs-queue-dlq-service/d' ./package.json
 RUN cat ./package.json
 RUN yarn install --frozen-lockfile
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -18,8 +18,7 @@ COPY . /app
 WORKDIR /app
 
 # Installing packages
-RUN rm .yarnrc
-RUN yarn add @atlassian/sqs-queue-dlq-service --frozen-file
+RUN yarn add @atlassian/sqs-queue-dlq-service
 RUN yarn install --frozen-lockfile
 RUN yarn list
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -19,6 +19,7 @@ WORKDIR /app
 
 # Installing packages
 RUN rm .yarnrc
+RUN yarn add @atlassian/sqs-queue-dlq-service --frozen-file
 RUN yarn install --frozen-lockfile
 RUN yarn list
 

--- a/package.json
+++ b/package.json
@@ -182,9 +182,6 @@
 		"ts-node-dev": "^2.0.0",
 		"yaml-lint": "^1.2.4"
 	},
-	"optionalDependencies": {
-		"@atlassian/sqs-queue-dlq-service": "^2.1.1"
-	},
 	"volta": {
 		"node": "18.18.1",
 		"yarn": "1.22.18"

--- a/spa/package.json
+++ b/spa/package.json
@@ -71,6 +71,5 @@
     "react-scripts": "^5.0.1",
     "ts-jest": "^29.1.1",
     "typescript": "^5.0.2"
-  },
-  "optionalDependencies": {}
+  }
 }


### PR DESCRIPTION
**What's in this PR?**
add dlq-service during BB pipeline

**Why**
1. The public yarn.lock doesn't contains the optional deps
2. But during BB pipeline, it will install the optional, but now the fronzenfile is wrong, so will error.

**Added feature flags**

**Affected issues**  

**How has this been tested?**  

https://bitbucket.org/atlassian/github-for-jira-deployment/pipelines/results/8402

![image](https://github.com/atlassian/github-for-jira/assets/105693507/43a28081-9231-4033-bd04-df36cabd0bbe)


**Whats Next?**
