### PR TITLE
ARC-2803 skip sending commit association for now

### DIFF
--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -27,7 +27,8 @@ export enum BooleanFlags {
 	GENERATE_CORE_HEAP_DUMPS_ON_LOW_MEM = "generate-core-heap-dumps-on-low-mem",
 	USE_RATELIMIT_ON_JIRA_CLIENT = "use-ratelimit-on-jira-client",
 	SKIP_PROCESS_QUEUE_IF_ISSUE_NOT_FOUND = "skip-process-queue-when-issue-not-exists",
-	SKIP_COMMIT_IF_SHA_NOT_FOUND_ON_LAST_TRY = "skip-commit-if-sha-not-found-on-last-try"
+	SKIP_COMMIT_IF_SHA_NOT_FOUND_ON_LAST_TRY = "skip-commit-if-sha-not-found-on-last-try",
+	SKIP_SENDING_COMMIT_ASSOCIATION = "skip-sending-commit-association"
 }
 
 export enum StringFlags {


### PR DESCRIPTION
**What's in this PR?**
Add a ff to skip sending commits association

**Why**
To send less data for ease on DD 500 error.
And this data is not being used anyway.

https://atlassian.slack.com/archives/C01PERFAUHZ/p1703129216457669

**Added feature flags**
skip-sending-commit-association

**Affected issues**  
[ARC-2803]

**How has this been tested?**  
Unit test.

**Whats Next?**
Fully rollout the FF.


[ARC-2803]: https://softwareteams.atlassian.net/browse/ARC-2803