### PR TITLE
ARC-2759 skip the error "Commit not found by sha..." if on last try

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -26,7 +26,8 @@ export enum BooleanFlags {
 	USE_CUSTOM_ROOT_CA_BUNDLE = "use-custom-root-ca-bundle",
 	GENERATE_CORE_HEAP_DUMPS_ON_LOW_MEM = "generate-core-heap-dumps-on-low-mem",
 	USE_RATELIMIT_ON_JIRA_CLIENT = "use-ratelimit-on-jira-client",
-	SKIP_PROCESS_QUEUE_IF_ISSUE_NOT_FOUND = "skip-process-queue-when-issue-not-exists"
+	SKIP_PROCESS_QUEUE_IF_ISSUE_NOT_FOUND = "skip-process-queue-when-issue-not-exists",
+	SKIP_COMMIT_IF_SHA_NOT_FOUND_ON_LAST_TRY = "skip-commit-if-sha-not-found-on-last-try"
 }
 
 export enum StringFlags {

--- a/src/github/client/github-client-errors.ts
+++ b/src/github/client/github-client-errors.ts
@@ -86,6 +86,13 @@ export class GithubClientNotFoundError extends GithubClientError {
 	}
 }
 
+export class GithubClientCommitNotFoundBySHAError extends GithubClientError {
+	constructor(cause: AxiosError) {
+		super("Commit not found by sha", cause);
+		this.uiErrorCode = "RESOURCE_NOT_FOUND";
+	}
+}
+
 
 /**
  * Type for errors section in GraphQL response

--- a/src/sqs/push.ts
+++ b/src/sqs/push.ts
@@ -30,5 +30,5 @@ export const pushQueueMessageHandler: MessageHandler<PushQueueMessagePayload> = 
 		subTrigger: "push"
 	};
 	const gitHubInstallationClient = await createInstallationClient(installationId, jiraHost, metrics, context.log, payload.gitHubAppConfig?.gitHubAppId);
-	await processPush(gitHubInstallationClient, payload, context.log);
+	await processPush(gitHubInstallationClient, context, payload, context.log);
 };

--- a/src/transforms/push.ts
+++ b/src/transforms/push.ts
@@ -1,5 +1,6 @@
 import Logger from "bunyan";
 import { uniq } from "lodash";
+import { createHashWithSharedSecret } from "utils/encryption";
 import { Subscription } from "models/subscription";
 import { getJiraClient, JiraClient } from "../jira/client/jira-client";
 import { JiraClientError } from "../jira/client/axios";
@@ -8,8 +9,9 @@ import { emitWebhookProcessedMetrics } from "utils/webhook-utils";
 import { JiraCommit, JiraCommitFile, JiraCommitFileChangeTypeEnum } from "interfaces/jira";
 import { isBlocked, shouldSendAll, booleanFlag, BooleanFlags } from "config/feature-flags";
 import { sqsQueues } from "../sqs/queues";
-import { GitHubAppConfig, PushQueueMessagePayload } from "~/src/sqs/sqs.types";
+import { GitHubAppConfig, PushQueueMessagePayload, SQSMessageContext } from "~/src/sqs/sqs.types";
 import { GitHubInstallationClient } from "../github/client/github-installation-client";
+import { GithubClientCommitNotFoundBySHAError } from "../github/client/github-client-errors";
 import { compact, isEmpty } from "lodash";
 import { GithubCommitFile, GitHubPushData } from "interfaces/github";
 import { transformRepositoryDevInfoBulk } from "~/src/transforms/transform-repository";
@@ -87,7 +89,7 @@ export const createJobData = async (payload: GitHubPushData, jiraHost: string, l
 export const enqueuePush = async (payload: GitHubPushData, jiraHost: string, logger: Logger, gitHubAppConfig?: GitHubAppConfig) =>
 	await sqsQueues.push.sendMessage(await createJobData(payload, jiraHost, logger, gitHubAppConfig), 0, logger);
 
-export const processPush = async (github: GitHubInstallationClient, payload: PushQueueMessagePayload, rootLogger: Logger) => {
+export const processPush = async (github: GitHubInstallationClient, context: SQSMessageContext<PushQueueMessagePayload>, payload: PushQueueMessagePayload, rootLogger: Logger) => {
 	const {
 		repository,
 		repository: { owner, name: repo },
@@ -143,10 +145,10 @@ export const processPush = async (github: GitHubInstallationClient, payload: Pus
 		const recentShas = shas.slice(0, MAX_COMMIT_HISTORY);
 
 		const invalidIssueKeys = await tryGetInvalidIssueKeys(recentShas, subscription, jiraClient, log);
+		const shouldSkipCommitIfShaNotFound = context.lastAttempt &&  await booleanFlag(BooleanFlags.SKIP_COMMIT_IF_SHA_NOT_FOUND_ON_LAST_TRY, jiraHost);
 
 		const commitPromises: Promise<JiraCommit | null>[] = recentShas.map(async (sha): Promise<JiraCommit | null> => {
 			try {
-
 				if (await booleanFlag(BooleanFlags.SKIP_PROCESS_QUEUE_IF_ISSUE_NOT_FOUND, jiraHost)) {
 					if (sha.issueKeys.every(k => invalidIssueKeys.includes(k))) {
 						log.info("Issue key not found on jira, skip processing commits");
@@ -194,6 +196,12 @@ export const processPush = async (github: GitHubInstallationClient, payload: Pus
 					flags: isMergeCommit ? ["MERGE_COMMIT"] : undefined
 				};
 			} catch (err: unknown) {
+
+				if (shouldSkipCommitIfShaNotFound && err instanceof GithubClientCommitNotFoundBySHAError) {
+					log.warn({ err, commitSha: createHashWithSharedSecret(sha.id) }, "Skip for commit not found by sha error on last try");
+					return null;
+				}
+
 				log.warn({ err }, "Failed to fetch data from GitHub");
 				throw err;
 			}


### PR DESCRIPTION
**What's in this PR?**
Add code to skip the commit if error is "422 not found by sha" when on the last try. Only apply for push queue.

**Why**
I think on the last re-try, if we still couldn't find the commit by sha from either github.com or ghes, it could means either the server is wrong or the commit is gone. We should skip the message instead of putting them in DLQ.

**Added feature flags**
skip-commit-if-sha-not-found-on-last-try

**Affected issues**  
[ARC-2759]

**How has this been tested?**  
Unit test.

**Whats Next?**


[ARC-2759]: https://softwareteams.atlassian.net/browse/ARC-2759