### PR TITLE
GUA-126 Deprecate Github for Jira repo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# GitHub For Jira
+# ⛔️ DEPRECATED - GitHub For Jira
+> This repository has been deprecated in favour of a private repository. The application is still available to download on the Atlassian marketplace.
 
 ## About
 


### PR DESCRIPTION
The Github for Jira repo has been moved to a private repository. Add an update to the README and deprecate repo.