### PR TITLE
Update ip-allowlist.md CIDR range recommendation

### DIFF
--- a/docs/ip-allowlist.md
+++ b/docs/ip-allowlist.md
@@ -9,9 +9,7 @@ be configured properly for the GitHub for Jira app to be able to communicate wit
 
 The servers of the GitHub for Jira app operate from IP addresses in:
 
-- CIDR range `13.52.5.96/28` (i.e. from the IP addresses starting with `13.52.5.96` and ending with `13.52.5.111`).
-
-- CIDR range `104.192.138.240/28` (i.e. from the IP addresses starting with `104.192.138.240` and ending with `104.192.138.255`).
+- CIDR range `104.192.142.240/28` (i.e. from the IP addresses starting with `104.192.142.240` and ending with `104.192.142.255`).
 
 A machine-readable version of the IP addresses that stays up-to-date is available at [https://ip-ranges.atlassian.com/](https://ip-ranges.atlassian.com/).
 


### PR DESCRIPTION
github-for-jira has moved to us-east-1 so the documentation should reflect the new outgoing ip range of 104.192.142.240/28
